### PR TITLE
Auto-approve version sync PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,6 @@
 # Require review for all changes by an operator-maintainer
 * @tigera/tigera-operator-maintainers
+
+# Auto-synced CRD imports: let the sync bot approve its own version-sync PRs
+# (still approvable by a maintainer too).
+/pkg/imports/ @tigera/tigera-operator-maintainers @marvin-tigera

--- a/.github/workflows/sync-versions.yml
+++ b/.github/workflows/sync-versions.yml
@@ -59,6 +59,7 @@ jobs:
         run: make gen-versions GIT_CLONE_URL_BASE=https://github.com/
 
       - uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0  # v8.1.0
+        id: cpr
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "Sync versions from Calico and Calico Enterprise"
@@ -72,3 +73,23 @@ jobs:
             Triggered by scheduled workflow.
           labels: auto-sync,docs-not-required,release-note-not-required,merge-when-ready
           delete-branch: true
+
+      # The PR author is github-actions[bot] (the GITHUB_TOKEN identity above), so
+      # it can't approve its own PR, and the Actions token can't approve PRs anyway.
+      # Approve as marvin-tigera (MARVIN_PAT) so Marvin merges it once CI is green.
+      # CODEOWNERS scopes pkg/imports/ to marvin so this approval satisfies the
+      # code-owner requirement; a sync PR touching files outside pkg/imports/ still
+      # needs a maintainer. dismiss_stale_reviews is off, so a single approval
+      # persists across the hourly updates -- the reviewDecision guard keeps reruns quiet.
+      - name: Auto-approve so Marvin merges once CI passes
+        if: steps.cpr.outputs.pull-request-operation == 'created' || steps.cpr.outputs.pull-request-operation == 'updated'
+        env:
+          GH_TOKEN: ${{ secrets.MARVIN_PAT }}
+          PR: ${{ steps.cpr.outputs.pull-request-number }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [ "$(gh pr view "$PR" -R "$REPO" --json reviewDecision -q .reviewDecision)" = "APPROVED" ]; then
+            echo "PR #$PR already approved; nothing to do."
+            exit 0
+          fi
+          gh pr review "$PR" -R "$REPO" --approve


### PR DESCRIPTION
The hourly version/CRD sync PRs sat waiting on a manual approval before Marvin would merge them. This adds an auto-approve step (as marvin-tigera, since the bot can't approve its own PR and the Actions token can't approve at all) so they merge unattended once CI is green.

The sync PRs need a code-owner review, so this also scopes `pkg/imports/` to marvin-tigera in CODEOWNERS (maintainers stay owners there too). A sync PR that ever touches files outside `pkg/imports/` would still need a maintainer's approval, but in practice these only touch the imported CRDs.

```release-note
None
```
