### PR TITLE
Treat semantically-equal IP pool CIDRs as equal

### DIFF
--- a/pkg/controller/ippool/defaults.go
+++ b/pkg/controller/ippool/defaults.go
@@ -65,6 +65,21 @@ func cidrToName(cidr string) (string, error) {
 	return name, nil
 }
 
+// normalizeCIDR returns the canonical string form of the given CIDR, as produced by net.IPNet.String().
+// This allows semantically-equal CIDRs that differ only in textual representation (for example IPv6
+// addresses with leading zeros or differing "::" compression, such as "fd20:5213:94f6:01e9:001f::/96"
+// versus "fd20:5213:94f6:1e9:1f::/96") to compare as equal. The Calico API server normalizes CIDRs when
+// it stores IP pools, so without this the operator can mistake an existing pool for a missing one and
+// enter an infinite delete/recreate loop. If the CIDR cannot be parsed, the original string is returned
+// unchanged so callers fall back to an exact string comparison.
+func normalizeCIDR(cidr string) string {
+	_, nw, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return cidr
+	}
+	return nw.String()
+}
+
 // fillDefaults fills in IP pool defaults on the Installation object. Defaulting of fields other than IP pools occurs
 // in pkg/controller/installation/
 func fillDefaults(ctx context.Context, client client.Client, instance *operator.Installation, currentPools *v3.IPPoolList) error {
@@ -154,7 +169,7 @@ func fillDefaults(ctx context.Context, client client.Client, instance *operator.
 	currentPoolLookup := map[string]string{}
 	if currentPools != nil {
 		for _, cur := range currentPools.Items {
-			currentPoolLookup[cur.Spec.CIDR] = cur.Name
+			currentPoolLookup[normalizeCIDR(cur.Spec.CIDR)] = cur.Name
 		}
 	}
 
@@ -208,7 +223,7 @@ func fillDefaults(ctx context.Context, client client.Client, instance *operator.
 
 		// Default the name if it's not set.
 		if pool.Name == "" {
-			if name, ok := currentPoolLookup[pool.CIDR]; ok {
+			if name, ok := currentPoolLookup[normalizeCIDR(pool.CIDR)]; ok {
 				// There's an existing IP pool with the same CIDR - use that. This allows us to
 				// assume control of IP pools that are already in the cluster.
 				pool.Name = name

--- a/pkg/controller/ippool/pool_controller.go
+++ b/pkg/controller/ippool/pool_controller.go
@@ -243,7 +243,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		if hasOwnerLabel(&p) {
 			// This pool is owned by the Installation object, so consider it ours.
 			reqLogger.V(1).Info("IP pool is owned by operator", "name", p.Name, "cidr", p.Spec.CIDR)
-			ourPools[p.Spec.CIDR] = p
+			ourPools[normalizeCIDR(p.Spec.CIDR)] = p
 		} else {
 			// The IP pool may have been created by the operator, but it may not have the managed-by label set if it was created
 			// before the operator started setting the label. The following logic allows opt-in ownership of IP pools created prior to
@@ -256,7 +256,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 				v1p := operatorv1.IPPool{}
 				FromProjectCalico(&v1p, p)
 				reqLogger.V(1).Info("Comparing IP pool", "clusterPool", p, "installationPool", cnp)
-				if !reflect.DeepEqual(cnp, v1p) {
+				// Compare using normalized CIDRs so that an existing pool with a canonical CIDR is still
+				// recognized as a match for an Installation pool that specifies the same CIDR in a
+				// non-canonical form. Only the CIDR field can differ textually while being semantically
+				// equal, so we normalize that field on copies before comparing the full structs.
+				cnpNorm := cnp
+				cnpNorm.CIDR = normalizeCIDR(cnp.CIDR)
+				v1p.CIDR = normalizeCIDR(v1p.CIDR)
+				if !reflect.DeepEqual(cnpNorm, v1p) {
 					// The IP pool in the cluster doesn't match the IP pool in the Installation - ignore it.
 					reqLogger.V(1).Info("IP pool doesn't match", "clusterPool", v1p, "installationPool", cnp)
 					continue
@@ -264,14 +271,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 				// Consider this IP pool to be owned by the operator.
 				reqLogger.V(1).Info("Assuming ownership of IP pool", "name", p.Name, "cidr", p.Spec.CIDR)
-				ourPools[p.Spec.CIDR] = p
+				ourPools[normalizeCIDR(p.Spec.CIDR)] = p
 			}
-			if _, ok := ourPools[p.Spec.CIDR]; !ok {
+			if _, ok := ourPools[normalizeCIDR(p.Spec.CIDR)]; !ok {
 				// This IP pool exists in the cluster, but is not owned by us - mark it down so that
 				// we can refuse to update any pool with this CIDR if it exists in the Installation.
 				// This branch is only hit if the pool does not have the managed-by label, and does
 				// not exactly match any pool in the Installation.
-				notOurs[p.Spec.CIDR] = true
+				notOurs[normalizeCIDR(p.Spec.CIDR)] = true
 			}
 		}
 	}
@@ -293,7 +300,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 		// If there is an existing IP pool in the cluster with the same CIDR, but it is not owned by us, then we cannot
 		// take action on it.
-		if _, ok := notOurs[p.CIDR]; ok {
+		if _, ok := notOurs[normalizeCIDR(p.CIDR)]; ok {
 			r.status.SetDegraded(operatorv1.ResourceValidationError, "Cannot update an IP pool not owned by the operator", nil, reqLogger)
 			continue
 		}
@@ -307,7 +314,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		// We'll only actually send the update if the API server is available or there are no IP pools in the cluster. We
 		// are careful here to only generate a degraded status if the API server is unavailable and we determine that an IP pool needs
 		// to be updated after initial IP pool creation.
-		if pool, ok := ourPools[p.CIDR]; apiAvailable || !ok || !reflect.DeepEqual(pool.Spec, v1res.Spec) {
+		if pool, ok := ourPools[normalizeCIDR(p.CIDR)]; apiAvailable || !ok || !reflect.DeepEqual(pool.Spec, v1res.Spec) {
 			if len(currentPools.Items) == 0 {
 				// There are no pools in the cluster. Create them using the v1 API, as they are needed for bootstrapping and the API server is non-functional
 				// if there are no IP pools in the cluster!
@@ -339,7 +346,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		reqLogger.WithValues("cidr", cidr).V(1).Info("Checking if pool is still valid")
 		found := false
 		for _, p := range installation.Spec.CalicoNetwork.IPPools {
-			if p.CIDR == cidr {
+			// cidr is a normalized map key; normalize the Installation CIDR before comparing so that a
+			// non-canonical CIDR in the Installation still matches the canonical CIDR stored on the pool.
+			if normalizeCIDR(p.CIDR) == cidr {
 				found = true
 				break
 			}
@@ -410,7 +419,11 @@ func ToProjectCalico(p operatorv1.IPPool) (*v3.IPPool, error) {
 			Name:   p.Name,
 			Labels: map[string]string{},
 		},
-		Spec: v3.IPPoolSpec{CIDR: p.CIDR},
+		// Normalize the CIDR to its canonical form. The Calico API server stores pools with canonical
+		// CIDRs, so emitting the canonical form here keeps the pool we create/update byte-for-byte
+		// consistent with what is stored, avoiding needless updates and rejection by API server versions
+		// that refuse to persist non-canonical CIDRs.
+		Spec: v3.IPPoolSpec{CIDR: normalizeCIDR(p.CIDR)},
 	}
 
 	// Set encap.

--- a/pkg/controller/ippool/pool_controller_test.go
+++ b/pkg/controller/ippool/pool_controller_test.go
@@ -355,6 +355,73 @@ var _ = Describe("IP Pool controller tests", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(ipPools.Items).To(HaveLen(1))
 	})
+
+	It("should not delete and recreate a pool when the Installation uses a non-canonical IPv6 CIDR", func() {
+		// Regression test for https://github.com/tigera/operator/issues/4783.
+		// The Calico API server stores IP pool CIDRs in canonical form, so a pool created from a
+		// non-canonical CIDR in the Installation is persisted with a different textual representation
+		// (e.g. with leading zeros stripped). The operator must treat the two as the same pool;
+		// otherwise it repeatedly marks the pool for deletion and recreates it in an infinite loop.
+		const nonCanonicalCIDR = "fd20:5213:94f6:01e9:001f::/96"
+		const canonicalCIDR = "fd20:5213:94f6:1e9:1f::/96"
+
+		instance := &operator.Installation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "default",
+				Finalizers: []string{"tigera.io/operator-cleanup"},
+			},
+			Spec: operator.InstallationSpec{
+				Variant:  operator.Calico,
+				Registry: "some.registry.org/",
+				CNI: &operator.CNISpec{
+					Type: operator.PluginCalico,
+					IPAM: &operator.IPAMSpec{Type: operator.IPAMPluginCalico},
+				},
+				CalicoNetwork: &operator.CalicoNetworkSpec{
+					IPPools: []operator.IPPool{
+						{CIDR: nonCanonicalCIDR},
+					},
+				},
+			},
+		}
+		Expect(c.Create(ctx, instance)).ShouldNot(HaveOccurred())
+
+		// Simulate a pool that the API server already normalized to its canonical form and that is
+		// owned by the operator (as indicated by the managed-by label).
+		existing := &v3.IPPool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "default-ipv6-ippool",
+				Labels: map[string]string{managedByLabel: managedByValue},
+			},
+			Spec: v3.IPPoolSpec{CIDR: canonicalCIDR},
+		}
+		Expect(c.Create(ctx, existing)).ShouldNot(HaveOccurred())
+
+		// Use the projectcalico.org/v3 API path so that, prior to the fix, the spurious deletion
+		// would actually be carried out rather than just marking the controller as degraded.
+		r.clientv3 = c
+		r.opts.UseV3CRDs = true
+
+		mockStatus.On("OnCRFound")
+		mockStatus.On("SetMetaData", mock.Anything)
+		mockStatus.On("IsAvailable").Return(true)
+		mockStatus.On("ReadyToMonitor")
+		mockStatus.On("ClearDegraded")
+
+		// Reconcile a couple of times to confirm we reach a steady state and aren't looping.
+		for i := 0; i < 2; i++ {
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+		}
+		mockStatus.AssertExpectations(GinkgoT())
+
+		// The pool must still exist exactly once, retaining its canonical CIDR, and must not have
+		// been deleted and recreated.
+		ipPools := v3.IPPoolList{}
+		Expect(c.List(ctx, &ipPools)).ShouldNot(HaveOccurred())
+		Expect(ipPools.Items).To(HaveLen(1))
+		Expect(ipPools.Items[0].Spec.CIDR).To(Equal(canonicalCIDR))
+	})
 })
 
 var _ = DescribeTable("cidrWithinCidr",


### PR DESCRIPTION
## Description

Bug fix for the IP pool controller (`pkg/controller/ippool`).

When an `Installation` specifies an IPv6 pool CIDR in a **non-canonical** form (e.g. with leading zeros, `fd20:5213:94f6:01e9:001f::/96`), the controller entered an infinite delete/recreate loop:

1. The existing pool is stored with the **canonical** CIDR (`fd20:5213:94f6:1e9:1f::/96`), because the Calico API server normalizes CIDRs via `net.ParseCIDR` when persisting pools.
2. The controller compared CIDRs as raw strings (`p.CIDR == cidr`), so it concluded the existing pool was not the one described in the `Installation`.
3. It marked the pool for deletion and recreated it from the `Installation` CIDR — which the API server re-normalized — returning to step 1, forever.

**Why merge:** this leaves affected clusters with an operator that churns IP pools indefinitely after upgrade; the only workaround today is to hand-edit the CIDR into canonical form.

**Fix:** compare CIDRs by their canonical form (`net.IPNet.String()`) everywhere the controller keys or matches pools by CIDR — the `ourPools` ownership map, adoption of pre-existing unlabelled pools, the `notOurs` not-owned detection, the create/update decision, and the delete check. The controller also now emits the canonical CIDR when creating/updating pools (`ToProjectCalico`) so the written resource matches what the API server stores (avoiding needless updates) and is accepted by API server versions that reject non-canonical CIDRs (see projectcalico/calico#11385). Unparseable CIDRs fall back to exact string comparison.

**Components affected:** IP pool controller only.

**Testing:**
- Added a regression unit test that reproduces the loop. With the fix reverted, the test fails — the pool is deleted and recreated with the non-canonical CIDR. With the fix, the pool is left untouched (canonical CIDR, single pool) across repeated reconciles.
- `make ut UT_DIR=./pkg/controller/ippool` passes; `gofmt` clean.

Fixes #4783

## Release Note

```release-note
Fixed an infinite IP pool delete/recreate loop that occurred when an Installation specified an IP pool CIDR in non-canonical form (for example an IPv6 CIDR with leading zeros).
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
