### PR TITLE
fix(release/branch): default enterprise registry at branch cut

### DIFF
--- a/hack/release/branch.go
+++ b/hack/release/branch.go
@@ -417,6 +417,10 @@ func modifyConfigVersions(ctx context.Context, c *cli.Command, repoRootDir strin
 	// Missing context keys are treated as empty strings; Generate() skips the update for empty versions.
 	calicoVersion, _ := ctx.Value(calicoConfigVersionCtxKey).(string)
 	enterpriseVersion, _ := ctx.Value(enterpriseConfigVersionCtxKey).(string)
+	enterpriseRegistry := c.String(enterpriseRegistryFlag.Name)
+	if enterpriseRegistry == "" {
+		enterpriseRegistry = quayRegistry
+	}
 	verCfg := &versions.VersionsConfig{
 		RepoRootDir: repoRootDir,
 		Calico: versions.VersionConfig{
@@ -425,7 +429,7 @@ func modifyConfigVersions(ctx context.Context, c *cli.Command, repoRootDir strin
 		},
 		Enterprise: versions.VersionConfig{
 			Version:  enterpriseVersion,
-			Registry: c.String(enterpriseRegistryFlag.Name),
+			Registry: addTrailingSlash(enterpriseRegistry),
 			Dir:      c.String(enterpriseDirFlag.Name),
 		},
 	}


### PR DESCRIPTION
## Description

Branch-cut tooling left the enterprise registry empty (and un-trailing-slashed) when `--enterprise-registry` was unset. Default it to `quay.io` and run it through `addTrailingSlash` in `modifyConfigVersions`. Equivalent of #4914's prep.go fix, which doesn't cherry-pick cleanly because the registry logic moved into branch.go on master.

## Release Note

```release-note
TBD
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`