### PR TITLE
Add egress rules to OSS guardian and goldmane network policies

### DIFF
--- a/pkg/render/goldmane/component.go
+++ b/pkg/render/goldmane/component.go
@@ -384,14 +384,33 @@ func (c *Component) networkPolicy() *v3.NetworkPolicy {
 			},
 		})
 	}
+	// Goldmane runs in calico-system, where the calico-system.default-deny policy blocks any
+	// egress that lacks an explicit allow. It needs DNS, the Kubernetes API server (its Role grants
+	// it ConfigMap access in calico-system) and, when connected to a management cluster, Guardian
+	// (to POST flows). See https://github.com/tigera/operator/issues/4804.
+	egressRules := networkpolicy.AppendDNSEgressRules([]v3.Rule{}, c.cfg.OpenShift)
+	egressRules = append(egressRules, []v3.Rule{
+		{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: networkpolicy.KubeAPIServerEntityRule,
+		},
+		{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: render.GuardianEntityRule,
+		},
+	}...)
+
 	return &v3.NetworkPolicy{
 		TypeMeta:   metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"},
 		ObjectMeta: metav1.ObjectMeta{Name: GoldmanePolicyName, Namespace: GoldmaneNamespace},
 		Spec: v3.NetworkPolicySpec{
 			Tier:     networkpolicy.CalicoTierName,
 			Selector: networkpolicy.KubernetesAppSelector(GoldmaneDeploymentName),
-			Types:    []v3.PolicyType{v3.PolicyTypeIngress},
+			Types:    []v3.PolicyType{v3.PolicyTypeIngress, v3.PolicyTypeEgress},
 			Ingress:  ingressRules,
+			Egress:   egressRules,
 		},
 	}
 }

--- a/pkg/render/goldmane/component_test.go
+++ b/pkg/render/goldmane/component_test.go
@@ -30,7 +30,9 @@ import (
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/render"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
+	"github.com/tigera/operator/pkg/render/common/networkpolicy"
 	"github.com/tigera/operator/pkg/render/common/securitycontext"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
 	"github.com/tigera/operator/pkg/render/goldmane"
@@ -269,6 +271,31 @@ var _ = Describe("ComponentRendering", func() {
 		np, err := rtest.GetResourceOfType[*v3.NetworkPolicy](objsToCreate, goldmane.GoldmanePolicyName, goldmane.GoldmaneNamespace)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(np.Spec.Ingress).To(HaveLen(1))
+
+		// Goldmane must allow egress so it can function under calico-system.default-deny: DNS,
+		// the Kubernetes API server, and Guardian. See https://github.com/tigera/operator/issues/4804.
+		Expect(np.Spec.Types).To(ConsistOf(v3.PolicyTypeIngress, v3.PolicyTypeEgress))
+		Expect(np.Spec.Egress).To(Equal([]v3.Rule{
+			{
+				Action:   v3.Allow,
+				Protocol: &networkpolicy.UDPProtocol,
+				Destination: v3.EntityRule{
+					NamespaceSelector: "projectcalico.org/name == 'kube-system'",
+					Selector:          "k8s-app in { 'kube-dns', 'coredns' }",
+					Ports:             networkpolicy.Ports(53),
+				},
+			},
+			{
+				Action:      v3.Allow,
+				Protocol:    &networkpolicy.TCPProtocol,
+				Destination: networkpolicy.KubeAPIServerEntityRule,
+			},
+			{
+				Action:      v3.Allow,
+				Protocol:    &networkpolicy.TCPProtocol,
+				Destination: render.GuardianEntityRule,
+			},
+		}))
 	})
 
 	It("Should apply overrides", func() {

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -69,6 +69,7 @@ const (
 	GuardianKeyPairSecret = "guardian-key-pair"
 
 	GoldmaneDeploymentName         = "goldmane"
+	GoldmaneServicePort            = 7443
 	GuardianSecretsRole            = "calico-guardian-secrets"
 	GuardianSecretsRoleBindingName = "calico-guardian-secrets"
 )
@@ -77,6 +78,7 @@ var (
 	GuardianEntityRule                = networkpolicy.CreateEntityRule(GuardianNamespace, GuardianDeploymentName, GuardianTargetPort)
 	GuardianSourceEntityRule          = networkpolicy.CreateSourceEntityRule(GuardianNamespace, GuardianDeploymentName)
 	GuardianServiceSelectorEntityRule = networkpolicy.CreateServiceSelectorEntityRule(GuardianNamespace, GuardianName)
+	GoldmaneEntityRule                = networkpolicy.CreateEntityRule(GuardianNamespace, GoldmaneDeploymentName, GoldmaneServicePort)
 )
 
 func Guardian(cfg *GuardianConfiguration) Component {
@@ -544,7 +546,29 @@ func (c *GuardianComponent) annotations() map[string]string {
 	return annotations
 }
 
-func ossNetworkPolicy() *v3.NetworkPolicy {
+func ossNetworkPolicy(cfg *GuardianConfiguration) *v3.NetworkPolicy {
+	// Guardian only runs in the OSS variant when the cluster is connected to a management
+	// cluster (Calico Cloud). Under the calico-system.default-deny policy it needs egress to DNS,
+	// the Kubernetes API server, and Goldmane (which it proxies management-cluster requests to).
+	// Egress to the management-cluster tunnel endpoint is intentionally not expressed here: a
+	// domain-based address would require the EgressAccessControl license, which OSS does not have.
+	// The trailing Pass defers that (and any other) egress to subsequent tiers so an administrator
+	// can allow it. See https://github.com/tigera/operator/issues/4804.
+	egressRules := networkpolicy.AppendDNSEgressRules([]v3.Rule{}, cfg.OpenShift)
+	egressRules = append(egressRules, []v3.Rule{
+		{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: networkpolicy.KubeAPIServerEntityRule,
+		},
+		{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: GoldmaneEntityRule,
+		},
+		{Action: v3.Pass},
+	}...)
+
 	return &v3.NetworkPolicy{
 		TypeMeta:   metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"},
 		ObjectMeta: metav1.ObjectMeta{Name: GuardianPolicyName, Namespace: GuardianNamespace},
@@ -552,7 +576,7 @@ func ossNetworkPolicy() *v3.NetworkPolicy {
 			Order:    &networkpolicy.HighPrecedenceOrder,
 			Tier:     networkpolicy.CalicoTierName,
 			Selector: networkpolicy.KubernetesAppSelector(GuardianName),
-			Types:    []v3.PolicyType{v3.PolicyTypeIngress},
+			Types:    []v3.PolicyType{v3.PolicyTypeIngress, v3.PolicyTypeEgress},
 			Ingress: []v3.Rule{
 				{
 					Action:   v3.Allow,
@@ -572,13 +596,14 @@ func ossNetworkPolicy() *v3.NetworkPolicy {
 					},
 				},
 			},
+			Egress: egressRules,
 		},
 	}
 }
 
 func guardianCalicoSystemPolicy(cfg *GuardianConfiguration) (*v3.NetworkPolicy, error) {
 	if !cfg.Installation.Variant.IsEnterprise() {
-		return ossNetworkPolicy(), nil
+		return ossNetworkPolicy(cfg), nil
 	}
 
 	egressRules := []v3.Rule{

--- a/pkg/render/guardian_test.go
+++ b/pkg/render/guardian_test.go
@@ -339,9 +339,36 @@ var _ = Describe("Rendering tests", func() {
 				policy := testutils.GetCalicoSystemPolicyFromResources(policyName, resources)
 				Expect(policy).NotTo(BeNil(), "OSS variant should always render a network policy")
 
-				// Verify it's the OSS policy (should only have Ingress type, no Egress)
-				Expect(policy.Spec.Types).To(ConsistOf(v3.PolicyTypeIngress))
-				Expect(policy.Spec.Egress).To(BeEmpty())
+				// The OSS policy must include egress so Guardian can function under calico-system.default-deny.
+				// See https://github.com/tigera/operator/issues/4804.
+				Expect(policy.Spec.Types).To(ConsistOf(v3.PolicyTypeIngress, v3.PolicyTypeEgress))
+
+				// Expect egress for DNS, the Kubernetes API server, and Goldmane, then a trailing Pass.
+				// The management-cluster tunnel egress is intentionally not rendered for OSS (it would
+				// require the EgressAccessControl license for domain-based addresses); the Pass defers
+				// it to subsequent tiers.
+				Expect(policy.Spec.Egress).To(Equal([]v3.Rule{
+					{
+						Action:   v3.Allow,
+						Protocol: &networkpolicy.UDPProtocol,
+						Destination: v3.EntityRule{
+							NamespaceSelector: "projectcalico.org/name == 'kube-system'",
+							Selector:          "k8s-app in { 'kube-dns', 'coredns' }",
+							Ports:             networkpolicy.Ports(53),
+						},
+					},
+					{
+						Action:      v3.Allow,
+						Protocol:    &networkpolicy.TCPProtocol,
+						Destination: networkpolicy.KubeAPIServerEntityRule,
+					},
+					{
+						Action:      v3.Allow,
+						Protocol:    &networkpolicy.TCPProtocol,
+						Destination: render.GoldmaneEntityRule,
+					},
+					{Action: v3.Pass},
+				}))
 			})
 
 			It("should render Enterprise network policy without domain-based egress when IncludeEgressNetworkPolicy is false", func() {

--- a/pkg/render/whisker/component.go
+++ b/pkg/render/whisker/component.go
@@ -278,6 +278,12 @@ func (c *Component) networkPolicy() *v3.NetworkPolicy {
 	}
 	egressRules = networkpolicy.AppendDNSEgressRules(egressRules, c.cfg.OpenShift)
 
+	// Whisker is a UI that is reached from outside calico-system (e.g. via an ingress controller or
+	// load balancer), so the source of its ingress traffic is not knowable by the operator. Pass
+	// ingress to subsequent tiers so an administrator can allow it rather than having it hard-denied
+	// by calico-system.default-deny. See https://github.com/tigera/operator/issues/4804.
+	ingressRules := []v3.Rule{{Action: v3.Pass}}
+
 	return &v3.NetworkPolicy{
 		TypeMeta:   metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"},
 		ObjectMeta: metav1.ObjectMeta{Name: WhiskerPolicyName, Namespace: WhiskerNamespace},
@@ -285,6 +291,7 @@ func (c *Component) networkPolicy() *v3.NetworkPolicy {
 			Tier:     networkpolicy.CalicoTierName,
 			Types:    []v3.PolicyType{v3.PolicyTypeIngress, v3.PolicyTypeEgress},
 			Selector: networkpolicy.KubernetesAppSelector(WhiskerDeploymentName),
+			Ingress:  ingressRules,
 			Egress:   egressRules,
 		},
 	}

--- a/pkg/render/whisker/component_test.go
+++ b/pkg/render/whisker/component_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	operatorv1 "github.com/tigera/operator/api/v1"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/securitycontext"
@@ -170,6 +171,29 @@ var _ = Describe("ComponentRendering", func() {
 			},
 		),
 	)
+
+	It("should render a network policy that passes ingress to subsequent tiers", func() {
+		cfg := &whisker.Configuration{
+			Installation: &operatorv1.InstallationSpec{
+				KubernetesProvider: operatorv1.ProviderGKE,
+				Variant:            operatorv1.Calico,
+			},
+			TrustedCertBundle:     defaultTrustedCertBundle,
+			WhiskerBackendKeyPair: defaultTLSKeyPair,
+			Whisker:               &operatorv1.Whisker{Spec: operatorv1.WhiskerSpec{Notifications: ptr.To(operatorv1.Enabled)}},
+		}
+		component := whisker.Whisker(cfg)
+		objsToCreate, _ := component.Objects()
+
+		np, err := rtest.GetResourceOfType[*v3.NetworkPolicy](objsToCreate, whisker.WhiskerPolicyName, whisker.WhiskerNamespace)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		// Whisker's ingress source (an ingress controller or load balancer) is not knowable by the
+		// operator, so ingress is passed to subsequent tiers rather than hard-denied by
+		// calico-system.default-deny. See https://github.com/tigera/operator/issues/4804.
+		Expect(np.Spec.Types).To(ConsistOf(v3.PolicyTypeIngress, v3.PolicyTypeEgress))
+		Expect(np.Spec.Ingress).To(Equal([]v3.Rule{{Action: v3.Pass}}))
+	})
 
 	It("should generate an IPv4-only NGINX configuration", func() {
 		cfg := &whisker.Configuration{


### PR DESCRIPTION
## Description

**Type:** bug fix.

In the OSS (Calico) variant, the `guardian` and `goldmane` network policies in the `calico-system` tier only declared **ingress** rules. All egress therefore fell through to the implicit `calico-system.default-deny` and was dropped — blocking DNS resolution and inter-component traffic for clusters connected to a management cluster, and polluting Whisker denied-flow logs. The enterprise Guardian path already builds egress via `AppendDNSEgressRules` + kube-API + tunnel rules; the OSS path short-circuited before any of it.

This PR adds the egress (and Whisker ingress) these components need to function under `default-deny`:

- **goldmane** — allow egress to DNS, the Kubernetes API server (its `Role` grants it ConfigMap access in `calico-system`), and guardian (flow-emitter POST). All destinations are known, so they are allowed explicitly with no trailing `Pass`.
- **guardian (OSS)** — allow egress to DNS, the Kubernetes API server, and goldmane (`:7443`), then a trailing `Pass`. Egress to the management-cluster tunnel endpoint is intentionally **not** rendered here: a domain-based management address would require the enterprise-only `EgressAccessControl` license, so the OSS policy cannot express it. The `Pass` defers that (and any other) egress to subsequent tiers for an administrator to allow. The enterprise path is unchanged.
- **whisker** — pass ingress to subsequent tiers. Whisker's ingress source (an ingress controller / load balancer) is not knowable by the operator, so ingress is passed rather than hard-denied by `default-deny`.

Egress rules follow the existing convention in `compliance.go`/`intrusion_detection.go` (pod-selector + backend `targetPort`). The Guardian policy continues to render only when the `calico-system` tier exists — precisely when the `default-deny` it must coexist with is present — so there is no window where Guardian is blocked but the allow policy is absent.

**Components affected:** `pkg/render/guardian.go`, `pkg/render/goldmane`, `pkg/render/whisker`.

**Testing:** Unit tests added/updated for the new guardian, goldmane, and whisker policy rules; the existing enterprise guardian golden-file test confirms enterprise rendering is unchanged. All `./pkg/render/...` tests pass.

**Issues:** Fixes #4804

## Release Note

```release-note
Add egress rules (DNS, Kubernetes API, and inter-component traffic) to the OSS guardian and goldmane network policies so they are not blocked by the calico-system default-deny policy, and allow ingress to whisker to be permitted by lower-tier policies.
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)