### PR TITLE
test(installation): skip Calico-variant VAP tests on release-v1.43

### DIFF
--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -2898,7 +2898,18 @@ var _ = Describe("updateValidatingAdmissionPolicies", func() {
 		cancel()
 	})
 
+	// The protect-builtin-tiers ValidatingAdmissionPolicy is a Calico v3.33 feature
+	// (projectcalico/calico#12824) and is not present in the calico v3.32.x that
+	// release-v1.43 bundles, so GetValidatingAdmissionPolicies returns an empty set for
+	// the Calico variant on this branch and the count assertions below cannot hold.
+	// Skip these here, mirroring projectcalico/calico#12962, which skips the same
+	// tier-protection tests on calico release-v3.32. (The "Enterprise variant" test
+	// below still exercises the VAP-management logic, since Calient v3.24 ships the VAP.)
+	const skipNoCalicoVAP = "Calico tier-protection VAP (projectcalico/calico#12824) is v3.33-only; absent from the calico v3.32 bundled by release-v1.43 — see projectcalico/calico#12962"
+
 	It("should create v1 VAPs when v1 is served", func() {
+		Skip(skipNoCalicoVAP)
+
 		r = ReconcileInstallation{
 			client:       clientFor(),
 			scheme:       scheme,
@@ -2930,6 +2941,8 @@ var _ = Describe("updateValidatingAdmissionPolicies", func() {
 	})
 
 	It("should create v1beta1 VAPs when only v1beta1 is served", func() {
+		Skip(skipNoCalicoVAP)
+
 		r = ReconcileInstallation{
 			client:       clientFor(),
 			scheme:       scheme,
@@ -2959,6 +2972,8 @@ var _ = Describe("updateValidatingAdmissionPolicies", func() {
 	})
 
 	It("should create v1alpha1 VAPs when only v1alpha1 is served", func() {
+		Skip(skipNoCalicoVAP)
+
 		r = ReconcileInstallation{
 			client:       clientFor(),
 			scheme:       scheme,
@@ -3011,6 +3026,8 @@ var _ = Describe("updateValidatingAdmissionPolicies", func() {
 	})
 
 	It("should delete stale v1 VAPs with managed label", func() {
+		Skip(skipNoCalicoVAP)
+
 		staleVAP := &admissionregistrationv1.ValidatingAdmissionPolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   "stale-policy",


### PR DESCRIPTION
> **Draft — not yet for review.** Skips a few `release-v1.43`-only failing unit tests; opening early to discuss the approach (mirrors calico#12962). Details below.

## Description

Test-only change for `release-v1.43`.

The `updateValidatingAdmissionPolicies` **Calico-variant** unit tests (added in #4878) assert that the `protect-builtin-tiers` ValidatingAdmissionPolicy is created. But that VAP is a Calico **v3.33** feature (projectcalico/calico#12824) and is **not** present in the OSS Calico **v3.32.0** that `release-v1.43` pins. The admission policies are generated from the pinned calico's `api/admission/` dir, so the v1.43 config regen (`build: update config for v1.43`) correctly dropped the Calico copy — while the hand-written tests still assert it, so they fail on the missing VAP.

This skips the four affected `Variant: operator.Calico` tests **on this branch only**, mirroring projectcalico/calico#12962 (which skips the same tier-protection tests on calico `release-v3.32`). The early-return cases and the **Enterprise-variant** test still run — Calient **v3.24** *does* ship the VAP (calico-private `release-calient-v3.24-1` has it), so VAP-management coverage is retained.

Why the asymmetry is expected: operator releases alternate which product gets a new minor — even minors bump OSS Calico, odd minors bump Enterprise. `release-v1.43` (odd) advanced Enterprise to v3.24 but kept OSS Calico at v3.32, so the OSS-side VAP isn't present yet (it arrives when an even operator minor moves OSS Calico to v3.33). **Master is unaffected** (pins calico master, which has the VAP), so the tests stay live there.

- **Type:** bug fix (broken release-branch unit test)
- **Components:** `pkg/controller/installation` (test only)
- **Testing:** `go test ./pkg/controller/installation/` focused on `updateValidatingAdmissionPolicies` → **3 passed, 0 failed, 4 skipped** (the 4 Calico-variant tests skip with a rationale; early-return + Enterprise-variant tests still pass).

## Release Note

```release-note
NONE
```

## For PR author

- [x] Tests for change. — N/A; this is a test-only change that skips tests not applicable to this branch's bundled OSS Calico (v3.32).
- [x] If changing pkg/apis/, run `make gen-files` — N/A, no `pkg/apis/` changes.
- [x] If changing versions, run `make gen-versions` — N/A, no version changes.

## For PR reviewers

- [ ] Milestone set according to targeted release.
- [x] Appropriate labels: `kind/bug`, `release-note-not-required`.
