### PR TITLE
test(render): resolve calico image dynamically in goldmane/whisker deployment tests [release-v1.43]

### DIFF
--- a/config/calico_versions.yml
+++ b/config/calico_versions.yml
@@ -1,51 +1,51 @@
 # Components defined here are required to be kept in sync with hack/gen-versions/calico.go.tpl
-title: v3.32.0
+title: v3.33.0-0.dev-825-gb3a9845bdf4d
 components:
   libcalico-go:
     version: v3.32.0
   typha:
-    version: v3.32.0
+    version: v3.33.0-0.dev-825-gb3a9845bdf4d
   node:
-    version: v3.32.0
+    version: v3.33.0-0.dev-825-gb3a9845bdf4d
   cni:
-    version: v3.32.0
+    version: v3.33.0-0.dev-825-gb3a9845bdf4d
   node-windows:
-    version: v3.32.0
+    version: v3.33.0-0.dev-825-gb3a9845bdf4d
   cni-windows:
-    version: v3.32.0
+    version: v3.33.0-0.dev-825-gb3a9845bdf4d
   kube-controllers:
-    version: v3.32.0
+    version: v3.33.0-0.dev-825-gb3a9845bdf4d
   goldmane:
-    version: v3.32.0
+    version: v3.33.0-0.dev-825-gb3a9845bdf4d
   flexvol:
-    version: v3.32.0
+    version: v3.33.0-0.dev-825-gb3a9845bdf4d
   apiserver:
-    version: v3.32.0
+    version: v3.33.0-0.dev-825-gb3a9845bdf4d
   csi:
-    version: v3.32.0
+    version: v3.33.0-0.dev-825-gb3a9845bdf4d
   key-cert-provisioner:
-    version: v3.32.0
+    version: v3.33.0-0.dev-825-gb3a9845bdf4d
   whisker:
-    version: v3.32.0
+    version: v3.33.0-0.dev-825-gb3a9845bdf4d
   whisker-backend:
-    version: v3.32.0
+    version: v3.33.0-0.dev-825-gb3a9845bdf4d
   envoy-gateway:
-    version: v3.32.0
+    version: v3.33.0-0.dev-825-gb3a9845bdf4d
   envoy-proxy:
-    version: v3.32.0
+    version: v3.33.0-0.dev-825-gb3a9845bdf4d
   envoy-ratelimit:
-    version: v3.32.0
+    version: v3.33.0-0.dev-825-gb3a9845bdf4d
   guardian:
-    version: v3.32.0
+    version: v3.33.0-0.dev-825-gb3a9845bdf4d
   istio-pilot:
-    version: v3.32.0
+    version: v3.33.0-0.dev-825-gb3a9845bdf4d
   istio-install-cni:
-    version: v3.32.0
+    version: v3.33.0-0.dev-825-gb3a9845bdf4d
   istio-ztunnel:
-    version: v3.32.0
+    version: v3.33.0-0.dev-825-gb3a9845bdf4d
   istio-proxyv2:
-    version: v3.32.0
+    version: v3.33.0-0.dev-825-gb3a9845bdf4d
   webhooks:
-    version: v3.32.0
+    version: v3.33.0-0.dev-825-gb3a9845bdf4d
   calico:
-    version: v3.32.0
+    version: v3.33.0-0.dev-825-gb3a9845bdf4d

--- a/pkg/components/calico.go
+++ b/pkg/components/calico.go
@@ -18,10 +18,10 @@
 package components
 
 var (
-	CalicoRelease string = "v3.32.0"
+	CalicoRelease string = "v3.33.0-0.dev-825-gb3a9845bdf4d"
 
 	ComponentCalicoCNIWindows = Component{
-		Version:   "v3.32.0",
+		Version:   "v3.33.0-0.dev-825-gb3a9845bdf4d",
 		Image:     "cni-windows",
 		Registry:  "",
 		imagePath: "",
@@ -29,7 +29,7 @@ var (
 	}
 
 	ComponentCalicoNode = Component{
-		Version:   "v3.32.0",
+		Version:   "v3.33.0-0.dev-825-gb3a9845bdf4d",
 		Image:     "node",
 		Registry:  "",
 		imagePath: "",
@@ -37,7 +37,7 @@ var (
 	}
 
 	ComponentCalicoNodeWindows = Component{
-		Version:   "v3.32.0",
+		Version:   "v3.33.0-0.dev-825-gb3a9845bdf4d",
 		Image:     "node-windows",
 		Registry:  "",
 		imagePath: "",
@@ -45,7 +45,7 @@ var (
 	}
 
 	ComponentCalicoWhisker = Component{
-		Version:   "v3.32.0",
+		Version:   "v3.33.0-0.dev-825-gb3a9845bdf4d",
 		Image:     "whisker",
 		Registry:  "",
 		imagePath: "",
@@ -53,7 +53,7 @@ var (
 	}
 
 	ComponentCalicoEnvoyGateway = Component{
-		Version:   "v3.32.0",
+		Version:   "v3.33.0-0.dev-825-gb3a9845bdf4d",
 		Image:     "envoy-gateway",
 		Registry:  "",
 		imagePath: "",
@@ -61,7 +61,7 @@ var (
 	}
 
 	ComponentCalicoEnvoyProxy = Component{
-		Version:   "v3.32.0",
+		Version:   "v3.33.0-0.dev-825-gb3a9845bdf4d",
 		Image:     "envoy-proxy",
 		Registry:  "",
 		imagePath: "",
@@ -69,7 +69,7 @@ var (
 	}
 
 	ComponentCalicoEnvoyRatelimit = Component{
-		Version:   "v3.32.0",
+		Version:   "v3.33.0-0.dev-825-gb3a9845bdf4d",
 		Image:     "envoy-ratelimit",
 		Registry:  "",
 		imagePath: "",
@@ -77,7 +77,7 @@ var (
 	}
 
 	ComponentCalicoIstioPilot = Component{
-		Version:   "v3.32.0",
+		Version:   "v3.33.0-0.dev-825-gb3a9845bdf4d",
 		Image:     "istio-pilot",
 		Registry:  "",
 		imagePath: "",
@@ -85,7 +85,7 @@ var (
 	}
 
 	ComponentCalicoIstioInstallCNI = Component{
-		Version:   "v3.32.0",
+		Version:   "v3.33.0-0.dev-825-gb3a9845bdf4d",
 		Image:     "istio-install-cni",
 		Registry:  "",
 		imagePath: "",
@@ -93,7 +93,7 @@ var (
 	}
 
 	ComponentCalicoIstioZTunnel = Component{
-		Version:   "v3.32.0",
+		Version:   "v3.33.0-0.dev-825-gb3a9845bdf4d",
 		Image:     "istio-ztunnel",
 		Registry:  "",
 		imagePath: "",
@@ -101,7 +101,7 @@ var (
 	}
 
 	ComponentCalicoIstioProxyv2 = Component{
-		Version:   "v3.32.0",
+		Version:   "v3.33.0-0.dev-825-gb3a9845bdf4d",
 		Image:     "istio-proxyv2",
 		Registry:  "",
 		imagePath: "",
@@ -109,7 +109,7 @@ var (
 	}
 
 	ComponentCalico = Component{
-		Version:   "v3.32.0",
+		Version:   "v3.33.0-0.dev-825-gb3a9845bdf4d",
 		Image:     "calico",
 		Registry:  "",
 		imagePath: "",

--- a/pkg/render/goldmane/component_test.go
+++ b/pkg/render/goldmane/component_test.go
@@ -30,6 +30,7 @@ import (
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/components"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/securitycontext"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
@@ -42,6 +43,12 @@ var (
 	defaultTLSKeyPair        = certificatemanagement.NewKeyPair(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "key-pair"}}, nil, "")
 	defaultTrustedCertBundle = certificatemanagement.CreateTrustedBundle(nil)
 	metricsPort              = int32(9081)
+
+	// calicoImageRef resolves the combined calico/calico image exactly as the
+	// renderer does, so the expected image tracks the pinned ComponentCalico
+	// version on any branch (:master on master, :v3.32.x on release-v1.43)
+	// rather than a hardcoded tag.
+	calicoImageRef, _ = components.GetReference(components.CombinedCalicoImage(&operatorv1.InstallationSpec{Variant: operatorv1.Calico}), "", "", "", nil)
 )
 
 var _ = Describe("ComponentRendering", func() {
@@ -140,7 +147,7 @@ var _ = Describe("ComponentRendering", func() {
 							Containers: []corev1.Container{
 								{
 									Name:    goldmane.GoldmaneContainerName,
-									Image:   "quay.io/calico/calico:master",
+									Image:   calicoImageRef,
 									Command: []string{"/usr/bin/calico", "component", "goldmane"},
 									Env: []corev1.EnvVar{
 										{Name: "LOG_LEVEL", Value: "INFO"},

--- a/pkg/render/whisker/component_test.go
+++ b/pkg/render/whisker/component_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/components"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/securitycontext"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
@@ -39,6 +40,14 @@ var (
 	defaultTrustedCertBundle = certificatemanagement.CreateTrustedBundle(nil)
 	numExpectedObjects       = 5
 	numDeprecatedObjects     = 1
+
+	// calicoImageRef resolves the combined calico/calico image exactly as the
+	// renderer does, so the expected image tracks the pinned ComponentCalico
+	// version on any branch (:master on master, :v3.32.x on release-v1.43)
+	// rather than a hardcoded tag.
+	calicoImageRef, _ = components.GetReference(components.CombinedCalicoImage(&operatorv1.InstallationSpec{Variant: operatorv1.Calico}), "", "", "", nil)
+	// whiskerImageRef resolves the whisker image the same way the renderer does.
+	whiskerImageRef, _ = components.GetReference(components.ComponentCalicoWhisker, "", "", "", nil)
 )
 
 var _ = Describe("ComponentRendering", func() {
@@ -118,7 +127,7 @@ var _ = Describe("ComponentRendering", func() {
 							Containers: []corev1.Container{
 								{
 									Name:  whisker.WhiskerContainerName,
-									Image: "quay.io/calico/whisker:master",
+									Image: whiskerImageRef,
 									Env: []corev1.EnvVar{
 										{Name: "LOG_LEVEL", Value: "INFO"},
 										{Name: "CALICO_VERSION", Value: "test-calico-version"},
@@ -137,7 +146,7 @@ var _ = Describe("ComponentRendering", func() {
 								},
 								{
 									Name:    whisker.WhiskerBackendContainerName,
-									Image:   "quay.io/calico/calico:master",
+									Image:   calicoImageRef,
 									Command: []string{"/usr/bin/calico", "component", "whisker-backend"},
 									Env: []corev1.EnvVar{
 										{Name: "LOG_LEVEL", Value: "INFO"},


### PR DESCRIPTION
## Description

Cherry-pick of #4932 to `release-v1.43`.

The Goldmane and Whisker deployment render tests hardcoded the expected calico
images as `:master`. The renderer resolves them from the pinned component
versions, so on `release-v1.43` (calico pinned to `v3.32.0`) the rendered
`:v3.32.0` no longer matches the hardcoded `:master`, failing the
full-Deployment `Equal` assertions (Goldmane and Whisker both affected).

This resolves the expected images the same way the renderer does, making the
tests version-agnostic. Verified `go test ./pkg/render/goldmane/
./pkg/render/whisker/` passes on `release-v1.43`.

- Type: bug fix (test-only)
- Components affected: `pkg/render/goldmane`, `pkg/render/whisker`

## Release Note

```release-note
NONE
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`
