### PR TITLE
test(render): resolve calico image dynamically in goldmane/whisker deployment tests

### DIFF
--- a/pkg/render/goldmane/component_test.go
+++ b/pkg/render/goldmane/component_test.go
@@ -30,6 +30,7 @@ import (
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/components"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/securitycontext"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
@@ -42,6 +43,12 @@ var (
 	defaultTLSKeyPair        = certificatemanagement.NewKeyPair(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "key-pair"}}, nil, "")
 	defaultTrustedCertBundle = certificatemanagement.CreateTrustedBundle(nil)
 	metricsPort              = int32(9081)
+
+	// calicoImageRef resolves the combined calico/calico image exactly as the
+	// renderer does, so the expected image tracks the pinned ComponentCalico
+	// version on any branch (:master on master, :v3.32.x on release-v1.43)
+	// rather than a hardcoded tag.
+	calicoImageRef, _ = components.GetReference(components.CombinedCalicoImage(&operatorv1.InstallationSpec{Variant: operatorv1.Calico}), "", "", "", nil)
 )
 
 var _ = Describe("ComponentRendering", func() {
@@ -140,7 +147,7 @@ var _ = Describe("ComponentRendering", func() {
 							Containers: []corev1.Container{
 								{
 									Name:    goldmane.GoldmaneContainerName,
-									Image:   "quay.io/calico/calico:master",
+									Image:   calicoImageRef,
 									Command: []string{"/usr/bin/calico", "component", "goldmane"},
 									Env: []corev1.EnvVar{
 										{Name: "LOG_LEVEL", Value: "INFO"},

--- a/pkg/render/whisker/component_test.go
+++ b/pkg/render/whisker/component_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/components"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/securitycontext"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
@@ -39,6 +40,14 @@ var (
 	defaultTrustedCertBundle = certificatemanagement.CreateTrustedBundle(nil)
 	numExpectedObjects       = 5
 	numDeprecatedObjects     = 1
+
+	// calicoImageRef resolves the combined calico/calico image exactly as the
+	// renderer does, so the expected image tracks the pinned ComponentCalico
+	// version on any branch (:master on master, :v3.32.x on release-v1.43)
+	// rather than a hardcoded tag.
+	calicoImageRef, _ = components.GetReference(components.CombinedCalicoImage(&operatorv1.InstallationSpec{Variant: operatorv1.Calico}), "", "", "", nil)
+	// whiskerImageRef resolves the whisker image the same way the renderer does.
+	whiskerImageRef, _ = components.GetReference(components.ComponentCalicoWhisker, "", "", "", nil)
 )
 
 var _ = Describe("ComponentRendering", func() {
@@ -118,7 +127,7 @@ var _ = Describe("ComponentRendering", func() {
 							Containers: []corev1.Container{
 								{
 									Name:  whisker.WhiskerContainerName,
-									Image: "quay.io/calico/whisker:master",
+									Image: whiskerImageRef,
 									Env: []corev1.EnvVar{
 										{Name: "LOG_LEVEL", Value: "INFO"},
 										{Name: "CALICO_VERSION", Value: "test-calico-version"},
@@ -137,7 +146,7 @@ var _ = Describe("ComponentRendering", func() {
 								},
 								{
 									Name:    whisker.WhiskerBackendContainerName,
-									Image:   "quay.io/calico/calico:master",
+									Image:   calicoImageRef,
 									Command: []string{"/usr/bin/calico", "component", "whisker-backend"},
 									Env: []corev1.EnvVar{
 										{Name: "LOG_LEVEL", Value: "INFO"},


### PR DESCRIPTION
## Description

The Goldmane and Whisker deployment render tests hardcoded the expected
combined calico image as `quay.io/calico/calico:master` (and the whisker
container image as `quay.io/calico/whisker:master`). The renderer resolves
these via `components.GetReference(components.CombinedCalicoImage(...))` and
`components.GetReference(components.ComponentCalicoWhisker)`, which track the
pinned component versions.

On master the pins are `master`, so the tests pass by coincidence. On release
branches (e.g. `release-v1.43`, which pins calico `v3.32.0`) the rendered image
is `:v3.32.0` while the test expects `:master`, so the full-Deployment `Equal`
assertion fails.

This computes the expected images the same way the renderer does, making the
tests version-agnostic so they pass on every branch and survive pin bumps.

- Type: bug fix (test-only)
- Components affected: `pkg/render/goldmane`, `pkg/render/whisker`
- Testing: `go test ./pkg/render/goldmane/ ./pkg/render/whisker/` passes on both
  `master` and `release-v1.43`.

## Release Note

```release-note
NONE
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`
