### PR TITLE
[release-v1.40] Align coreos-prometheus (v3.12.0) and coreos-alertmanager (v0.32.1) with CE v3.22

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -106,14 +106,14 @@ components:
   # coreos-prometheus holds the version of prometheus built for tigera/prometheus,
   # which prometheus operator uses to validate.
   coreos-prometheus:
-    version: v3.4.1
+    version: v3.12.0
   prometheus:
     image: tigera/prometheus
     version: v3.22.5
   # coreos-prometheus holds the version of alertmanager built for tigera/alertmanager,
   # which prometheus operator uses to validate.
   coreos-alertmanager:
-    version: v0.28.0
+    version: v0.32.1
   alertmanager:
     image: tigera/alertmanager
     version: v3.22.5

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -228,7 +228,7 @@ var (
 	}
 
 	ComponentCoreOSPrometheus = Component{
-		Version:  "v3.4.1",
+		Version:  "v3.12.0",
 		Registry: "",
 	}
 
@@ -245,7 +245,7 @@ var (
 	}
 
 	ComponentCoreOSAlertmanager = Component{
-		Version:  "v0.28.0",
+		Version:  "v0.32.1",
 		Registry: "",
 	}
 


### PR DESCRIPTION
## Description

Follow-up to the Calico Enterprise v3.22 CVE work. The operator sets the Prometheus/Alertmanager CR `spec.version` from `ComponentCoreOSPrometheus.Version` / `ComponentCoreOSAlertmanager.Version` (see `pkg/render/monitor/monitor.go`). Those were stale relative to what CE v3.22 actually builds, so the prometheus-operator would generate config for an old version while the image runs a newer binary.

Aligns them with the versions shipped by `tigera/calico-private` `release-calient-v3.22`:

| component | before | after | CE source |
|---|---|---|---|
| `coreos-prometheus` | v3.4.1 | **v3.12.0** | `third_party/prometheus` (upstream prometheus 3.12.0) |
| `coreos-alertmanager` | v0.28.0 | **v0.32.1** | `third_party/alertmanager` (upstream alertmanager 0.32.1) |

The deployed image tags (`tigera/prometheus`, `tigera/alertmanager`) are unchanged — they remain at the product version; only the `spec.version` validation field is corrected.

`pkg/components/enterprise.go` regenerated via `make gen-versions`.

## Checks run locally
- `make validate-gen-versions` ✅
- `make format-check` ✅
- `make vet` ✅
- `make static-checks` ✅ (0 issues)

## Release Note
```release-note
NONE
```