### PR TITLE
gatewayapi: mirror trust bundle into Gateway namespaces on OSS too

### DIFF
--- a/pkg/controller/gatewayapi/gatewayapi_controller.go
+++ b/pkg/controller/gatewayapi/gatewayapi_controller.go
@@ -17,11 +17,11 @@ package gatewayapi
 import (
 	"context"
 	"fmt"
+	"time"
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -52,7 +52,9 @@ import (
 	"github.com/tigera/operator/pkg/ctrlruntime"
 	"github.com/tigera/operator/pkg/render"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
+	"github.com/tigera/operator/pkg/render/common/secret"
 	"github.com/tigera/operator/pkg/render/gatewayapi"
+	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 )
 
 const (
@@ -505,29 +507,46 @@ func (r *ReconcileGatewayAPI) Reconcile(ctx context.Context, request reconcile.R
 	}
 	gatewayConfig.GatewayNamespaces = nsSet.SortedList()
 
-	// Previously-provisioned namespaces, for cleanup. Enterprise reads the shared CRB's
-	// Subjects; OSS has no CRB, so it enumerates the mirrored trust-bundle ConfigMaps.
-	gatewayConfig.CurrentGatewayNamespaces = set.New[string]()
-	if variant.IsEnterprise() {
-		existingCRB := &rbacv1.ClusterRoleBinding{}
-		if err = r.client.Get(ctx, types.NamespacedName{Name: gatewayapi.GatewayNamespacesCRBName}, existingCRB); err == nil {
-			for _, s := range existingCRB.Subjects {
-				if s.Kind == "ServiceAccount" {
-					gatewayConfig.CurrentGatewayNamespaces.Insert(s.Namespace)
+	// Legacy tigera-gateway teardown (TODO: remove once upgrades from 3.x are unsupported).
+	// Delete the old controller first and alone (while terminating it re-creates proxies we remove),
+	// then its orphaned proxies, requeueing until clean. Skipped if a Gateway lives in tigera-gateway,
+	// since then the proxy there belongs to the new controller.
+	const legacyGatewayNamespace = "tigera-gateway"
+	legacyNamespaceHostsGateway := false
+	for _, ns := range gatewayConfig.GatewayNamespaces {
+		if ns == legacyGatewayNamespace {
+			legacyNamespaceHostsGateway = true
+		}
+	}
+	if !legacyNamespaceHostsGateway {
+		legacyController := &v1.Deployment{}
+		switch err = r.client.Get(ctx, types.NamespacedName{Namespace: legacyGatewayNamespace, Name: "envoy-gateway"}, legacyController); {
+		case err == nil:
+			if derr := r.client.Delete(ctx, legacyController); derr != nil && !errors.IsNotFound(derr) {
+				r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error deleting legacy gateway controller", derr, reqLogger)
+				return reconcile.Result{}, derr
+			}
+			reqLogger.Info("Deleting legacy tigera-gateway controller before cleaning its proxies")
+			return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+		case !errors.IsNotFound(err):
+			r.status.SetDegraded(operatorv1.ResourceReadError, "Error checking for legacy tigera-gateway controller", err, reqLogger)
+			return reconcile.Result{}, err
+		}
+
+		orphans, oerr := r.legacyGatewayOrphans(ctx, legacyGatewayNamespace)
+		if oerr != nil {
+			r.status.SetDegraded(operatorv1.ResourceReadError, "Error listing legacy gateway resources", oerr, reqLogger)
+			return reconcile.Result{}, oerr
+		}
+		if len(orphans) > 0 {
+			for _, obj := range orphans {
+				if derr := r.client.Delete(ctx, obj); derr != nil && !errors.IsNotFound(derr) {
+					r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error deleting legacy gateway resource", derr, reqLogger)
+					return reconcile.Result{}, derr
 				}
 			}
-		} else if !errors.IsNotFound(err) {
-			r.status.SetDegraded(operatorv1.ResourceReadError, "Error reading gateway namespaces ClusterRoleBinding", err, log)
-			return reconcile.Result{}, err
-		}
-	} else {
-		cmList := &corev1.ConfigMapList{}
-		if err = r.client.List(ctx, cmList, client.MatchingLabels{gatewayapi.GatewayNamespaceBundleLabel: "true"}); err != nil {
-			r.status.SetDegraded(operatorv1.ResourceReadError, "Error listing gateway trust bundle ConfigMaps", err, log)
-			return reconcile.Result{}, err
-		}
-		for i := range cmList.Items {
-			gatewayConfig.CurrentGatewayNamespaces.Insert(cmList.Items[i].Namespace)
+			reqLogger.Info("Cleaning orphaned legacy tigera-gateway proxies", "count", len(orphans))
+			return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 		}
 	}
 
@@ -553,6 +572,12 @@ func (r *ReconcileGatewayAPI) Reconcile(ctx context.Context, request reconcile.R
 	err = r.newComponentHandler(log, r.client, r.scheme, gatewayAPI).CreateOrUpdateOrDelete(ctx, nonCRDComponent, r.status)
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceCreateError, "Error rendering GatewayAPI resources", err, log)
+		return reconcile.Result{}, err
+	}
+
+	// Per-namespace resources, owned by the namespace's Gateways so the GC cleans them up.
+	if err = r.reconcileGatewayNamespaceResources(ctx, trustedBundle, pullSecrets, variant.IsEnterprise(), gwList.Items, ownedClass); err != nil {
+		r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error writing per-namespace Gateway resources", err, log)
 		return reconcile.Result{}, err
 	}
 
@@ -631,4 +656,113 @@ func (r *ReconcileGatewayAPI) maintainFinalizer(ctx context.Context, gatewayAPI 
 	// These objects require graceful termination before the CNI plugin is torn down.
 	gatewayAPIDeployment := v1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "envoy-gateway", Namespace: common.CalicoNamespace}}
 	return utils.MaintainInstallationFinalizer(ctx, r.client, gatewayAPI, render.GatewayAPIFinalizer, &gatewayAPIDeployment)
+}
+
+// reconcileGatewayNamespaceResources writes the per-namespace resources owned by the namespace's
+// Gateways, so the GC removes them once the last Gateway is gone (and the GatewayAPI CR's deletion
+// doesn't strand them). Reserved namespaces are skipped; trust bundle on both variants, the rest on
+// Enterprise.
+func (r *ReconcileGatewayAPI) reconcileGatewayNamespaceResources(ctx context.Context, bundle certificatemanagement.TrustedBundle, pullSecrets []*corev1.Secret, enterprise bool, gateways []gapi.Gateway, ownedClass map[string]bool) error {
+	ownersByNamespace := map[string][]metav1.OwnerReference{}
+	for i := range gateways {
+		gw := &gateways[i]
+		if !ownedClass[string(gw.Spec.GatewayClassName)] || gw.Namespace == common.CalicoNamespace || gw.Namespace == common.OperatorNamespace() {
+			continue
+		}
+		ownersByNamespace[gw.Namespace] = append(ownersByNamespace[gw.Namespace], metav1.OwnerReference{
+			APIVersion: "gateway.networking.k8s.io/v1",
+			Kind:       "Gateway",
+			Name:       gw.Name,
+			UID:        gw.UID,
+		})
+	}
+	for namespace, owners := range ownersByNamespace {
+		var objs []client.Object
+		if bundle != nil {
+			objs = append(objs, bundle.ConfigMap(namespace))
+		}
+		if enterprise {
+			objs = append(objs,
+				gatewayapi.GatewayNamespaceServiceAccount(namespace),
+				gatewayapi.GatewayNamespaceRoleBinding(namespace),
+				render.CreateOperatorSecretsRoleBinding(namespace),
+			)
+			objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(namespace, pullSecrets...)...)...)
+		}
+		for _, obj := range objs {
+			if err := r.upsertGatewayOwned(ctx, obj, owners); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// legacyGatewayOrphans returns the resources in namespace owned by the tigera-gateway-class
+// GatewayClass or the GatewayAPI CR — the pre-namespaced proxies. Owner-scoped, so unrelated
+// resources are never returned.
+func (r *ReconcileGatewayAPI) legacyGatewayOrphans(ctx context.Context, namespace string) ([]client.Object, error) {
+	ownedByLegacyGateway := func(o client.Object) bool {
+		for _, ref := range o.GetOwnerReferences() {
+			if ref.Kind == "GatewayAPI" || (ref.Kind == "GatewayClass" && ref.Name == gatewayapi.GatewayClassName) {
+				return true
+			}
+		}
+		return false
+	}
+	deployments := &v1.DeploymentList{}
+	services := &corev1.ServiceList{}
+	serviceAccounts := &corev1.ServiceAccountList{}
+	configMaps := &corev1.ConfigMapList{}
+	for _, list := range []client.ObjectList{deployments, services, serviceAccounts, configMaps} {
+		if err := r.client.List(ctx, list, client.InNamespace(namespace)); err != nil {
+			return nil, err
+		}
+	}
+	var orphans []client.Object
+	for i := range deployments.Items {
+		if ownedByLegacyGateway(&deployments.Items[i]) {
+			orphans = append(orphans, &deployments.Items[i])
+		}
+	}
+	for i := range services.Items {
+		if ownedByLegacyGateway(&services.Items[i]) {
+			orphans = append(orphans, &services.Items[i])
+		}
+	}
+	for i := range serviceAccounts.Items {
+		if ownedByLegacyGateway(&serviceAccounts.Items[i]) {
+			orphans = append(orphans, &serviceAccounts.Items[i])
+		}
+	}
+	for i := range configMaps.Items {
+		if ownedByLegacyGateway(&configMaps.Items[i]) {
+			orphans = append(orphans, &configMaps.Items[i])
+		}
+	}
+	return orphans, nil
+}
+
+// upsertGatewayOwned creates or updates obj, refreshing its owner references (and ConfigMap/Secret
+// data) so the namespace's owner set stays current as its Gateways come and go.
+func (r *ReconcileGatewayAPI) upsertGatewayOwned(ctx context.Context, desired client.Object, owners []metav1.OwnerReference) error {
+	desired.SetOwnerReferences(owners)
+	existing := desired.DeepCopyObject().(client.Object)
+	switch err := r.client.Get(ctx, client.ObjectKeyFromObject(desired), existing); {
+	case errors.IsNotFound(err):
+		return r.client.Create(ctx, desired)
+	case err != nil:
+		return err
+	default:
+		existing.SetOwnerReferences(owners)
+		switch d := desired.(type) {
+		case *corev1.ConfigMap:
+			e := existing.(*corev1.ConfigMap)
+			e.Data, e.Annotations = d.Data, d.Annotations
+		case *corev1.Secret:
+			e := existing.(*corev1.Secret)
+			e.Data, e.Type = d.Data, d.Type
+		}
+		return r.client.Update(ctx, existing)
+	}
 }

--- a/pkg/controller/gatewayapi/gatewayapi_controller.go
+++ b/pkg/controller/gatewayapi/gatewayapi_controller.go
@@ -505,10 +505,10 @@ func (r *ReconcileGatewayAPI) Reconcile(ctx context.Context, request reconcile.R
 	}
 	gatewayConfig.GatewayNamespaces = nsSet.SortedList()
 
-	// Enterprise: read previously-provisioned namespaces from the shared CRB's
-	// Subjects so we can clean them up when their Gateway is gone.
+	// Previously-provisioned namespaces, for cleanup. Enterprise reads the shared CRB's
+	// Subjects; OSS has no CRB, so it enumerates the mirrored trust-bundle ConfigMaps.
+	gatewayConfig.CurrentGatewayNamespaces = set.New[string]()
 	if variant.IsEnterprise() {
-		gatewayConfig.CurrentGatewayNamespaces = set.New[string]()
 		existingCRB := &rbacv1.ClusterRoleBinding{}
 		if err = r.client.Get(ctx, types.NamespacedName{Name: gatewayapi.GatewayNamespacesCRBName}, existingCRB); err == nil {
 			for _, s := range existingCRB.Subjects {
@@ -519,6 +519,15 @@ func (r *ReconcileGatewayAPI) Reconcile(ctx context.Context, request reconcile.R
 		} else if !errors.IsNotFound(err) {
 			r.status.SetDegraded(operatorv1.ResourceReadError, "Error reading gateway namespaces ClusterRoleBinding", err, log)
 			return reconcile.Result{}, err
+		}
+	} else {
+		cmList := &corev1.ConfigMapList{}
+		if err = r.client.List(ctx, cmList, client.MatchingLabels{gatewayapi.GatewayNamespaceBundleLabel: "true"}); err != nil {
+			r.status.SetDegraded(operatorv1.ResourceReadError, "Error listing gateway trust bundle ConfigMaps", err, log)
+			return reconcile.Result{}, err
+		}
+		for i := range cmList.Items {
+			gatewayConfig.CurrentGatewayNamespaces.Insert(cmList.Items[i].Namespace)
 		}
 	}
 

--- a/pkg/controller/gatewayapi/gatewayapi_controller.go
+++ b/pkg/controller/gatewayapi/gatewayapi_controller.go
@@ -17,6 +17,7 @@ package gatewayapi
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
@@ -513,12 +514,7 @@ func (r *ReconcileGatewayAPI) Reconcile(ctx context.Context, request reconcile.R
 	// sweep. Owner-scoped, requeueing until clean. Skipped if a Gateway lives in tigera-gateway,
 	// since then the proxy there belongs to the new controller.
 	const legacyGatewayNamespace = "tigera-gateway"
-	legacyNamespaceHostsGateway := false
-	for _, ns := range gatewayConfig.GatewayNamespaces {
-		if ns == legacyGatewayNamespace {
-			legacyNamespaceHostsGateway = true
-		}
-	}
+	legacyNamespaceHostsGateway := slices.Contains(gatewayConfig.GatewayNamespaces, legacyGatewayNamespace)
 	if !legacyNamespaceHostsGateway {
 		legacyController := &v1.Deployment{}
 		switch err = r.client.Get(ctx, types.NamespacedName{Namespace: legacyGatewayNamespace, Name: "envoy-gateway"}, legacyController); {

--- a/pkg/controller/gatewayapi/gatewayapi_controller.go
+++ b/pkg/controller/gatewayapi/gatewayapi_controller.go
@@ -508,8 +508,9 @@ func (r *ReconcileGatewayAPI) Reconcile(ctx context.Context, request reconcile.R
 	gatewayConfig.GatewayNamespaces = nsSet.SortedList()
 
 	// Legacy tigera-gateway teardown (TODO: remove once upgrades from 3.x are unsupported).
-	// Delete the old controller first and alone (while terminating it re-creates proxies we remove),
-	// then its orphaned proxies, requeueing until clean. Skipped if a Gateway lives in tigera-gateway,
+	// Foreground-delete the old controller so its Deployment lingers until its pods are gone — only
+	// then does the Get below return NotFound, guaranteeing nothing re-creates the proxies we then
+	// sweep. Owner-scoped, requeueing until clean. Skipped if a Gateway lives in tigera-gateway,
 	// since then the proxy there belongs to the new controller.
 	const legacyGatewayNamespace = "tigera-gateway"
 	legacyNamespaceHostsGateway := false
@@ -522,11 +523,14 @@ func (r *ReconcileGatewayAPI) Reconcile(ctx context.Context, request reconcile.R
 		legacyController := &v1.Deployment{}
 		switch err = r.client.Get(ctx, types.NamespacedName{Namespace: legacyGatewayNamespace, Name: "envoy-gateway"}, legacyController); {
 		case err == nil:
-			if derr := r.client.Delete(ctx, legacyController); derr != nil && !errors.IsNotFound(derr) {
-				r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error deleting legacy gateway controller", derr, reqLogger)
-				return reconcile.Result{}, derr
+			if legacyController.DeletionTimestamp == nil {
+				foreground := metav1.DeletePropagationForeground
+				if derr := r.client.Delete(ctx, legacyController, &client.DeleteOptions{PropagationPolicy: &foreground}); derr != nil && !errors.IsNotFound(derr) {
+					r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error deleting legacy gateway controller", derr, reqLogger)
+					return reconcile.Result{}, derr
+				}
 			}
-			reqLogger.Info("Deleting legacy tigera-gateway controller before cleaning its proxies")
+			reqLogger.Info("Deleting legacy tigera-gateway controller; waiting for its pods before cleaning proxies")
 			return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 		case !errors.IsNotFound(err):
 			r.status.SetDegraded(operatorv1.ResourceReadError, "Error checking for legacy tigera-gateway controller", err, reqLogger)

--- a/pkg/controller/gatewayapi/gatewayapi_controller_test.go
+++ b/pkg/controller/gatewayapi/gatewayapi_controller_test.go
@@ -30,10 +30,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextenv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gapi "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/yaml" // gopkg.in/yaml.v2 didn't parse all the fields but this package did
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
@@ -47,6 +49,7 @@ import (
 	"github.com/tigera/operator/pkg/dns"
 	"github.com/tigera/operator/pkg/render"
 	"github.com/tigera/operator/pkg/render/gatewayapi"
+	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 )
 
 var _ = Describe("Gateway API controller tests", func() {
@@ -700,6 +703,77 @@ var _ = Describe("Gateway API controller tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(actualFelixConfig.Spec.PolicySyncPathPrefix).ToNot(Equal(DefaultPolicySyncPrefix))
 		Expect(actualFelixConfig.Spec.PolicySyncPathPrefix).To(Equal("/dev/null"))
+	})
+
+	// Legacy tigera-gateway teardown (remove with the teardown gate once 3.x upgrades are unsupported).
+	It("deletes only GatewayClass/GatewayAPI-owned legacy resources in tigera-gateway, leaving the GatewayClass and unrelated resources", func() {
+		Expect(c.Create(ctx, installation)).NotTo(HaveOccurred())
+		Expect(c.Create(ctx, &operatorv1.GatewayAPI{ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"}})).NotTo(HaveOccurred())
+		Expect(c.Create(ctx, &gapi.GatewayClass{ObjectMeta: metav1.ObjectMeta{Name: gatewayapi.GatewayClassName}})).NotTo(HaveOccurred())
+
+		By("seeding the legacy controller + a class-owned proxy (Deployment/Service/SA/ConfigMap)")
+		Expect(c.Create(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "tigera-gateway", Name: "envoy-gateway"}})).NotTo(HaveOccurred())
+		ownedByClass := []metav1.OwnerReference{{APIVersion: "gateway.networking.k8s.io/v1", Kind: "GatewayClass", Name: gatewayapi.GatewayClassName, UID: "abc"}}
+		Expect(c.Create(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "tigera-gateway", Name: "envoy-gw-ns-gw-abcd1234", OwnerReferences: ownedByClass}})).NotTo(HaveOccurred())
+		Expect(c.Create(ctx, &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Namespace: "tigera-gateway", Name: "envoy-gw-ns-gw-abcd1234", OwnerReferences: ownedByClass}})).NotTo(HaveOccurred())
+
+		By("seeding an unrelated, unowned ServiceAccount + ConfigMap a user might have placed there")
+		Expect(c.Create(ctx, &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Namespace: "tigera-gateway", Name: "user-sa"}})).NotTo(HaveOccurred())
+		Expect(c.Create(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "tigera-gateway", Name: "user-config"}})).NotTo(HaveOccurred())
+
+		By("first reconcile: deletes the controller alone (so it can't re-create proxies), keeps the proxy")
+		result, err := r.Reconcile(ctx, reconcile.Request{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(BeNumerically(">", 0))
+		Expect(apierrors.IsNotFound(c.Get(ctx, client.ObjectKey{Namespace: "tigera-gateway", Name: "envoy-gateway"}, &appsv1.Deployment{}))).To(BeTrue())
+		Expect(c.Get(ctx, client.ObjectKey{Namespace: "tigera-gateway", Name: "envoy-gw-ns-gw-abcd1234"}, &appsv1.Deployment{})).NotTo(HaveOccurred())
+
+		By("second reconcile: controller gone, so the orphaned class-owned proxy resources are deleted")
+		result, err = r.Reconcile(ctx, reconcile.Request{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(BeNumerically(">", 0))
+		Expect(apierrors.IsNotFound(c.Get(ctx, client.ObjectKey{Namespace: "tigera-gateway", Name: "envoy-gw-ns-gw-abcd1234"}, &appsv1.Deployment{}))).To(BeTrue())
+		Expect(apierrors.IsNotFound(c.Get(ctx, client.ObjectKey{Namespace: "tigera-gateway", Name: "envoy-gw-ns-gw-abcd1234"}, &corev1.ServiceAccount{}))).To(BeTrue())
+
+		By("leaving unrelated unowned resources and the GatewayClass untouched")
+		Expect(c.Get(ctx, client.ObjectKey{Namespace: "tigera-gateway", Name: "user-sa"}, &corev1.ServiceAccount{})).NotTo(HaveOccurred())
+		Expect(c.Get(ctx, client.ObjectKey{Namespace: "tigera-gateway", Name: "user-config"}, &corev1.ConfigMap{})).NotTo(HaveOccurred())
+		Expect(c.Get(ctx, client.ObjectKey{Name: gatewayapi.GatewayClassName}, &gapi.GatewayClass{})).NotTo(HaveOccurred())
+	})
+
+	It("writes per-namespace Gateway resources owned by the namespace's Gateways (Enterprise)", func() {
+		bundle, err := certificatemanagement.CreateTrustedBundleWithSystemRootCertificates(nil)
+		Expect(err).NotTo(HaveOccurred())
+		pullSecrets := []*corev1.Secret{{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret", Namespace: common.OperatorNamespace()}}}
+		gateways := []gapi.Gateway{
+			{ObjectMeta: metav1.ObjectMeta{Namespace: "app-ns", Name: "gw1", UID: "u1"}, Spec: gapi.GatewaySpec{GatewayClassName: gatewayapi.GatewayClassName}},
+			{ObjectMeta: metav1.ObjectMeta{Namespace: "app-ns", Name: "gw2", UID: "u2"}, Spec: gapi.GatewaySpec{GatewayClassName: gatewayapi.GatewayClassName}},
+			{ObjectMeta: metav1.ObjectMeta{Namespace: "other-ns", Name: "gw3", UID: "u3"}, Spec: gapi.GatewaySpec{GatewayClassName: "not-ours"}},
+			{ObjectMeta: metav1.ObjectMeta{Namespace: common.CalicoNamespace, Name: "gw4", UID: "u4"}, Spec: gapi.GatewaySpec{GatewayClassName: gatewayapi.GatewayClassName}},
+		}
+		Expect(r.reconcileGatewayNamespaceResources(ctx, bundle, pullSecrets, true, gateways, map[string]bool{gatewayapi.GatewayClassName: true})).NotTo(HaveOccurred())
+
+		By("creating the bundle + WAF SA/RoleBindings/pull-secret in app-ns, owned by both Gateways")
+		ownerNames := func(o client.Object) []string {
+			var n []string
+			for _, ref := range o.GetOwnerReferences() {
+				if ref.Kind == "Gateway" {
+					n = append(n, ref.Name)
+				}
+			}
+			return n
+		}
+		cm := &corev1.ConfigMap{}
+		Expect(c.Get(ctx, client.ObjectKey{Namespace: "app-ns", Name: certificatemanagement.TrustedCertConfigMapName}, cm)).NotTo(HaveOccurred())
+		Expect(ownerNames(cm)).To(ConsistOf("gw1", "gw2"))
+		Expect(c.Get(ctx, client.ObjectKey{Namespace: "app-ns", Name: "waf-http-filter"}, &corev1.ServiceAccount{})).NotTo(HaveOccurred())
+		Expect(c.Get(ctx, client.ObjectKey{Namespace: "app-ns", Name: "waf-http-filter-gateway-resources"}, &rbacv1.RoleBinding{})).NotTo(HaveOccurred())
+		Expect(c.Get(ctx, client.ObjectKey{Namespace: "app-ns", Name: "tigera-operator-secrets"}, &rbacv1.RoleBinding{})).NotTo(HaveOccurred())
+		Expect(c.Get(ctx, client.ObjectKey{Namespace: "app-ns", Name: "tigera-pull-secret"}, &corev1.Secret{})).NotTo(HaveOccurred())
+
+		By("skipping namespaces whose Gateway is not ours, and reserved namespaces")
+		Expect(apierrors.IsNotFound(c.Get(ctx, client.ObjectKey{Namespace: "other-ns", Name: certificatemanagement.TrustedCertConfigMapName}, &corev1.ConfigMap{}))).To(BeTrue())
+		Expect(apierrors.IsNotFound(c.Get(ctx, client.ObjectKey{Namespace: common.CalicoNamespace, Name: "waf-http-filter"}, &corev1.ServiceAccount{}))).To(BeTrue())
 	})
 })
 

--- a/pkg/render/gatewayapi/gateway_api.go
+++ b/pkg/render/gatewayapi/gateway_api.go
@@ -103,7 +103,6 @@ const (
 	GatewayAPIName                      = "calico-gateway-api"
 	GatewayControllerLabel              = GatewayAPIName + "-controller"
 	GatewayCertgenLabel                 = GatewayAPIName + "-certgen"
-	GatewayNamespaceBundleLabel         = GatewayAPIName + "-trusted-bundle"
 	EnvoyGatewayConfigName              = "envoy-gateway-config"
 	EnvoyGatewayConfigKey               = "envoy-gateway.yaml"
 	EnvoyGatewayDeploymentContainerName = "envoy-gateway"
@@ -403,11 +402,8 @@ type GatewayAPIImplementationConfig struct {
 	IncludeV3NetworkPolicy bool
 
 	// GatewayNamespaces is the list of namespaces containing a Gateway managed by
-	// this operator (Enterprise only).
+	// this operator, used to keep the shared WAF CRB's subjects in sync (Enterprise only).
 	GatewayNamespaces []string
-	// CurrentGatewayNamespaces tracks previously provisioned namespaces for cleanup
-	// when Gateways are removed.
-	CurrentGatewayNamespaces set.Set[string]
 
 	// TrustedBundle carries the public CA bundle (extracted from the operator's UBI
 	// base image) plus Calico's internal CA. Mounted on the envoy-gateway controller
@@ -511,70 +507,19 @@ func (pr *gatewayAPIImplementationComponent) Objects() ([]client.Object, []clien
 		pr.cfg.CurrentGatewayClasses.Delete(className)
 	}
 
-	// The data-plane proxy mounts the trust bundle from its own namespace on both variants;
-	// reserved namespaces already carry the core-owned copy.
-	if pr.cfg.TrustedBundle != nil {
-		for _, ns := range pr.cfg.GatewayNamespaces {
-			if !isReservedOperatorNamespace(ns) {
-				objs = append(objs, pr.gatewayNamespaceBundle(ns))
-			}
-		}
-	}
+	// Per-namespace resources (trust bundle + Enterprise WAF SA/RoleBindings/pull-secret) are
+	// controller-managed and Gateway-owned, so the GC cleans them up — not rendered here.
 
 	if pr.cfg.Installation.Variant.IsEnterprise() {
-		// Shared WAF ClusterRoles bound by per-namespace SAs.
+		// Shared WAF ClusterRoles bound per-namespace by the controller-managed SAs.
 		objs = append(objs,
 			pr.wafHttpFilterClusterScopedRole(),
 			pr.wafHttpFilterGatewayResourcesRole(),
 		)
-
-		// Per-namespace resources for namespaces containing a Gateway managed by
-		// this operator (populated by the GatewayAPI controller).
-		for _, ns := range pr.cfg.GatewayNamespaces {
-			objs = append(objs,
-				pr.gatewayNamespaceSA(ns),
-				pr.gatewayNamespaceRoleBinding(ns),
-			)
-			// Skip shared resources in reserved namespaces — core Installation owns them.
-			if !isReservedOperatorNamespace(ns) {
-				objs = append(objs, render.CreateOperatorSecretsRoleBinding(ns))
-				objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(ns, pr.cfg.PullSecrets...)...)...)
-			}
-		}
+		// Shared CRB: subjects recomputed each reconcile, removed when no Gateway namespaces remain.
 		if len(pr.cfg.GatewayNamespaces) > 0 {
 			objs = append(objs, pr.gatewayNamespacesCRB(pr.cfg.GatewayNamespaces))
-		}
-	}
-
-	// Clean up resources for namespaces that no longer host a Gateway. The trust bundle is
-	// mirrored on both variants; WAF/pull-secret/CRB are Enterprise-only.
-	if pr.cfg.CurrentGatewayNamespaces != nil {
-		currentNS := set.New(pr.cfg.GatewayNamespaces...)
-		enterprise := pr.cfg.Installation.Variant.IsEnterprise()
-		for _, ns := range pr.cfg.CurrentGatewayNamespaces.UnsortedList() {
-			if currentNS.Has(ns) {
-				continue
-			}
-			if !isReservedOperatorNamespace(ns) {
-				// Secret must go before the RoleBinding that grants us delete perms.
-				if enterprise {
-					objsToDelete = append(objsToDelete, secret.ToRuntimeObjects(secret.CopyToNamespace(ns, pr.cfg.PullSecrets...)...)...)
-				}
-				if pr.cfg.TrustedBundle != nil {
-					objsToDelete = append(objsToDelete, pr.gatewayNamespaceBundle(ns))
-				}
-			}
-			if enterprise {
-				objsToDelete = append(objsToDelete,
-					pr.gatewayNamespaceSA(ns),
-					pr.gatewayNamespaceRoleBinding(ns),
-				)
-				if !isReservedOperatorNamespace(ns) {
-					objsToDelete = append(objsToDelete, render.CreateOperatorSecretsRoleBinding(ns))
-				}
-			}
-		}
-		if pr.cfg.Installation.Variant.IsEnterprise() && len(pr.cfg.GatewayNamespaces) == 0 {
+		} else {
 			objsToDelete = append(objsToDelete, pr.gatewayNamespacesCRB(nil))
 		}
 	}
@@ -613,6 +558,17 @@ func (pr *gatewayAPIImplementationComponent) legacyTeardownObjects(creating []cl
 	for _, o := range creating {
 		if o.GetNamespace() == legacyNS {
 			skip.Insert(key(o))
+		}
+	}
+	// If a Gateway lives in tigera-gateway, the controller manages its per-namespace resources
+	// (Gateway-owned) — don't queue those for legacy delete or we'd fight it every reconcile.
+	for _, ns := range pr.cfg.GatewayNamespaces {
+		if ns == legacyNS {
+			skip.Insert(key(GatewayNamespaceServiceAccount(legacyNS)))
+			skip.Insert(key(render.CreateOperatorSecretsRoleBinding(legacyNS)))
+			for _, s := range secret.ToRuntimeObjects(secret.CopyToNamespace(legacyNS, pr.cfg.PullSecrets...)...) {
+				skip.Insert(key(s))
+			}
 		}
 	}
 
@@ -672,6 +628,14 @@ func (pr *gatewayAPIImplementationComponent) legacyTeardownObjects(creating []cl
 			ObjectMeta: metav1.ObjectMeta{Name: helmPrefix + "-certgen", Namespace: legacyNS},
 		},
 	)
+
+	// envoy-gateway certgen TLS Secrets — unowned, so nothing else GCs them.
+	for _, name := range []string{"envoy", "envoy-gateway", "envoy-oidc-hmac", "envoy-rate-limit"} {
+		objs = append(objs, &corev1.Secret{
+			TypeMeta:   metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: legacyNS},
+		})
+	}
 
 	// Enterprise-only WAF SA in tigera-gateway, plus the orphaned legacy CRBs
 	// that bound it (the new install uses waf-http-filter-gateway-namespaces
@@ -1358,19 +1322,8 @@ func (pr *gatewayAPIImplementationComponent) wafHttpFilterGatewayResourcesRole()
 	}
 }
 
-// gatewayNamespaceBundle is the trust bundle ConfigMap for a Gateway namespace, labeled so
-// the controller can find previously-provisioned namespaces for cleanup.
-func (pr *gatewayAPIImplementationComponent) gatewayNamespaceBundle(namespace string) *corev1.ConfigMap {
-	cm := pr.cfg.TrustedBundle.ConfigMap(namespace)
-	if cm.Labels == nil {
-		cm.Labels = map[string]string{}
-	}
-	cm.Labels[GatewayNamespaceBundleLabel] = "true"
-	return cm
-}
-
-// gatewayNamespaceSA creates a waf-http-filter ServiceAccount in a Gateway namespace.
-func (pr *gatewayAPIImplementationComponent) gatewayNamespaceSA(namespace string) *corev1.ServiceAccount {
+// GatewayNamespaceServiceAccount returns the waf-http-filter ServiceAccount for a Gateway namespace.
+func GatewayNamespaceServiceAccount(namespace string) *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -1412,7 +1365,8 @@ func (pr *gatewayAPIImplementationComponent) gatewayNamespacesCRB(namespaces []s
 
 // gatewayNamespaceRoleBinding scopes the WAF SA's Gateway API read access
 // to its own namespace (least privilege for proxies in user namespaces).
-func (pr *gatewayAPIImplementationComponent) gatewayNamespaceRoleBinding(namespace string) *rbacv1.RoleBinding {
+// GatewayNamespaceRoleBinding returns the waf-http-filter-gateway-resources RoleBinding for a Gateway namespace.
+func GatewayNamespaceRoleBinding(namespace string) *rbacv1.RoleBinding {
 	return &rbacv1.RoleBinding{
 		TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/render/gatewayapi/gateway_api.go
+++ b/pkg/render/gatewayapi/gateway_api.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 	"sync"
 
@@ -556,13 +557,11 @@ func (pr *gatewayAPIImplementationComponent) legacyTeardownObjects(creating []cl
 	}
 	// If a Gateway lives in tigera-gateway, the controller manages its per-namespace resources
 	// (Gateway-owned) — don't queue those for legacy delete or we'd fight it every reconcile.
-	for _, ns := range pr.cfg.GatewayNamespaces {
-		if ns == legacyNS {
-			skip.Insert(key(GatewayNamespaceServiceAccount(legacyNS)))
-			skip.Insert(key(render.CreateOperatorSecretsRoleBinding(legacyNS)))
-			for _, s := range secret.ToRuntimeObjects(secret.CopyToNamespace(legacyNS, pr.cfg.PullSecrets...)...) {
-				skip.Insert(key(s))
-			}
+	if slices.Contains(pr.cfg.GatewayNamespaces, legacyNS) {
+		skip.Insert(key(GatewayNamespaceServiceAccount(legacyNS)))
+		skip.Insert(key(render.CreateOperatorSecretsRoleBinding(legacyNS)))
+		for _, s := range secret.ToRuntimeObjects(secret.CopyToNamespace(legacyNS, pr.cfg.PullSecrets...)...) {
+			skip.Insert(key(s))
 		}
 	}
 

--- a/pkg/render/gatewayapi/gateway_api.go
+++ b/pkg/render/gatewayapi/gateway_api.go
@@ -187,12 +187,6 @@ func toMap(v any) (map[string]any, error) {
 	return out, nil
 }
 
-// isReservedOperatorNamespace reports whether core Installation already owns
-// tigera-operator-secrets / tigera-pull-secret in ns (deleting ours would wipe them).
-func isReservedOperatorNamespace(ns string) bool {
-	return ns == common.CalicoNamespace || ns == common.OperatorNamespace()
-}
-
 // Chart output is deterministic for our single render, so it's cached by
 // sync.Once. Callers must deep-copy any object they intend to mutate.
 var (

--- a/pkg/render/gatewayapi/gateway_api.go
+++ b/pkg/render/gatewayapi/gateway_api.go
@@ -103,6 +103,7 @@ const (
 	GatewayAPIName                      = "calico-gateway-api"
 	GatewayControllerLabel              = GatewayAPIName + "-controller"
 	GatewayCertgenLabel                 = GatewayAPIName + "-certgen"
+	GatewayNamespaceBundleLabel         = GatewayAPIName + "-trusted-bundle"
 	EnvoyGatewayConfigName              = "envoy-gateway-config"
 	EnvoyGatewayConfigKey               = "envoy-gateway.yaml"
 	EnvoyGatewayDeploymentContainerName = "envoy-gateway"
@@ -510,6 +511,16 @@ func (pr *gatewayAPIImplementationComponent) Objects() ([]client.Object, []clien
 		pr.cfg.CurrentGatewayClasses.Delete(className)
 	}
 
+	// The data-plane proxy mounts the trust bundle from its own namespace on both variants;
+	// reserved namespaces already carry the core-owned copy.
+	if pr.cfg.TrustedBundle != nil {
+		for _, ns := range pr.cfg.GatewayNamespaces {
+			if !isReservedOperatorNamespace(ns) {
+				objs = append(objs, pr.gatewayNamespaceBundle(ns))
+			}
+		}
+	}
+
 	if pr.cfg.Installation.Variant.IsEnterprise() {
 		// Shared WAF ClusterRoles bound by per-namespace SAs.
 		objs = append(objs,
@@ -528,41 +539,43 @@ func (pr *gatewayAPIImplementationComponent) Objects() ([]client.Object, []clien
 			if !isReservedOperatorNamespace(ns) {
 				objs = append(objs, render.CreateOperatorSecretsRoleBinding(ns))
 				objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(ns, pr.cfg.PullSecrets...)...)...)
-				// envoy-proxy pods mount the bundle from their own namespace.
-				if pr.cfg.TrustedBundle != nil {
-					objs = append(objs, pr.cfg.TrustedBundle.ConfigMap(ns))
-				}
 			}
 		}
 		if len(pr.cfg.GatewayNamespaces) > 0 {
 			objs = append(objs, pr.gatewayNamespacesCRB(pr.cfg.GatewayNamespaces))
 		}
+	}
 
-		// Clean up resources for namespaces that no longer host a Gateway.
-		if pr.cfg.CurrentGatewayNamespaces != nil {
-			currentNS := set.New(pr.cfg.GatewayNamespaces...)
-			for _, ns := range pr.cfg.CurrentGatewayNamespaces.UnsortedList() {
-				if !currentNS.Has(ns) {
-					// Secret must go before the RoleBinding that grants us delete perms; skip shared
-					// resources in reserved namespaces (core-owned).
-					if !isReservedOperatorNamespace(ns) {
-						objsToDelete = append(objsToDelete, secret.ToRuntimeObjects(secret.CopyToNamespace(ns, pr.cfg.PullSecrets...)...)...)
-						if pr.cfg.TrustedBundle != nil {
-							objsToDelete = append(objsToDelete, pr.cfg.TrustedBundle.ConfigMap(ns))
-						}
-					}
-					objsToDelete = append(objsToDelete,
-						pr.gatewayNamespaceSA(ns),
-						pr.gatewayNamespaceRoleBinding(ns),
-					)
-					if !isReservedOperatorNamespace(ns) {
-						objsToDelete = append(objsToDelete, render.CreateOperatorSecretsRoleBinding(ns))
-					}
+	// Clean up resources for namespaces that no longer host a Gateway. The trust bundle is
+	// mirrored on both variants; WAF/pull-secret/CRB are Enterprise-only.
+	if pr.cfg.CurrentGatewayNamespaces != nil {
+		currentNS := set.New(pr.cfg.GatewayNamespaces...)
+		enterprise := pr.cfg.Installation.Variant.IsEnterprise()
+		for _, ns := range pr.cfg.CurrentGatewayNamespaces.UnsortedList() {
+			if currentNS.Has(ns) {
+				continue
+			}
+			if !isReservedOperatorNamespace(ns) {
+				// Secret must go before the RoleBinding that grants us delete perms.
+				if enterprise {
+					objsToDelete = append(objsToDelete, secret.ToRuntimeObjects(secret.CopyToNamespace(ns, pr.cfg.PullSecrets...)...)...)
+				}
+				if pr.cfg.TrustedBundle != nil {
+					objsToDelete = append(objsToDelete, pr.gatewayNamespaceBundle(ns))
 				}
 			}
-			if len(pr.cfg.GatewayNamespaces) == 0 {
-				objsToDelete = append(objsToDelete, pr.gatewayNamespacesCRB(nil))
+			if enterprise {
+				objsToDelete = append(objsToDelete,
+					pr.gatewayNamespaceSA(ns),
+					pr.gatewayNamespaceRoleBinding(ns),
+				)
+				if !isReservedOperatorNamespace(ns) {
+					objsToDelete = append(objsToDelete, render.CreateOperatorSecretsRoleBinding(ns))
+				}
 			}
+		}
+		if pr.cfg.Installation.Variant.IsEnterprise() && len(pr.cfg.GatewayNamespaces) == 0 {
+			objsToDelete = append(objsToDelete, pr.gatewayNamespacesCRB(nil))
 		}
 	}
 
@@ -1343,6 +1356,17 @@ func (pr *gatewayAPIImplementationComponent) wafHttpFilterGatewayResourcesRole()
 			},
 		},
 	}
+}
+
+// gatewayNamespaceBundle is the trust bundle ConfigMap for a Gateway namespace, labeled so
+// the controller can find previously-provisioned namespaces for cleanup.
+func (pr *gatewayAPIImplementationComponent) gatewayNamespaceBundle(namespace string) *corev1.ConfigMap {
+	cm := pr.cfg.TrustedBundle.ConfigMap(namespace)
+	if cm.Labels == nil {
+		cm.Labels = map[string]string{}
+	}
+	cm.Labels[GatewayNamespaceBundleLabel] = "true"
+	return cm
 }
 
 // gatewayNamespaceSA creates a waf-http-filter ServiceAccount in a Gateway namespace.

--- a/pkg/render/gatewayapi/gateway_api_test.go
+++ b/pkg/render/gatewayapi/gateway_api_test.go
@@ -37,7 +37,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
-	"k8s.io/utils/set"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gapi "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/yaml"
@@ -69,12 +68,14 @@ func testScheme() *runtime.Scheme {
 
 // expectLegacyCleanup asserts the legacy tigera-gateway upgrade-cleanup is
 // queued in objsToDelete and the Namespace itself is *not* deleted. enterprise
-// adds the WAF SA + the two orphaned legacy CRBs; hasPullSecret accounts for
-// the tigera-pull-secret previously copied into the legacy namespace.
+// adds the WAF SA, the two orphaned legacy CRBs, and the shared gateway-namespaces
+// CRB (removed when no Gateway namespaces remain); hasPullSecret accounts for the
+// tigera-pull-secret previously copied into the legacy namespace.
 func expectLegacyCleanup(objsToDelete []client.Object, enterprise, hasPullSecret bool) {
-	expected := 12 + 1 + 3 // helm-rendered in-namespace + tigera-operator-secrets RB + cluster-scoped (MWC, CR, CRB).
+	expected := 12 + 4 + 1 + 3 // helm-rendered in-namespace + certgen Secrets + tigera-operator-secrets RB + cluster-scoped (MWC, CR, CRB).
 	if enterprise {
-		expected += 3
+		expected += 4
+		rtest.ExpectResourceInList(objsToDelete, GatewayNamespacesCRBName, "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding")
 	}
 	if hasPullSecret {
 		expected += 1
@@ -88,6 +89,7 @@ func expectLegacyCleanup(objsToDelete []client.Object, enterprise, hasPullSecret
 	}
 	rtest.ExpectResourceInList(objsToDelete, "envoy-gateway-topology-injector.tigera-gateway", "", "admissionregistration.k8s.io", "v1", "MutatingWebhookConfiguration")
 	rtest.ExpectResourceInList(objsToDelete, "envoy-gateway", "tigera-gateway", "apps", "v1", "Deployment")
+	rtest.ExpectResourceInList(objsToDelete, "envoy", "tigera-gateway", "", "v1", "Secret")
 	rtest.ExpectResourceInList(objsToDelete, "tigera-operator-secrets", "tigera-gateway", "rbac.authorization.k8s.io", "v1", "RoleBinding")
 }
 
@@ -1531,63 +1533,36 @@ value:
 		Expect(err).To(HaveOccurred())
 	})
 
-	It("should create per-namespace resources for each Gateway namespace (Enterprise)", func() {
-		installation := &operatorv1.InstallationSpec{
-			Variant: operatorv1.CalicoEnterprise,
-		}
-		pullSecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret", Namespace: "tigera-operator"},
-			Data:       map[string][]byte{".dockerconfigjson": []byte("{}")},
-		}
-		gatewayAPI := &operatorv1.GatewayAPI{
-			Spec: operatorv1.GatewayAPISpec{
-				GatewayClasses: []operatorv1.GatewayClassSpec{{Name: "tigera-gateway-class"}},
-			},
-		}
+	It("renders the shared WAF CRB with a subject per Gateway namespace; per-namespace resources are controller-managed (Enterprise)", func() {
 		gatewayComp, gatewayCompErr := GatewayAPIImplementationComponent(&GatewayAPIImplementationConfig{
 			Scheme:            testScheme(),
-			Installation:      installation,
-			GatewayAPI:        gatewayAPI,
-			PullSecrets:       []*corev1.Secret{pullSecret},
+			Installation:      &operatorv1.InstallationSpec{Variant: operatorv1.CalicoEnterprise},
+			GatewayAPI:        &operatorv1.GatewayAPI{Spec: operatorv1.GatewayAPISpec{GatewayClasses: []operatorv1.GatewayClassSpec{{Name: "tigera-gateway-class"}}}},
+			PullSecrets:       []*corev1.Secret{{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret", Namespace: "tigera-operator"}}},
 			GatewayNamespaces: []string{"default", "app-ns"},
 		})
 		Expect(gatewayCompErr).NotTo(HaveOccurred())
 
 		objsToCreate, _ := gatewayComp.Objects()
 
-		// Verify per-namespace ServiceAccounts.
-		sa1, err := rtest.GetResourceOfType[*corev1.ServiceAccount](objsToCreate, "waf-http-filter", "default")
-		Expect(err).NotTo(HaveOccurred())
-		Expect(sa1.Namespace).To(Equal("default"))
-
-		sa2, err := rtest.GetResourceOfType[*corev1.ServiceAccount](objsToCreate, "waf-http-filter", "app-ns")
-		Expect(err).NotTo(HaveOccurred())
-		Expect(sa2.Namespace).To(Equal("app-ns"))
-
-		// Verify a single shared ClusterRoleBinding (cluster-scoped role) with one Subject per namespace.
+		// The shared CRB carries one subject per Gateway namespace.
 		crb, err := rtest.GetResourceOfType[*rbacv1.ClusterRoleBinding](objsToCreate, GatewayNamespacesCRBName, "")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(crb.RoleRef.Name).To(Equal("waf-http-filter-cluster-scoped"))
-		Expect(crb.Subjects).To(HaveLen(2))
-		nsSubjects := []string{crb.Subjects[0].Namespace, crb.Subjects[1].Namespace}
+		nsSubjects := []string{}
+		for _, s := range crb.Subjects {
+			nsSubjects = append(nsSubjects, s.Namespace)
+		}
 		Expect(nsSubjects).To(ConsistOf("default", "app-ns"))
 
-		// Verify per-namespace RoleBindings for gateway resources scoped to that namespace.
-		rb1, err := rtest.GetResourceOfType[*rbacv1.RoleBinding](objsToCreate, "waf-http-filter-gateway-resources", "default")
-		Expect(err).NotTo(HaveOccurred())
-		Expect(rb1.RoleRef.Name).To(Equal("waf-http-filter-gateway-resources"))
-		Expect(rb1.Subjects).To(HaveLen(1))
-		Expect(rb1.Subjects[0].Namespace).To(Equal("default"))
-
-		rb2, err := rtest.GetResourceOfType[*rbacv1.RoleBinding](objsToCreate, "waf-http-filter-gateway-resources", "app-ns")
-		Expect(err).NotTo(HaveOccurred())
-		Expect(rb2.Subjects[0].Namespace).To(Equal("app-ns"))
-
-		// Verify pull secrets copied to each namespace.
+		// The per-namespace SA / RoleBinding / pull-secret are written by the controller (Gateway-owned),
+		// not rendered here.
+		_, err = rtest.GetResourceOfType[*corev1.ServiceAccount](objsToCreate, "waf-http-filter", "default")
+		Expect(err).To(HaveOccurred())
+		_, err = rtest.GetResourceOfType[*rbacv1.RoleBinding](objsToCreate, "waf-http-filter-gateway-resources", "default")
+		Expect(err).To(HaveOccurred())
 		_, err = rtest.GetResourceOfType[*corev1.Secret](objsToCreate, "tigera-pull-secret", "default")
-		Expect(err).NotTo(HaveOccurred())
-		_, err = rtest.GetResourceOfType[*corev1.Secret](objsToCreate, "tigera-pull-secret", "app-ns")
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).To(HaveOccurred())
 	})
 
 	It("should not legacy-delete operator resources that the per-NS loop is re-creating in tigera-gateway", func() {
@@ -1619,77 +1594,6 @@ value:
 				Expect(obj.Name).NotTo(Equal("tigera-operator-secrets"), "must not queue tigera-operator-secrets RB for delete in tigera-gateway")
 			}
 		}
-	})
-
-	It("should copy the trust bundle ConfigMap into each Gateway namespace", func() {
-		bundle, err := certificatemanagement.CreateTrustedBundleWithSystemRootCertificates(nil)
-		Expect(err).NotTo(HaveOccurred())
-		gatewayComp, gatewayCompErr := GatewayAPIImplementationComponent(&GatewayAPIImplementationConfig{
-			Scheme:            testScheme(),
-			Installation:      &operatorv1.InstallationSpec{Variant: operatorv1.CalicoEnterprise},
-			GatewayAPI:        &operatorv1.GatewayAPI{Spec: operatorv1.GatewayAPISpec{GatewayClasses: []operatorv1.GatewayClassSpec{{Name: "tigera-gateway-class"}}}},
-			TrustedBundle:     bundle,
-			GatewayNamespaces: []string{"default", "app-ns"},
-		})
-		Expect(gatewayCompErr).NotTo(HaveOccurred())
-
-		objsToCreate, _ := gatewayComp.Objects()
-		for _, ns := range []string{"default", "app-ns"} {
-			_, err := rtest.GetResourceOfType[*corev1.ConfigMap](objsToCreate, certificatemanagement.TrustedCertConfigMapName, ns)
-			Expect(err).NotTo(HaveOccurred(), "trust bundle ConfigMap should be copied into %s", ns)
-		}
-	})
-
-	It("should copy the trust bundle ConfigMap into each Gateway namespace (open-source)", func() {
-		// The data-plane proxy mounts the bundle from its own namespace regardless of
-		// variant, so the per-namespace copy must happen on open-source too.
-		bundle, err := certificatemanagement.CreateTrustedBundleWithSystemRootCertificates(nil)
-		Expect(err).NotTo(HaveOccurred())
-		gatewayComp, gatewayCompErr := GatewayAPIImplementationComponent(&GatewayAPIImplementationConfig{
-			Scheme:            testScheme(),
-			Installation:      &operatorv1.InstallationSpec{Variant: operatorv1.Calico},
-			GatewayAPI:        &operatorv1.GatewayAPI{Spec: operatorv1.GatewayAPISpec{GatewayClasses: []operatorv1.GatewayClassSpec{{Name: "tigera-gateway-class"}}}},
-			TrustedBundle:     bundle,
-			GatewayNamespaces: []string{"default", "app-ns"},
-		})
-		Expect(gatewayCompErr).NotTo(HaveOccurred())
-
-		objsToCreate, _ := gatewayComp.Objects()
-		for _, ns := range []string{"default", "app-ns"} {
-			cm, err := rtest.GetResourceOfType[*corev1.ConfigMap](objsToCreate, certificatemanagement.TrustedCertConfigMapName, ns)
-			Expect(err).NotTo(HaveOccurred(), "trust bundle ConfigMap should be copied into %s", ns)
-			Expect(cm.Labels).To(HaveKeyWithValue(GatewayNamespaceBundleLabel, "true"))
-		}
-
-		// The WAF per-namespace machinery stays Enterprise-only.
-		_, err = rtest.GetResourceOfType[*rbacv1.ClusterRoleBinding](objsToCreate, GatewayNamespacesCRBName, "")
-		Expect(err).To(HaveOccurred())
-		_, err = rtest.GetResourceOfType[*corev1.ServiceAccount](objsToCreate, "waf-http-filter", "default")
-		Expect(err).To(HaveOccurred())
-	})
-
-	It("should clean up the trust bundle ConfigMap from stale Gateway namespaces (open-source)", func() {
-		bundle, err := certificatemanagement.CreateTrustedBundleWithSystemRootCertificates(nil)
-		Expect(err).NotTo(HaveOccurred())
-		gatewayComp, gatewayCompErr := GatewayAPIImplementationComponent(&GatewayAPIImplementationConfig{
-			Scheme:                   testScheme(),
-			Installation:             &operatorv1.InstallationSpec{Variant: operatorv1.Calico},
-			GatewayAPI:               &operatorv1.GatewayAPI{Spec: operatorv1.GatewayAPISpec{GatewayClasses: []operatorv1.GatewayClassSpec{{Name: "tigera-gateway-class"}}}},
-			TrustedBundle:            bundle,
-			GatewayNamespaces:        []string{"default"},
-			CurrentGatewayNamespaces: set.New("default", "removed-ns"),
-		})
-		Expect(gatewayCompErr).NotTo(HaveOccurred())
-
-		objsToCreate, objsToDelete := gatewayComp.Objects()
-
-		// Still copied into the live namespace.
-		_, err = rtest.GetResourceOfType[*corev1.ConfigMap](objsToCreate, certificatemanagement.TrustedCertConfigMapName, "default")
-		Expect(err).NotTo(HaveOccurred())
-
-		// Removed from the namespace that no longer hosts a Gateway.
-		_, err = rtest.GetResourceOfType[*corev1.ConfigMap](objsToDelete, certificatemanagement.TrustedCertConfigMapName, "removed-ns")
-		Expect(err).NotTo(HaveOccurred(), "trust bundle ConfigMap should be deleted from removed-ns")
 	})
 
 	It("should not create per-namespace resources when no Gateway namespaces are provided (Enterprise)", func() {
@@ -1835,170 +1739,6 @@ value:
 		// Open-source should NOT have waf-http-filter SA at all.
 		_, err = rtest.GetResourceOfType[*corev1.ServiceAccount](objsToCreate, "waf-http-filter", "default")
 		Expect(err).To(HaveOccurred())
-	})
-
-	It("should clean up stale per-namespace resources when Gateways are removed", func() {
-		installation := &operatorv1.InstallationSpec{
-			Variant: operatorv1.CalicoEnterprise,
-		}
-		gatewayAPI := &operatorv1.GatewayAPI{
-			Spec: operatorv1.GatewayAPISpec{
-				GatewayClasses: []operatorv1.GatewayClassSpec{{Name: "tigera-gateway-class"}},
-			},
-		}
-		pullSecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret", Namespace: "tigera-operator"},
-			Data:       map[string][]byte{".dockerconfigjson": []byte("{}")},
-		}
-		gatewayComp, gatewayCompErr := GatewayAPIImplementationComponent(&GatewayAPIImplementationConfig{
-			Scheme:       testScheme(),
-			Installation: installation,
-			GatewayAPI:   gatewayAPI,
-			PullSecrets:  []*corev1.Secret{pullSecret},
-			// "default" still has a Gateway, but "removed-ns" no longer does.
-			GatewayNamespaces:        []string{"default"},
-			CurrentGatewayNamespaces: set.New("default", "removed-ns"),
-		})
-		Expect(gatewayCompErr).NotTo(HaveOccurred())
-
-		objsToCreate, objsToDelete := gatewayComp.Objects()
-
-		// "default" resources should be created.
-		_, err := rtest.GetResourceOfType[*corev1.ServiceAccount](objsToCreate, "waf-http-filter", "default")
-		Expect(err).NotTo(HaveOccurred())
-
-		// Shared CRB should still be created with only the "default" subject.
-		crb, err := rtest.GetResourceOfType[*rbacv1.ClusterRoleBinding](objsToCreate, GatewayNamespacesCRBName, "")
-		Expect(err).NotTo(HaveOccurred())
-		Expect(crb.Subjects).To(HaveLen(1))
-		Expect(crb.Subjects[0].Namespace).To(Equal("default"))
-
-		// Verify stale "removed-ns" resources and the legacy tigera-gateway
-		// upgrade cleanup are in the delete list. The tigera-gateway Namespace
-		// itself is intentionally not present.
-		rtest.ExpectResources(objsToDelete, []client.Object{
-			// Legacy tigera-gateway upgrade cleanup: pull secret + helm-rendered
-			// in-namespace resources + Enterprise WAF SA + the orphaned legacy
-			// CRBs + tigera-operator-secrets RB + cluster-scoped legacy bits.
-			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret", Namespace: "tigera-gateway"}},
-			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "envoy-gateway", Namespace: "tigera-gateway"}},
-			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "envoy-gateway-config", Namespace: "tigera-gateway"}},
-			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "envoy-gateway", Namespace: "tigera-gateway"}},
-			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "envoy-gateway", Namespace: "tigera-gateway"}},
-			&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: "tigera-gateway-api-gateway-helm-infra-manager", Namespace: "tigera-gateway"}},
-			&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "tigera-gateway-api-gateway-helm-infra-manager", Namespace: "tigera-gateway"}},
-			&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: "tigera-gateway-api-gateway-helm-leader-election-role", Namespace: "tigera-gateway"}},
-			&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "tigera-gateway-api-gateway-helm-leader-election-rolebinding", Namespace: "tigera-gateway"}},
-			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "tigera-gateway-api-gateway-helm-certgen", Namespace: "tigera-gateway"}},
-			&rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: "tigera-gateway-api-gateway-helm-certgen", Namespace: "tigera-gateway"}},
-			&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "tigera-gateway-api-gateway-helm-certgen", Namespace: "tigera-gateway"}},
-			&batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "tigera-gateway-api-gateway-helm-certgen", Namespace: "tigera-gateway"}},
-			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "waf-http-filter", Namespace: "tigera-gateway"}},
-			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "waf-http-filter-cluster-scoped"}},
-			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "waf-http-filter-gateway-resources"}},
-			&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "tigera-operator-secrets", Namespace: "tigera-gateway"}},
-			&admissionregv1.MutatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: "envoy-gateway-topology-injector.tigera-gateway"}},
-			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "waf-http-filter"}},
-			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "waf-http-filter"}},
-			// Stale per-namespace resources for "removed-ns".
-			&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "tigera-operator-secrets", Namespace: "removed-ns"}},
-			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "waf-http-filter", Namespace: "removed-ns"}},
-			&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "waf-http-filter-gateway-resources", Namespace: "removed-ns"}},
-			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret", Namespace: "removed-ns"}},
-		})
-
-		// Secret must be deleted before the RoleBinding that grants us delete perms (else 403).
-		secretIdx, rbIdx := -1, -1
-		for i, obj := range objsToDelete {
-			if obj.GetNamespace() != "removed-ns" {
-				continue
-			}
-			switch obj.(type) {
-			case *corev1.Secret:
-				if obj.GetName() == "tigera-pull-secret" {
-					secretIdx = i
-				}
-			case *rbacv1.RoleBinding:
-				if obj.GetName() == "tigera-operator-secrets" {
-					rbIdx = i
-				}
-			}
-		}
-		Expect(secretIdx).NotTo(Equal(-1))
-		Expect(rbIdx).NotTo(Equal(-1))
-		Expect(secretIdx).To(BeNumerically("<", rbIdx),
-			"tigera-pull-secret must be deleted before tigera-operator-secrets RoleBinding")
-	})
-
-	It("must not create or delete core-owned shared resources in reserved namespaces", func() {
-		installation := &operatorv1.InstallationSpec{Variant: operatorv1.CalicoEnterprise}
-		gatewayAPI := &operatorv1.GatewayAPI{
-			Spec: operatorv1.GatewayAPISpec{
-				GatewayClasses: []operatorv1.GatewayClassSpec{{Name: "tigera-gateway-class"}},
-			},
-		}
-		pullSecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret", Namespace: "tigera-operator"},
-			Data:       map[string][]byte{".dockerconfigjson": []byte("{}")},
-		}
-		gatewayComp, gatewayCompErr := GatewayAPIImplementationComponent(&GatewayAPIImplementationConfig{
-			Scheme:       testScheme(),
-			Installation: installation,
-			GatewayAPI:   gatewayAPI,
-			PullSecrets:  []*corev1.Secret{pullSecret},
-			// Gateways in reserved namespaces (odd but possible) plus a normal one.
-			GatewayNamespaces:        []string{common.CalicoNamespace, common.OperatorNamespace(), "app-ns"},
-			CurrentGatewayNamespaces: set.New(common.CalicoNamespace, common.OperatorNamespace(), "app-ns"),
-		})
-		Expect(gatewayCompErr).NotTo(HaveOccurred())
-
-		objsToCreate, _ := gatewayComp.Objects()
-
-		// app-ns gets the full treatment — WAF SA + both RoleBindings + pull secret.
-		_, err := rtest.GetResourceOfType[*rbacv1.RoleBinding](objsToCreate, "tigera-operator-secrets", "app-ns")
-		Expect(err).NotTo(HaveOccurred())
-		_, err = rtest.GetResourceOfType[*corev1.Secret](objsToCreate, "tigera-pull-secret", "app-ns")
-		Expect(err).NotTo(HaveOccurred())
-
-		// Reserved namespaces get WAF-specific resources but not the shared ones.
-		for _, ns := range []string{common.CalicoNamespace, common.OperatorNamespace()} {
-			_, err = rtest.GetResourceOfType[*corev1.ServiceAccount](objsToCreate, "waf-http-filter", ns)
-			Expect(err).NotTo(HaveOccurred(), "WAF SA should still be created in %s", ns)
-			_, err = rtest.GetResourceOfType[*rbacv1.RoleBinding](objsToCreate, "waf-http-filter-gateway-resources", ns)
-			Expect(err).NotTo(HaveOccurred(), "WAF gateway-resources RB should still be created in %s", ns)
-
-			_, err = rtest.GetResourceOfType[*rbacv1.RoleBinding](objsToCreate, "tigera-operator-secrets", ns)
-			Expect(err).To(HaveOccurred(), "must not create tigera-operator-secrets in reserved namespace %s", ns)
-			_, err = rtest.GetResourceOfType[*corev1.Secret](objsToCreate, "tigera-pull-secret", ns)
-			Expect(err).To(HaveOccurred(), "must not copy tigera-pull-secret into reserved namespace %s", ns)
-		}
-
-		// Delete path: never queue shared resources in reserved namespaces.
-		gatewayComp, gatewayCompErr = GatewayAPIImplementationComponent(&GatewayAPIImplementationConfig{
-			Scheme:                   testScheme(),
-			Installation:             installation,
-			GatewayAPI:               gatewayAPI,
-			PullSecrets:              []*corev1.Secret{pullSecret},
-			GatewayNamespaces:        nil,
-			CurrentGatewayNamespaces: set.New(common.CalicoNamespace, common.OperatorNamespace()),
-		})
-		Expect(gatewayCompErr).NotTo(HaveOccurred())
-
-		_, objsToDelete := gatewayComp.Objects()
-		for _, obj := range objsToDelete {
-			ns := obj.GetNamespace()
-			if ns != common.CalicoNamespace && ns != common.OperatorNamespace() {
-				continue
-			}
-			switch o := obj.(type) {
-			case *rbacv1.RoleBinding:
-				Expect(o.Name).NotTo(Equal("tigera-operator-secrets"),
-					"must not delete tigera-operator-secrets in reserved namespace %s", ns)
-			case *corev1.Secret:
-				Expect(o.Name).NotTo(Equal("tigera-pull-secret"),
-					"must not delete tigera-pull-secret in reserved namespace %s", ns)
-			}
-		}
 	})
 
 	It("should queue the legacy tigera-gateway install for cleanup on every reconcile", func() {

--- a/pkg/render/gatewayapi/gateway_api_test.go
+++ b/pkg/render/gatewayapi/gateway_api_test.go
@@ -1640,6 +1640,58 @@ value:
 		}
 	})
 
+	It("should copy the trust bundle ConfigMap into each Gateway namespace (open-source)", func() {
+		// The data-plane proxy mounts the bundle from its own namespace regardless of
+		// variant, so the per-namespace copy must happen on open-source too.
+		bundle, err := certificatemanagement.CreateTrustedBundleWithSystemRootCertificates(nil)
+		Expect(err).NotTo(HaveOccurred())
+		gatewayComp, gatewayCompErr := GatewayAPIImplementationComponent(&GatewayAPIImplementationConfig{
+			Scheme:            testScheme(),
+			Installation:      &operatorv1.InstallationSpec{Variant: operatorv1.Calico},
+			GatewayAPI:        &operatorv1.GatewayAPI{Spec: operatorv1.GatewayAPISpec{GatewayClasses: []operatorv1.GatewayClassSpec{{Name: "tigera-gateway-class"}}}},
+			TrustedBundle:     bundle,
+			GatewayNamespaces: []string{"default", "app-ns"},
+		})
+		Expect(gatewayCompErr).NotTo(HaveOccurred())
+
+		objsToCreate, _ := gatewayComp.Objects()
+		for _, ns := range []string{"default", "app-ns"} {
+			cm, err := rtest.GetResourceOfType[*corev1.ConfigMap](objsToCreate, certificatemanagement.TrustedCertConfigMapName, ns)
+			Expect(err).NotTo(HaveOccurred(), "trust bundle ConfigMap should be copied into %s", ns)
+			Expect(cm.Labels).To(HaveKeyWithValue(GatewayNamespaceBundleLabel, "true"))
+		}
+
+		// The WAF per-namespace machinery stays Enterprise-only.
+		_, err = rtest.GetResourceOfType[*rbacv1.ClusterRoleBinding](objsToCreate, GatewayNamespacesCRBName, "")
+		Expect(err).To(HaveOccurred())
+		_, err = rtest.GetResourceOfType[*corev1.ServiceAccount](objsToCreate, "waf-http-filter", "default")
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should clean up the trust bundle ConfigMap from stale Gateway namespaces (open-source)", func() {
+		bundle, err := certificatemanagement.CreateTrustedBundleWithSystemRootCertificates(nil)
+		Expect(err).NotTo(HaveOccurred())
+		gatewayComp, gatewayCompErr := GatewayAPIImplementationComponent(&GatewayAPIImplementationConfig{
+			Scheme:                   testScheme(),
+			Installation:             &operatorv1.InstallationSpec{Variant: operatorv1.Calico},
+			GatewayAPI:               &operatorv1.GatewayAPI{Spec: operatorv1.GatewayAPISpec{GatewayClasses: []operatorv1.GatewayClassSpec{{Name: "tigera-gateway-class"}}}},
+			TrustedBundle:            bundle,
+			GatewayNamespaces:        []string{"default"},
+			CurrentGatewayNamespaces: set.New("default", "removed-ns"),
+		})
+		Expect(gatewayCompErr).NotTo(HaveOccurred())
+
+		objsToCreate, objsToDelete := gatewayComp.Objects()
+
+		// Still copied into the live namespace.
+		_, err = rtest.GetResourceOfType[*corev1.ConfigMap](objsToCreate, certificatemanagement.TrustedCertConfigMapName, "default")
+		Expect(err).NotTo(HaveOccurred())
+
+		// Removed from the namespace that no longer hosts a Gateway.
+		_, err = rtest.GetResourceOfType[*corev1.ConfigMap](objsToDelete, certificatemanagement.TrustedCertConfigMapName, "removed-ns")
+		Expect(err).NotTo(HaveOccurred(), "trust bundle ConfigMap should be deleted from removed-ns")
+	})
+
 	It("should not create per-namespace resources when no Gateway namespaces are provided (Enterprise)", func() {
 		installation := &operatorv1.InstallationSpec{
 			Variant: operatorv1.CalicoEnterprise,


### PR DESCRIPTION
- the data-plane proxy mounts tigera-ca-bundle from its own namespace on both variants, but the per-namespace copy was Enterprise-gated, so OSS proxies hung at ContainerCreating (configmap not found)
- mirror the bundle for both variants; controller tracks OSS namespaces via a labeled ConfigMap for cleanup

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
None
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
