### PR TITLE
fix: revert GO_BUILD_VER to 1.25.11, use GOTOOLCHAIN instead

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ endif
 REPO?=tigera/operator
 PACKAGE_NAME?=github.com/tigera/operator
 LOCAL_USER_ID?=$(shell id -u $$USER)
-GO_BUILD_VER?=1.26.3-llvm21.1.8-k8s1.35.5
+GO_BUILD_VER?=1.25.11-llvm18.1.8-k8s1.33.12
 CALICO_BUILD?=calico/go-build:$(GO_BUILD_VER)-$(BUILDARCH)
 SRC_FILES=$(shell find ./pkg -name '*.go')
 SRC_FILES+=$(shell find ./api -name '*.go')
@@ -157,6 +157,7 @@ CONTAINERIZED= mkdir -p .go-pkg-cache $(GOMOD_CACHE) && \
 		-e KUBECONFIG=/go/src/$(PACKAGE_NAME)/kubeconfig.yaml \
 		-e ACK_GINKGO_RC=true \
 		-e ACK_GINKGO_DEPRECATIONS=1.16.5 \
+		-e GOTOOLCHAIN=go1.26.4+auto \
 		-w /go/src/$(PACKAGE_NAME) \
 		--net=host \
 		$(EXTRA_DOCKER_ARGS)
@@ -506,8 +507,13 @@ cluster-destroy: $(BINDIR)/kubectl $(BINDIR)/kind
 ###############################################################################
 .PHONY: static-checks
 ## Perform static checks on the code.
+# Use the newer go-build image for lint because golangci-lint bundled in the
+# 1.25.x image was built with Go 1.25 and refuses to lint code targeting
+# Go 1.26.3. The binary build still uses GO_BUILD_VER (1.25.x) to ensure
+# glibc compatibility with the runtime UBI image.
+CALICO_BUILD_LINT ?= calico/go-build:1.26.3-llvm21.1.8-k8s1.35.5-$(BUILDARCH)
 static-checks:
-	$(CONTAINERIZED) $(CALICO_BUILD) golangci-lint run --timeout 5m
+	$(CONTAINERIZED) $(CALICO_BUILD_LINT) golangci-lint run --timeout 5m
 
 .PHONY: fix
 ## Fix static checks


### PR DESCRIPTION
The 1.26.3-llvm21.1.8-k8s1.35.5 go-build image links against glibc 2.34 but the operator runtime UBI image only has glibc 2.28, causing the operator binary to crash on startup:

  operator: /lib64/libc.so.6: version GLIBC_2.34 not found

Revert GO_BUILD_VER to 1.25.11-llvm18.1.8-k8s1.33.12 (matching glibc) and set GOTOOLCHAIN=go1.26.4+auto in the CONTAINERIZED macro so Go auto-downloads the 1.26.x compiler while still linking against the container's glibc.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
Fix: Revert GO_BUILD_VER to avoid glibc mismatch in operator runtime
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
