### PR TITLE
[v3.24] Remove legacy waf-http-filter ext_proc sidecar (PMREQ-384)

### DIFF
--- a/pkg/render/gatewayapi/gateway_api.go
+++ b/pkg/render/gatewayapi/gateway_api.go
@@ -112,24 +112,6 @@ const (
 )
 
 var (
-	// logger gateway name and namespace are set from the k8s downward api pod metadata.
-	GatewayNameEnvVar = corev1.EnvVar{
-		Name: "LOGGER_GATEWAY_NAME",
-		ValueFrom: &corev1.EnvVarSource{
-			FieldRef: &corev1.ObjectFieldSelector{
-				FieldPath: "metadata.name",
-			},
-		},
-	}
-	GatewayNamespaceEnvVar = corev1.EnvVar{
-		Name: "LOGGER_GATEWAY_NAMESPACE",
-		ValueFrom: &corev1.EnvVarSource{
-			FieldRef: &corev1.ObjectFieldSelector{
-				FieldPath: "metadata.namespace",
-			},
-		},
-	}
-
 	// Owning Gateway name and namespace are exposed via pod labels set by EnvoyProxy.
 	// These allow the l7-log-collector to know which Gateway it is collecting logs for
 	// without needing to query the Kubernetes API.
@@ -412,7 +394,6 @@ type gatewayAPIImplementationComponent struct {
 	envoyGatewayImage   string
 	envoyProxyImage     string
 	envoyRatelimitImage string
-	calicoImage         string
 	L7LogCollectorImage string
 
 	// Pre-rendered helm chart resources.
@@ -443,10 +424,6 @@ func (pr *gatewayAPIImplementationComponent) ResolveImages(is *operatorv1.ImageS
 			return err
 		}
 		pr.envoyRatelimitImage, err = components.GetReference(components.ComponentGatewayAPIEnvoyRatelimit, reg, path, prefix, is)
-		if err != nil {
-			return err
-		}
-		pr.calicoImage, err = components.GetReference(components.CombinedCalicoImage(pr.cfg.Installation), reg, path, prefix, is)
 		if err != nil {
 			return err
 		}
@@ -922,37 +899,6 @@ func (pr *gatewayAPIImplementationComponent) envoyProxyConfig(className, ns stri
 		// The WAF HTTP filter is not supported when the envoy proxy is deployed as a DaemonSet
 		// as there is no support for init containers in a DaemonSet.
 		if envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment != nil {
-			// Add or update the Init Container to the deployment
-			wafHTTPFilter := corev1.Container{
-				Name:    wafFilterName,
-				Image:   pr.calicoImage,
-				Command: []string{components.CalicoBinaryPath, "component", "waf-http-filter"},
-				Args: []string{
-					"--logFileDirectory",
-					"/var/log/calico/waf",
-					"--logFileName",
-					"waf.log",
-					"--socketPath",
-					"/var/run/waf-http-filter/extproc.sock",
-				},
-				RestartPolicy: ptr.To(corev1.ContainerRestartPolicyAlways),
-				VolumeMounts: []corev1.VolumeMount{
-					{
-						Name:      wafFilterName,
-						MountPath: "/var/run/waf-http-filter",
-					},
-					{
-						Name:      "var-log-calico",
-						MountPath: "/var/log/calico",
-					},
-				},
-				Env: []corev1.EnvVar{
-					GatewayNameEnvVar,
-					GatewayNamespaceEnvVar,
-				},
-				SecurityContext: securitycontext.NewRootContext(true),
-			}
-			// need to make changes to the envoy container to mount the socket
 			l7LogCollector := corev1.Container{
 				Name:  "l7-log-collector",
 				Image: pr.L7LogCollectorImage,
@@ -987,16 +933,8 @@ func (pr *gatewayAPIImplementationComponent) envoyProxyConfig(className, ns stri
 				SecurityContext: securitycontext.NewRootContext(true),
 			}
 
-			hasWAFHTTPFilter := false
 			hasL7LogCollector := false
 			for i, initContainer := range envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.InitContainers {
-				if initContainer.Name == wafHTTPFilter.Name {
-					hasWAFHTTPFilter = true
-					// Handle update
-					if initContainer.Image != wafHTTPFilter.Image {
-						envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.InitContainers[i] = wafHTTPFilter
-					}
-				}
 				if initContainer.Name == l7LogCollector.Name {
 					hasL7LogCollector = true
 					// Handle update
@@ -1009,68 +947,31 @@ func (pr *gatewayAPIImplementationComponent) envoyProxyConfig(className, ns stri
 					}
 				}
 			}
-			if !hasWAFHTTPFilter {
-				envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.InitContainers = append(envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.InitContainers, wafHTTPFilter)
-			}
-
 			if !hasL7LogCollector {
 				envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.InitContainers = append(envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.InitContainers, l7LogCollector)
 			}
 
 			accessLogsName := "access-logs"
 			// Add or update Container volume mount
-			wafSocketVolumeMount := corev1.VolumeMount{
-				Name:      wafFilterName,
-				MountPath: "/var/run/waf-http-filter",
-			}
-
 			l7SocketVolumeMount := corev1.VolumeMount{
 				Name:      accessLogsName,
 				MountPath: "/access_logs",
 			}
 
-			hasWAFFilterSocketVolumeMount := false
 			hasAccessLogsVolumeMount := false
-
 			for i, volumeMount := range envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.Container.VolumeMounts {
-				switch volumeMount.Name {
-				case wafSocketVolumeMount.Name:
-					hasWAFFilterSocketVolumeMount = true
-					if volumeMount.MountPath != wafSocketVolumeMount.MountPath {
-						envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.Container.VolumeMounts[i] = wafSocketVolumeMount
-					}
-				case l7SocketVolumeMount.Name:
+				if volumeMount.Name == l7SocketVolumeMount.Name {
 					hasAccessLogsVolumeMount = true
 					if volumeMount.MountPath != l7SocketVolumeMount.MountPath {
 						envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.Container.VolumeMounts[i] = l7SocketVolumeMount
 					}
-
 				}
 			}
-			if !hasWAFFilterSocketVolumeMount {
-				envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.Container.VolumeMounts = append(envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.Container.VolumeMounts, wafSocketVolumeMount)
-			}
-
 			if !hasAccessLogsVolumeMount {
 				envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.Container.VolumeMounts = append(envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.Container.VolumeMounts, l7SocketVolumeMount)
 			}
 
 			// Add or update Pod volumes
-			logsVolume := corev1.Volume{
-				VolumeSource: corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: "/var/log/calico",
-						Type: ptr.To(corev1.HostPathDirectoryOrCreate),
-					},
-				},
-				Name: "var-log-calico",
-			}
-			WAFHttpFilterSocketVolume := corev1.Volume{
-				VolumeSource: corev1.VolumeSource{
-					EmptyDir: &corev1.EmptyDirVolumeSource{},
-				},
-				Name: wafFilterName,
-			}
 			AccessLogsVolume := []corev1.Volume{
 				{
 					VolumeSource: corev1.VolumeSource{
@@ -1087,23 +988,8 @@ func (pr *gatewayAPIImplementationComponent) envoyProxyConfig(className, ns stri
 					Name: "felix-sync",
 				},
 			}
-			hasLogsVolume := false
-			hasSocketVolume := false
 			hasAccessLogsVolume := false
 			for i, volume := range envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.Pod.Volumes {
-				if volume.Name == logsVolume.Name {
-					hasLogsVolume = true
-					// Handle update
-					if volume.HostPath.Path != logsVolume.HostPath.Path || volume.HostPath.Type != logsVolume.HostPath.Type {
-						envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.Pod.Volumes[i] = logsVolume
-					}
-				}
-				if volume.Name == WAFHttpFilterSocketVolume.Name {
-					hasSocketVolume = true
-					if volume.EmptyDir != WAFHttpFilterSocketVolume.EmptyDir {
-						envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.Pod.Volumes[i] = WAFHttpFilterSocketVolume
-					}
-				}
 				for _, acVolume := range AccessLogsVolume {
 					if volume.Name == acVolume.Name {
 						hasAccessLogsVolume = true
@@ -1112,19 +998,13 @@ func (pr *gatewayAPIImplementationComponent) envoyProxyConfig(className, ns stri
 						}
 					}
 				}
-
-			}
-			if !hasLogsVolume {
-				envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.Pod.Volumes = append(envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.Pod.Volumes, logsVolume)
-			}
-			if !hasSocketVolume {
-				envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.Pod.Volumes = append(envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.Pod.Volumes, WAFHttpFilterSocketVolume)
 			}
 			if !hasAccessLogsVolume {
 				envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.Pod.Volumes = append(envoyProxy.Spec.Provider.Kubernetes.EnvoyDeployment.Pod.Volumes, AccessLogsVolume...)
 			}
 
-			// Configure service account for WAF HTTP Filter license client
+			// Configure the envoy-proxy pod's service account, used by the l7-log-collector
+			// for license verification and Gateway-API reads.
 			// Use EnvoyProxy patch mechanism to set serviceAccountName and automountServiceAccountToken
 			serviceAccountPatch := map[string]interface{}{
 				"spec": map[string]interface{}{

--- a/pkg/render/gatewayapi/gateway_api_test.go
+++ b/pkg/render/gatewayapi/gateway_api_test.go
@@ -1060,7 +1060,7 @@ value:
 		Expect(envoyDeployment.Container.VolumeMounts).To(BeNil())
 	})
 
-	It("should deploy waf-http-filter for Enterprise", func() {
+	It("should deploy l7-log-collector (no waf-http-filter sidecar) for Enterprise", func() {
 		installation := &operatorv1.InstallationSpec{
 			Variant: operatorv1.CalicoEnterprise,
 		}
@@ -1085,30 +1085,17 @@ value:
 		Expect(envoyDeployment).ToNot(BeNil())
 
 		Expect(envoyDeployment.Pod).ToNot(BeNil())
-		Expect(envoyDeployment.Pod.Volumes).To(HaveLen(4))
-		Expect(envoyDeployment.Pod.Volumes[0].Name).To(Equal("var-log-calico"))
-		Expect(envoyDeployment.Pod.Volumes[0].HostPath.Path).To(Equal("/var/log/calico"))
-		Expect(envoyDeployment.Pod.Volumes[1].Name).To(Equal("waf-http-filter"))
-		Expect(envoyDeployment.Pod.Volumes[1].EmptyDir).ToNot(BeNil())
+		Expect(envoyDeployment.Pod.Volumes).To(HaveLen(2))
+		Expect(envoyDeployment.Pod.Volumes[0].Name).To(Equal("access-logs"))
+		Expect(envoyDeployment.Pod.Volumes[0].EmptyDir).ToNot(BeNil())
+		Expect(envoyDeployment.Pod.Volumes[1].Name).To(Equal("felix-sync"))
+		Expect(envoyDeployment.Pod.Volumes[1].CSI.Driver).To(Equal("csi.tigera.io"))
 
-		Expect(envoyDeployment.InitContainers[0].Name).To(Equal("waf-http-filter"))
+		Expect(envoyDeployment.InitContainers).To(HaveLen(1))
+		Expect(envoyDeployment.InitContainers[0].Name).To(Equal("l7-log-collector"))
 		Expect(*envoyDeployment.InitContainers[0].RestartPolicy).To(Equal(corev1.ContainerRestartPolicyAlways))
 		Expect(envoyDeployment.InitContainers[0].VolumeMounts).To(HaveLen(2))
 		Expect(envoyDeployment.InitContainers[0].VolumeMounts).To(ContainElements([]corev1.VolumeMount{
-			{
-				Name:      "waf-http-filter",
-				MountPath: "/var/run/waf-http-filter",
-			},
-			{
-				Name:      "var-log-calico",
-				MountPath: "/var/log/calico",
-			},
-		}))
-
-		Expect(envoyDeployment.InitContainers[1].Name).To(Equal("l7-log-collector"))
-		Expect(*envoyDeployment.InitContainers[1].RestartPolicy).To(Equal(corev1.ContainerRestartPolicyAlways))
-		Expect(envoyDeployment.InitContainers[1].VolumeMounts).To(HaveLen(2))
-		Expect(envoyDeployment.InitContainers[1].VolumeMounts).To(ContainElements([]corev1.VolumeMount{
 			{
 				Name:      "access-logs",
 				MountPath: "/access_logs",
@@ -1119,15 +1106,8 @@ value:
 			},
 		}))
 
-		// logger gateway name and namespace are set from the k8s downward api pod metadata.
-		Expect(envoyDeployment.InitContainers[0].Env).To(ContainElements(GatewayNameEnvVar, GatewayNamespaceEnvVar))
-
 		Expect(envoyDeployment.Container).ToNot(BeNil())
-		Expect(envoyDeployment.Container.VolumeMounts).To(HaveLen(2))
-		Expect(envoyDeployment.Container.VolumeMounts).To(ContainElement(corev1.VolumeMount{
-			Name:      "waf-http-filter",
-			MountPath: "/var/run/waf-http-filter",
-		}))
+		Expect(envoyDeployment.Container.VolumeMounts).To(HaveLen(1))
 		Expect(envoyDeployment.Container.VolumeMounts).To(ContainElement(corev1.VolumeMount{
 			Name:      "access-logs",
 			MountPath: "/access_logs",
@@ -1136,7 +1116,7 @@ value:
 		Expect(proxy.Spec.Telemetry.AccessLog.Settings).To(Equal(AccessLogSettings))
 	})
 
-	It("should deploy waf-http-filter for Enterprise when using a custom proxy", func() {
+	It("should deploy l7-log-collector (no waf-http-filter sidecar) for Enterprise when using a custom proxy", func() {
 		installation := &operatorv1.InstallationSpec{
 			Variant: operatorv1.CalicoEnterprise,
 		}
@@ -1224,26 +1204,13 @@ value:
 		envoyDeployment := proxy.Spec.Provider.Kubernetes.EnvoyDeployment
 		Expect(envoyDeployment).ToNot(BeNil())
 
-		Expect(envoyDeployment.InitContainers).To(HaveLen(3))
+		Expect(envoyDeployment.InitContainers).To(HaveLen(2))
 		Expect(envoyDeployment.InitContainers[0].Name).To(Equal("some-other-sidecar"))
-		Expect(envoyDeployment.InitContainers[1].Name).To(Equal("waf-http-filter"))
+
+		Expect(envoyDeployment.InitContainers[1].Name).To(Equal("l7-log-collector"))
 		Expect(*envoyDeployment.InitContainers[1].RestartPolicy).To(Equal(corev1.ContainerRestartPolicyAlways))
 		Expect(envoyDeployment.InitContainers[1].VolumeMounts).To(HaveLen(2))
 		Expect(envoyDeployment.InitContainers[1].VolumeMounts).To(ContainElements([]corev1.VolumeMount{
-			{
-				Name:      "waf-http-filter",
-				MountPath: "/var/run/waf-http-filter",
-			},
-			{
-				Name:      "var-log-calico",
-				MountPath: "/var/log/calico",
-			},
-		}))
-
-		Expect(envoyDeployment.InitContainers[2].Name).To(Equal("l7-log-collector"))
-		Expect(*envoyDeployment.InitContainers[2].RestartPolicy).To(Equal(corev1.ContainerRestartPolicyAlways))
-		Expect(envoyDeployment.InitContainers[2].VolumeMounts).To(HaveLen(2))
-		Expect(envoyDeployment.InitContainers[2].VolumeMounts).To(ContainElements([]corev1.VolumeMount{
 			{
 				Name:      "access-logs",
 				MountPath: "/access_logs",
@@ -1260,26 +1227,19 @@ value:
 				Name:      "some-other-volume",
 				MountPath: "/test",
 			}, corev1.VolumeMount{
-				Name:      "waf-http-filter",
-				MountPath: "/var/run/waf-http-filter",
-			}, corev1.VolumeMount{
 				Name:      "access-logs",
 				MountPath: "/access_logs",
 			},
 		))
 
 		Expect(envoyDeployment.Pod).ToNot(BeNil())
-		Expect(envoyDeployment.Pod.Volumes).To(HaveLen(5))
+		Expect(envoyDeployment.Pod.Volumes).To(HaveLen(3))
 		Expect(envoyDeployment.Pod.Volumes[0].Name).To(Equal("some-other-volume"))
 		Expect(envoyDeployment.Pod.Volumes[0].EmptyDir).ToNot(BeNil())
-		Expect(envoyDeployment.Pod.Volumes[1].Name).To(Equal("var-log-calico"))
-		Expect(envoyDeployment.Pod.Volumes[1].HostPath.Path).To(Equal("/var/log/calico"))
-		Expect(envoyDeployment.Pod.Volumes[2].Name).To(Equal("waf-http-filter"))
-		Expect(envoyDeployment.Pod.Volumes[2].EmptyDir).ToNot(BeNil())
-		Expect(envoyDeployment.Pod.Volumes[3].Name).To(Equal("access-logs"))
-		Expect(envoyDeployment.Pod.Volumes[3].EmptyDir).ToNot(BeNil())
-		Expect(envoyDeployment.Pod.Volumes[4].Name).To(Equal("felix-sync"))
-		Expect(envoyDeployment.Pod.Volumes[4].CSI.Driver).To(Equal("csi.tigera.io"))
+		Expect(envoyDeployment.Pod.Volumes[1].Name).To(Equal("access-logs"))
+		Expect(envoyDeployment.Pod.Volumes[1].EmptyDir).ToNot(BeNil())
+		Expect(envoyDeployment.Pod.Volumes[2].Name).To(Equal("felix-sync"))
+		Expect(envoyDeployment.Pod.Volumes[2].CSI.Driver).To(Equal("csi.tigera.io"))
 		Expect(proxy.Spec.Telemetry.AccessLog.Settings).To(Equal(AccessLogSettings))
 	})
 
@@ -1306,7 +1266,7 @@ value:
 
 		envoyDeployment := proxy.Spec.Provider.Kubernetes.EnvoyDeployment
 		Expect(envoyDeployment).ToNot(BeNil())
-		Expect(envoyDeployment.InitContainers).To(HaveLen(2))
+		Expect(envoyDeployment.InitContainers).To(HaveLen(1))
 
 		// Find the l7-log-collector init container
 		var l7LogCollector *corev1.Container


### PR DESCRIPTION
Cherry-pick of #4925.

## Description

The WAF data plane on Enterprise Gateway moved to the Coraza WASM filter baked into the envoy-proxy image (EV-6701). The old `waf-http-filter` ext_proc sidecar is no longer how WAF is enforced, but `gateway_api.go` still injects it into every Enterprise envoy-proxy deployment. With both running, the proxy pod gets stuck at 3/4 ready and serves no traffic. PMREQ-384 already signed off on deprecating the sidecar.

This PR removes the sidecar from the gateway-api render, and nothing else.

Removed:
- the `waf-http-filter` init container
- its two WAF-only volumes (the `var-log-calico` HostPath and the `waf-http-filter` emptyDir socket) and the socket mount on the envoy container
- the `calicoImage` field and its image resolution, which only fed that container
- the `LOGGER_GATEWAY_NAME` / `LOGGER_GATEWAY_NAMESPACE` env vars, which only that container used

Kept on purpose: the `waf-http-filter`-named ServiceAccount, the two ClusterRoles, and the per-namespace RoleBindings. The l7-log-collector sidecar runs in the same pod under that identity and still needs it for license checks and Gateway-API reads. Renaming those objects to something l7-appropriate is a separate follow-up.

The l7-log-collector render is untouched.

This is an Enterprise-only change to the gateway-api render. It pairs with a calico-private PR that deletes the sidecar binary itself (link below). Merge this one first: the combined `calico` binary keeps the now-unused `waf-http-filter` subcommand until this lands in a hashrelease, so removing the render first is safe and removing the binary first is not.

Companion calico-private PR (draft, merges after this): tigera/calico-private#12308

## Test plan

- `go test ./pkg/render/gatewayapi/` passes. The two specs that asserted the sidecar was deployed now assert only l7-log-collector is, and the owning-gateway env test was updated for the new init-container count.
- `go build ./...`, `go vet ./pkg/render/gatewayapi/`, and gofmt are all clean.

Cherry-pick re-verified on `release-v1.43`: clean pick, `go build` / `go vet` / `gofmt` / `go test ./pkg/render/gatewayapi/` all pass.

## Release Note

```release-note
Remove the deprecated waf-http-filter sidecar from the Enterprise Gateway data plane. WAF is now enforced by the Coraza WASM filter on the envoy-proxy.
```
