### PR TITLE
feat(applicationlayer): WAF observability — gateway audit-log capture + Felix/fluentd event log (EV-6650)

### DIFF
--- a/pkg/controller/applicationlayer/applicationlayer_controller.go
+++ b/pkg/controller/applicationlayer/applicationlayer_controller.go
@@ -181,7 +181,10 @@ func (r *ReconcileApplicationLayer) Reconcile(ctx context.Context, request recon
 			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
 			reqLogger.Info("ApplicationLayer object not found")
 			// Patch tproxyMode if it's  needed after crd deletion.
-			if err = r.patchFelixConfiguration(ctx, nil, r.isGatewayWAFEnabled(ctx)); err != nil {
+			gatewayWAFEnabled, gwErr := r.isGatewayWAFEnabled(ctx)
+			if gwErr != nil {
+				reqLogger.Error(gwErr, "Error checking GatewayAPI WAF state; skipping felix configuration patch")
+			} else if err = r.patchFelixConfiguration(ctx, nil, gatewayWAFEnabled); err != nil {
 				reqLogger.Error(err, "Error patching felix configuration")
 			}
 			r.status.OnCRNotFound()
@@ -245,7 +248,12 @@ func (r *ReconcileApplicationLayer) Reconcile(ctx context.Context, request recon
 	}
 
 	// Patch felix configuration if necessary.
-	if err = r.patchFelixConfiguration(ctx, instance, r.isGatewayWAFEnabled(ctx)); err != nil {
+	gatewayWAFEnabled, err := r.isGatewayWAFEnabled(ctx)
+	if err != nil {
+		r.status.SetDegraded(operatorv1.ResourceReadError, "Error checking GatewayAPI WAF state", err, reqLogger)
+		return reconcile.Result{}, err
+	}
+	if err = r.patchFelixConfiguration(ctx, instance, gatewayWAFEnabled); err != nil {
 		r.status.SetDegraded(operatorv1.ResourcePatchError, "Error patching felix configuration", err, reqLogger)
 		return reconcile.Result{}, err
 	}
@@ -590,12 +598,16 @@ func wafEventLogsFileRequired(al *operatorv1.ApplicationLayer, gatewayWAFEnabled
 			(al.Spec.WebApplicationFirewall != nil && *al.Spec.WebApplicationFirewall == operatorv1.WAFEnabled)))
 }
 
-// isGatewayWAFEnabled reports whether the GatewayAPI WAF data-plane extension is enabled. A missing or
-// unreadable GatewayAPI CR is treated as disabled.
-func (r *ReconcileApplicationLayer) isGatewayWAFEnabled(ctx context.Context) bool {
-	gw, _, err := gatewayapi.GetGatewayAPI(ctx, r.client)
+// isGatewayWAFEnabled reports whether the GatewayAPI WAF data-plane extension is enabled. A missing
+// GatewayAPI CR is treated as disabled (no error); any other read error is returned so the caller can
+// requeue rather than spuriously treating WAF as disabled and flapping FelixConfiguration.
+func (r *ReconcileApplicationLayer) isGatewayWAFEnabled(ctx context.Context) (bool, error) {
+	gw, msg, err := gatewayapi.GetGatewayAPI(ctx, r.client)
 	if err != nil {
-		return false
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("%s: %w", msg, err)
 	}
-	return gw.Spec.IsWAFGatewayExtensionEnabled()
+	return gw.Spec.IsWAFGatewayExtensionEnabled(), nil
 }

--- a/pkg/controller/applicationlayer/applicationlayer_controller.go
+++ b/pkg/controller/applicationlayer/applicationlayer_controller.go
@@ -22,6 +22,7 @@ import (
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
+	"github.com/tigera/operator/pkg/controller/gatewayapi"
 	"github.com/tigera/operator/pkg/controller/options"
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils"
@@ -137,6 +138,13 @@ func add(mgr manager.Manager, c ctrlruntime.Controller) error {
 		return fmt.Errorf("applicationlayer-controller failed to watch FelixConfiguration resource: %w", err)
 	}
 
+	// Watch for changes to GatewayAPI; its WAF data-plane extension shares the
+	// FelixConfiguration WAFEventLogsFileEnabled toggle, so toggling it must re-trigger this controller.
+	err = c.WatchObject(&operatorv1.GatewayAPI{}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return fmt.Errorf("applicationlayer-controller failed to watch GatewayAPI resource: %w", err)
+	}
+
 	// Watch for changes to TigeraStatus.
 	if err = utils.AddTigeraStatusWatch(c, ResourceName); err != nil {
 		return fmt.Errorf("applicationlayer-controller failed to watch applicationlayer Tigerastatus: %w", err)
@@ -173,7 +181,7 @@ func (r *ReconcileApplicationLayer) Reconcile(ctx context.Context, request recon
 			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
 			reqLogger.Info("ApplicationLayer object not found")
 			// Patch tproxyMode if it's  needed after crd deletion.
-			if err = r.patchFelixConfiguration(ctx, nil); err != nil {
+			if err = r.patchFelixConfiguration(ctx, nil, r.isGatewayWAFEnabled(ctx)); err != nil {
 				reqLogger.Error(err, "Error patching felix configuration")
 			}
 			r.status.OnCRNotFound()
@@ -237,7 +245,7 @@ func (r *ReconcileApplicationLayer) Reconcile(ctx context.Context, request recon
 	}
 
 	// Patch felix configuration if necessary.
-	if err = r.patchFelixConfiguration(ctx, instance); err != nil {
+	if err = r.patchFelixConfiguration(ctx, instance, r.isGatewayWAFEnabled(ctx)); err != nil {
 		r.status.SetDegraded(operatorv1.ResourcePatchError, "Error patching felix configuration", err, reqLogger)
 		return reconcile.Result{}, err
 	}
@@ -494,7 +502,9 @@ func (r *ReconcileApplicationLayer) getTProxyMode(al *operatorv1.ApplicationLaye
 
 // patchFelixConfiguration takes all application layer specs as arguments and patches felix config.
 // If at least one of the specs requires TPROXYMode as "Enabled" it'll be patched as "Enabled" otherwise it is "Disabled".
-func (r *ReconcileApplicationLayer) patchFelixConfiguration(ctx context.Context, al *operatorv1.ApplicationLayer) error {
+// gatewayWAFEnabled reflects the GatewayAPI WAF data-plane extension (design-25): its audit events flow through
+// Felix's WAF event log, so it shares the WAFEventLogsFileEnabled toggle with the ApplicationLayer WAF.
+func (r *ReconcileApplicationLayer) patchFelixConfiguration(ctx context.Context, al *operatorv1.ApplicationLayer, gatewayWAFEnabled bool) error {
 	// Fetch the Istio CR and Installation variant so DesiredPolicySyncPathPrefix
 	// can see whether the istio side still needs the field. Both reads tolerate
 	// NotFound — the istio side has no claim if either is absent.
@@ -515,6 +525,8 @@ func (r *ReconcileApplicationLayer) patchFelixConfiguration(ctx context.Context,
 	istioNeeds := utils.IstioRequiresPolicySync(istioCR, variant)
 
 	_, err = utils.PatchFelixConfiguration(ctx, r.client, func(fc *v3.FelixConfiguration) (bool, error) {
+		wafEventLogsFileEnabled := wafEventLogsFileRequired(al, gatewayWAFEnabled)
+
 		var tproxyMode string
 		if ok, v := r.getTProxyMode(al); ok {
 			tproxyMode = v
@@ -527,6 +539,14 @@ func (r *ReconcileApplicationLayer) patchFelixConfiguration(ctx context.Context,
 				//
 				// The felix bug was fixed in v3.16, v3.15.1 and v3.14.4; it should be safe to set new config fields
 				// once we know we're only upgrading from those versions and above.
+				//
+				// WAFEventLogsFileEnabled is an independent field: still enable it when a WAF producer
+				// (ApplicationLayer or the gateway data plane) requires it, without touching TPROXYMode.
+				if wafEventLogsFileEnabled && (fc.Spec.WAFEventLogsFileEnabled == nil || !*fc.Spec.WAFEventLogsFileEnabled) {
+					fc.Spec.WAFEventLogsFileEnabled = &wafEventLogsFileEnabled
+					log.Info("Patching FelixConfiguration: ", "wafEventLogsFileEnabled", wafEventLogsFileEnabled)
+					return true, nil
+				}
 				return false, nil
 			}
 
@@ -539,8 +559,6 @@ func (r *ReconcileApplicationLayer) patchFelixConfiguration(ctx context.Context,
 		policySyncPrefix := r.getPolicySyncPathPrefix(&fc.Spec, al, istioNeeds)
 		policySyncPrefixSetDesired := fc.Spec.PolicySyncPathPrefix == policySyncPrefix
 		tproxyModeSetDesired := fc.Spec.TPROXYMode != "" && fc.Spec.TPROXYMode == string(tproxyMode)
-		wafEventLogsFileEnabled := al != nil && ((al.Spec.SidecarInjection != nil && *al.Spec.SidecarInjection == operatorv1.SidecarEnabled) ||
-			(al.Spec.WebApplicationFirewall != nil && *al.Spec.WebApplicationFirewall == operatorv1.WAFEnabled))
 		wafEventLogsFileEnabledDesired := fc.Spec.WAFEventLogsFileEnabled != nil && *fc.Spec.WAFEventLogsFileEnabled == wafEventLogsFileEnabled
 
 		// If tproxy mode is already set to desired state return false to indicate patch not needed.
@@ -562,4 +580,22 @@ func (r *ReconcileApplicationLayer) patchFelixConfiguration(ctx context.Context,
 	})
 
 	return err
+}
+
+// wafEventLogsFileRequired reports whether Felix should write WAF event logs to file, which is required
+// when either the ApplicationLayer WAF/sidecar or the GatewayAPI WAF data-plane extension is enabled.
+func wafEventLogsFileRequired(al *operatorv1.ApplicationLayer, gatewayWAFEnabled bool) bool {
+	return gatewayWAFEnabled ||
+		(al != nil && ((al.Spec.SidecarInjection != nil && *al.Spec.SidecarInjection == operatorv1.SidecarEnabled) ||
+			(al.Spec.WebApplicationFirewall != nil && *al.Spec.WebApplicationFirewall == operatorv1.WAFEnabled)))
+}
+
+// isGatewayWAFEnabled reports whether the GatewayAPI WAF data-plane extension is enabled. A missing or
+// unreadable GatewayAPI CR is treated as disabled.
+func (r *ReconcileApplicationLayer) isGatewayWAFEnabled(ctx context.Context) bool {
+	gw, _, err := gatewayapi.GetGatewayAPI(ctx, r.client)
+	if err != nil {
+		return false
+	}
+	return gw.Spec.IsWAFGatewayExtensionEnabled()
 }

--- a/pkg/controller/applicationlayer/applicationlayer_controller_test.go
+++ b/pkg/controller/applicationlayer/applicationlayer_controller_test.go
@@ -273,6 +273,34 @@ var _ = Describe("Application layer controller tests", func() {
 			Expect(fc.Spec.TPROXYMode).To(Equal(""))
 		})
 
+		It("should enable WAFEventLogsFileEnabled when the GatewayAPI WAF extension is enabled (no ApplicationLayer CR)", func() {
+			// The gateway data-plane WAF (design-25) emits audit events that flow through Felix's WAF event
+			// log, so it requires the same FelixConfiguration toggle as the legacy ApplicationLayer WAF — even
+			// when no ApplicationLayer CR is present.
+			mockStatus.On("OnCRNotFound").Return()
+
+			By("creating a GatewayAPI CR with the WAF extension enabled")
+			wafEnabled := operatorv1.WAFExtensionStateEnabled
+			Expect(c.Create(ctx, &operatorv1.GatewayAPI{
+				ObjectMeta: metav1.ObjectMeta{Name: "default"},
+				Spec: operatorv1.GatewayAPISpec{
+					Extensions: &operatorv1.GatewayAPIExtensions{
+						WAF: &operatorv1.WAFExtensionSpec{State: &wafEnabled},
+					},
+				},
+			})).NotTo(HaveOccurred())
+
+			By("reconciling without an ApplicationLayer resource")
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			By("ensuring felix WAFEventLogsFileEnabled is true")
+			fc := v3.FelixConfiguration{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+			Expect(test.GetResource(c, &fc)).To(BeNil())
+			Expect(fc.Spec.WAFEventLogsFileEnabled).NotTo(BeNil())
+			Expect(*fc.Spec.WAFEventLogsFileEnabled).To(BeTrue())
+		})
+
 		It("should render accurate resources for for log collection", func() {
 			mockStatus.On("AddDaemonsets", mock.Anything).Return()
 			mockStatus.On("AddDeployments", mock.Anything).Return()

--- a/pkg/render/fluentd.go
+++ b/pkg/render/fluentd.go
@@ -694,6 +694,9 @@ func (c *fluentdComponent) envvars() []corev1.EnvVar {
 		{Name: "FLUENT_UID", Value: "0"},
 		{Name: "FLOW_LOG_FILE", Value: c.path("/var/log/calico/flowlogs/flows.log")},
 		{Name: "DNS_LOG_FILE", Value: c.path("/var/log/calico/dnslogs/dns.log")},
+		// WAF events are written by Felix (gated by FelixConfiguration.WAFEventLogsFileEnabled) and tailed by the
+		// fluentd-node WAF source. The path is always set; the file only exists when a WAF producer is enabled.
+		{Name: "WAF_LOG_FILE", Value: c.path("/var/log/calico/waf/waf.log")},
 		{Name: "FLUENTD_ES_SECURE", Value: "true"},
 		{Name: "NODENAME", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"}}},
 		{Name: "LINSEED_TOKEN", Value: c.path(GetLinseedTokenPath(c.cfg.ManagedCluster))},

--- a/pkg/render/fluentd_test.go
+++ b/pkg/render/fluentd_test.go
@@ -139,6 +139,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			corev1.EnvVar{Name: "FLUENT_UID", Value: "0"},
 			corev1.EnvVar{Name: "FLOW_LOG_FILE", Value: "/var/log/calico/flowlogs/flows.log"},
 			corev1.EnvVar{Name: "DNS_LOG_FILE", Value: "/var/log/calico/dnslogs/dns.log"},
+			corev1.EnvVar{Name: "WAF_LOG_FILE", Value: "/var/log/calico/waf/waf.log"},
 			corev1.EnvVar{Name: "FLUENTD_ES_SECURE", Value: "true"},
 			corev1.EnvVar{
 				Name: "NODENAME",
@@ -326,6 +327,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			corev1.EnvVar{Name: "FLUENT_UID", Value: "0"},
 			corev1.EnvVar{Name: "FLOW_LOG_FILE", Value: "/var/log/calico/flowlogs/flows.log"},
 			corev1.EnvVar{Name: "DNS_LOG_FILE", Value: "/var/log/calico/dnslogs/dns.log"},
+			corev1.EnvVar{Name: "WAF_LOG_FILE", Value: "/var/log/calico/waf/waf.log"},
 			corev1.EnvVar{Name: "FLUENTD_ES_SECURE", Value: "true"},
 			corev1.EnvVar{
 				Name: "NODENAME",
@@ -435,6 +437,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			corev1.EnvVar{Name: "FLUENT_UID", Value: "0"},
 			corev1.EnvVar{Name: "FLOW_LOG_FILE", Value: "/var/log/calico/flowlogs/flows.log"},
 			corev1.EnvVar{Name: "DNS_LOG_FILE", Value: "/var/log/calico/dnslogs/dns.log"},
+			corev1.EnvVar{Name: "WAF_LOG_FILE", Value: "/var/log/calico/waf/waf.log"},
 			corev1.EnvVar{Name: "FLUENTD_ES_SECURE", Value: "true"},
 			corev1.EnvVar{
 				Name: "NODENAME",
@@ -554,6 +557,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			{Name: "FLUENT_UID", Value: "0"},
 			{Name: "FLOW_LOG_FILE", Value: "c:/var/log/calico/flowlogs/flows.log"},
 			{Name: "DNS_LOG_FILE", Value: "c:/var/log/calico/dnslogs/dns.log"},
+			{Name: "WAF_LOG_FILE", Value: "c:/var/log/calico/waf/waf.log"},
 			{Name: "FLUENTD_ES_SECURE", Value: "true"},
 			{
 				Name: "NODENAME",
@@ -574,6 +578,7 @@ var _ = Describe("Tigera Secure Fluentd rendering tests", func() {
 			{Name: "FLUENT_UID", Value: "0"},
 			{Name: "FLOW_LOG_FILE", Value: "c:/var/log/calico/flowlogs/flows.log"},
 			{Name: "DNS_LOG_FILE", Value: "c:/var/log/calico/dnslogs/dns.log"},
+			{Name: "WAF_LOG_FILE", Value: "c:/var/log/calico/waf/waf.log"},
 			{Name: "FLUENTD_ES_SECURE", Value: "true"},
 			{
 				Name: "NODENAME",

--- a/pkg/render/gatewayapi/gateway_api.go
+++ b/pkg/render/gatewayapi/gateway_api.go
@@ -111,6 +111,22 @@ const (
 	EnvoyGatewayDeploymentContainerName = "envoy-gateway"
 	EnvoyGatewayJobContainerName        = "envoy-gateway-certgen"
 	wafFilterName                       = "waf-http-filter"
+
+	// wafLogComponentWasm is the Envoy "wasm" logger component. Envoy Gateway does not
+	// define a const for it (its enum omits wasm), but EnvoyProxy.Spec.Logging.Level
+	// passes arbitrary component keys through to Envoy's --component-log-level arg, and
+	// Envoy recognises "wasm". Setting it to info surfaces the Coraza WASM filter's
+	// "AuditLog:" lines (emitted via proxywasm.LogInfo) in Envoy's application log.
+	wafLogComponentWasm = envoyapi.ProxyLogComponent("wasm")
+
+	// wafAuditLogPath is the file that Envoy's application log is redirected to via
+	// --log-path, and that the l7-log-collector tails for Coraza "AuditLog:" lines
+	// (WAF_AUDIT_LOG_PATH). It lives on the "access-logs" emptyDir that is already
+	// mounted in both the envoy container (which writes it) and the l7-log-collector
+	// (which reads it) - so no extra volume or mount is needed. Envoy will not create
+	// parent directories for --log-path, so this is a file directly under the existing
+	// /access_logs mount, not a new subdirectory.
+	wafAuditLogPath = "/access_logs/envoy.log"
 )
 
 var (
@@ -911,6 +927,30 @@ func (pr *gatewayAPIImplementationComponent) envoyProxyConfig(className, ns stri
 		// The WAF HTTP filter is not supported when the envoy proxy is deployed as a DaemonSet
 		// as there is no support for init containers in a DaemonSet.
 		if envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment != nil {
+			// Tune Envoy log levels for WAF audit capture: the wasm component logs at
+			// info so the Coraza filter's "AuditLog:" lines reach Envoy's application
+			// log, while the default stays at warn to keep the redirected log file
+			// approximately just the audit lines. A user-supplied default level (e.g.
+			// for debugging) is preserved.
+			if envoyProxy.Spec.Logging.Level == nil {
+				envoyProxy.Spec.Logging.Level = map[envoyapi.ProxyLogComponent]envoyapi.LogLevel{}
+			}
+			if _, ok := envoyProxy.Spec.Logging.Level[envoyapi.LogComponentDefault]; !ok {
+				envoyProxy.Spec.Logging.Level[envoyapi.LogComponentDefault] = envoyapi.LogLevelWarn
+			}
+			envoyProxy.Spec.Logging.Level[wafLogComponentWasm] = envoyapi.LogLevelInfo
+
+			// Redirect Envoy's application log (where the wasm filter's "AuditLog:" lines
+			// land) to a file on the "access-logs" emptyDir so the l7-log-collector can
+			// tail it (the collector already mounts that volume). EnvoyProxy has no native
+			// log-path field, and a Patch on the envoy container's args would replace Envoy
+			// Gateway's generated args, so use ExtraArgs, which EG appends to the proxy
+			// command line. func-e parses each element as a single token, so the flag and
+			// value are separate elements. A user-supplied --log-path is left untouched.
+			if !slices.Contains(envoyProxy.Spec.ExtraArgs, "--log-path") {
+				envoyProxy.Spec.ExtraArgs = append(envoyProxy.Spec.ExtraArgs, "--log-path", wafAuditLogPath)
+			}
+
 			l7LogCollector := corev1.Container{
 				Name:  "l7-log-collector",
 				Image: pr.L7LogCollectorImage,
@@ -926,6 +966,12 @@ func (pr *gatewayAPIImplementationComponent) envoyProxyConfig(className, ns stri
 					{
 						Name:  "ENVOY_ACCESS_LOG_PATH",
 						Value: "/access_logs/access.log",
+					},
+					// WAF audit capture: file the collector tails for the wasm filter's
+					// Coraza "AuditLog:" lines (Envoy's app log, redirected via --log-path).
+					{
+						Name:  "WAF_AUDIT_LOG_PATH",
+						Value: wafAuditLogPath,
 					},
 					// Owning Gateway info from pod labels (set by EnvoyProxy)
 					OwningGatewayNameEnvVar,

--- a/pkg/render/gatewayapi/gateway_api.go
+++ b/pkg/render/gatewayapi/gateway_api.go
@@ -825,6 +825,24 @@ func (pr *gatewayAPIImplementationComponent) controllerObjects() []client.Object
 	return objs
 }
 
+// ensureExtraArg sets "flag value" in an Envoy Gateway ExtraArgs slice (func-e parses each token as
+// a separate element), replacing the value if flag is already present or appending the flag/value
+// pair if not. It copies the slice so it never mutates a slice backing a cached EnvoyProxy object.
+func ensureExtraArg(args []string, flag, value string) []string {
+	out := append([]string(nil), args...)
+	for i, a := range out {
+		if a == flag {
+			if i+1 < len(out) {
+				out[i+1] = value
+			} else {
+				out = append(out, value)
+			}
+			return out
+		}
+	}
+	return append(out, flag, value)
+}
+
 func (pr *gatewayAPIImplementationComponent) envoyProxyConfig(className, ns string, envoyProxy *envoyapi.EnvoyProxy, classSpec *operatorv1.GatewayClassSpec) *envoyapi.EnvoyProxy {
 	// Ensure the minimal structure that we need for basic correctness and for the following
 	// customizations.  Note, we always create the running EnvoyProxy in our own namespace, even
@@ -940,16 +958,17 @@ func (pr *gatewayAPIImplementationComponent) envoyProxyConfig(className, ns stri
 			}
 			envoyProxy.Spec.Logging.Level[wafLogComponentWasm] = envoyapi.LogLevelInfo
 
-			// Redirect Envoy's application log (where the wasm filter's "AuditLog:" lines
-			// land) to a file on the "access-logs" emptyDir so the l7-log-collector can
-			// tail it (the collector already mounts that volume). EnvoyProxy has no native
-			// log-path field, and a Patch on the envoy container's args would replace Envoy
-			// Gateway's generated args, so use ExtraArgs, which EG appends to the proxy
-			// command line. func-e parses each element as a single token, so the flag and
-			// value are separate elements. A user-supplied --log-path is left untouched.
-			if !slices.Contains(envoyProxy.Spec.ExtraArgs, "--log-path") {
-				envoyProxy.Spec.ExtraArgs = append(envoyProxy.Spec.ExtraArgs, "--log-path", wafAuditLogPath)
-			}
+			// Redirect Envoy's application log (where the wasm filter's "AuditLog:" lines land)
+			// to a file on the "access-logs" emptyDir so the l7-log-collector can tail it (the
+			// collector already mounts that volume, and can only read files under /access_logs).
+			// EnvoyProxy has no native log-path field, and a Patch on the envoy container's args
+			// would replace Envoy Gateway's generated args, so use ExtraArgs, which EG appends to
+			// the proxy command line. func-e parses each element as a single token, so the flag
+			// and value are separate elements. The operator owns --log-path whenever WAF audit
+			// capture is enabled: it must match WAF_AUDIT_LOG_PATH on the l7-log-collector and
+			// live on the shared access-logs volume, so set it to wafAuditLogPath, replacing any
+			// value carried over from a custom base EnvoyProxy.
+			envoyProxy.Spec.ExtraArgs = ensureExtraArg(envoyProxy.Spec.ExtraArgs, "--log-path", wafAuditLogPath)
 
 			l7LogCollector := corev1.Container{
 				Name:  "l7-log-collector",

--- a/pkg/render/gatewayapi/gateway_api.go
+++ b/pkg/render/gatewayapi/gateway_api.go
@@ -826,21 +826,34 @@ func (pr *gatewayAPIImplementationComponent) controllerObjects() []client.Object
 }
 
 // ensureExtraArg sets "flag value" in an Envoy Gateway ExtraArgs slice (func-e parses each token as
-// a separate element), replacing the value if flag is already present or appending the flag/value
-// pair if not. It copies the slice so it never mutates a slice backing a cached EnvoyProxy object.
+// a separate element), replacing the value if flag is already present as an option, or inserting the
+// flag/value pair if not. A bare "--" terminates option parsing, so tokens at or after it are left
+// alone: the flag is matched only before "--", and a newly inserted pair goes before it. The slice is
+// copied, so this never mutates a slice backing a cached EnvoyProxy object.
 func ensureExtraArg(args []string, flag, value string) []string {
-	out := append([]string(nil), args...)
-	for i, a := range out {
-		if a == flag {
-			if i+1 < len(out) {
-				out[i+1] = value
-			} else {
-				out = append(out, value)
-			}
-			return out
+	// Options end at the first bare "--"; anything from there on is a non-option token.
+	sep := len(args)
+	for i, a := range args {
+		if a == "--" {
+			sep = i
+			break
 		}
 	}
-	return append(out, flag, value)
+	out := make([]string, 0, len(args)+2)
+	for i := 0; i < sep; i++ {
+		if args[i] == flag {
+			out = append(out, flag, value)
+			next := i + 1
+			if next < sep { // drop the existing value, if any
+				next++
+			}
+			return append(out, args[next:]...)
+		}
+		out = append(out, args[i])
+	}
+	// flag is not present as an option: insert it just before the "--" (or at the end).
+	out = append(out, flag, value)
+	return append(out, args[sep:]...)
 }
 
 func (pr *gatewayAPIImplementationComponent) envoyProxyConfig(className, ns string, envoyProxy *envoyapi.EnvoyProxy, classSpec *operatorv1.GatewayClassSpec) *envoyapi.EnvoyProxy {

--- a/pkg/render/gatewayapi/gateway_api_extraargs_test.go
+++ b/pkg/render/gatewayapi/gateway_api_extraargs_test.go
@@ -47,4 +47,14 @@ var _ = Describe("ensureExtraArg", func() {
 		_ = ensureExtraArg(in, "--log-path", logPath)
 		Expect(in).To(Equal([]string{"--log-path", "/custom.log"}))
 	})
+
+	It("leaves a flag-looking token after a bare -- untouched", func() {
+		Expect(ensureExtraArg([]string{"--", "--log-path", "/positional"}, "--log-path", logPath)).
+			To(Equal([]string{"--log-path", logPath, "--", "--log-path", "/positional"}))
+	})
+
+	It("inserts the option before a bare -- separator", func() {
+		Expect(ensureExtraArg([]string{"--foo", "bar", "--", "x"}, "--log-path", logPath)).
+			To(Equal([]string{"--foo", "bar", "--log-path", logPath, "--", "x"}))
+	})
 })

--- a/pkg/render/gatewayapi/gateway_api_extraargs_test.go
+++ b/pkg/render/gatewayapi/gateway_api_extraargs_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gatewayapi
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ensureExtraArg", func() {
+	const logPath = "/access_logs/envoy.log"
+
+	It("appends flag and value when the flag is absent", func() {
+		Expect(ensureExtraArg(nil, "--log-path", logPath)).
+			To(Equal([]string{"--log-path", logPath}))
+	})
+
+	It("overrides a value carried over from a custom base EnvoyProxy", func() {
+		Expect(ensureExtraArg([]string{"--log-path", "/custom/envoy.log"}, "--log-path", logPath)).
+			To(Equal([]string{"--log-path", logPath}))
+	})
+
+	It("preserves other args while overriding the flag", func() {
+		Expect(ensureExtraArg([]string{"--foo", "bar", "--log-path", "/custom.log"}, "--log-path", logPath)).
+			To(Equal([]string{"--foo", "bar", "--log-path", logPath}))
+	})
+
+	It("is idempotent across reconciles", func() {
+		once := ensureExtraArg([]string{"--log-path", "/custom.log"}, "--log-path", logPath)
+		Expect(ensureExtraArg(once, "--log-path", logPath)).To(Equal(once))
+	})
+
+	It("does not mutate the input slice (cache safety)", func() {
+		in := []string{"--log-path", "/custom.log"}
+		_ = ensureExtraArg(in, "--log-path", logPath)
+		Expect(in).To(Equal([]string{"--log-path", "/custom.log"}))
+	})
+})

--- a/pkg/render/gatewayapi/gateway_api_test.go
+++ b/pkg/render/gatewayapi/gateway_api_test.go
@@ -1107,6 +1107,12 @@ value:
 				MountPath: "/var/run/felix",
 			},
 		}))
+		// WAF audit capture: the l7-log-collector tails the redirected Envoy app log on
+		// the access-logs volume it already mounts.
+		Expect(envoyDeployment.InitContainers[0].Env).To(ContainElement(corev1.EnvVar{
+			Name:  "WAF_AUDIT_LOG_PATH",
+			Value: "/access_logs/envoy.log",
+		}))
 
 		Expect(envoyDeployment.Container).ToNot(BeNil())
 		Expect(envoyDeployment.Container.VolumeMounts).To(HaveLen(1))
@@ -1116,6 +1122,18 @@ value:
 		}))
 
 		Expect(proxy.Spec.Telemetry.AccessLog.Settings).To(Equal(AccessLogSettings))
+
+		// WAF audit capture: the wasm component logs at info so Coraza "AuditLog:" lines
+		// reach Envoy's application log, while everything else stays at warn so the
+		// redirected log file is approximately just the audit lines.
+		Expect(proxy.Spec.Logging.Level).To(HaveKeyWithValue(envoyapi.LogComponentDefault, envoyapi.LogLevelWarn))
+		Expect(proxy.Spec.Logging.Level).To(HaveKeyWithValue(envoyapi.ProxyLogComponent("wasm"), envoyapi.LogLevelInfo))
+
+		// WAF audit capture: Envoy's application log is redirected to a file on the
+		// var-log-calico HostPath volume via --log-path (appended through ExtraArgs,
+		// which Envoy Gateway adds to the proxy args verbatim - each token a separate
+		// element). The l7-log-collector tails this file.
+		Expect(proxy.Spec.ExtraArgs).To(Equal([]string{"--log-path", "/access_logs/envoy.log"}))
 	})
 
 	It("should deploy l7-log-collector (no waf-http-filter sidecar) for Enterprise when using a custom proxy", func() {
@@ -1221,6 +1239,10 @@ value:
 				Name:      "felix-sync",
 				MountPath: "/var/run/felix",
 			},
+		}))
+		Expect(envoyDeployment.InitContainers[1].Env).To(ContainElement(corev1.EnvVar{
+			Name:  "WAF_AUDIT_LOG_PATH",
+			Value: "/access_logs/envoy.log",
 		}))
 
 		Expect(envoyDeployment.Container).ToNot(BeNil())


### PR DESCRIPTION
## Description

Operator render for the Gateway API WAF observability path (EV-6650), split out of #4821:

- **Audit-log capture (gateway proxy render)** — `pkg/render/gatewayapi/gateway_api.go`:
  - `EnvoyProxy.Spec.Logging.Level = {default: warn, wasm: info}` — surfaces the Coraza WASM filter's `AuditLog:` lines in Envoy's application log.
  - `EnvoyProxy.Spec.ExtraArgs += --log-path /access_logs/envoy.log` — redirects the application log onto the existing `access-logs` emptyDir (ExtraArgs rather than a container-args Patch, which would replace EG's generated args; the path sits directly under `/access_logs` because Envoy doesn't create `--log-path` parent dirs).
  - `WAF_AUDIT_LOG_PATH=/access_logs/envoy.log` on the l7-log-collector, which tails the file and forwards WAF decision records via `PolicySync.ReportWAF`.
- **Felix + fluentd event-log legs** — `WAFEventLogsFileEnabled` (FelixConfiguration) and `WAF_LOG_FILE` (fluentd) so WAF block / would-block decisions land in the `tigera_secure_ee_waf` index.


## Release Note

```release-note
Add operator render for Gateway API WAF observability (EV-6650): capture the Coraza audit log from the gateway proxy, and enable the Felix + fluentd legs (WAFEventLogsFileEnabled, WAF_LOG_FILE) so WAF block / would-block decisions land in the tigera_secure_ee_waf index.
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `release-note-required`
  - `docs-pr-required`

## Linked

- Design: `tigera/designs#25` (PMREQ-384)
- Producer pair: `tigera/calico-private#12142` (EV-6650) — must merge first
- Stacked on: #4821