### PR TITLE
Default CNI install mode to CalicoOnly on Kind

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -669,6 +669,12 @@ func fillDefaults(instance *operatorv1.Installation, currentPools *v3.IPPoolList
 	}
 	if instance.Spec.CNI.InstallMode == nil {
 		mode := operatorv1.CNIInstallModeAll
+		if instance.Spec.KubernetesProvider == operatorv1.ProviderKind {
+			// kind node images already ship the upstream CNI plugins, so skip
+			// the cni-plugins init container. Other providers default to All
+			// for backward compatibility.
+			mode = operatorv1.CNIInstallModeCalicoOnly
+		}
 		instance.Spec.CNI.InstallMode = &mode
 	}
 

--- a/pkg/controller/installation/defaults_test.go
+++ b/pkg/controller/installation/defaults_test.go
@@ -54,6 +54,7 @@ var _ = Describe("Defaulting logic tests", func() {
 		Expect(instance.Spec.Variant).To(Equal(operator.Calico))
 		Expect(instance.Spec.Registry).To(BeEmpty())
 		Expect(instance.Spec.CNI.Type).To(Equal(operator.PluginCalico))
+		Expect(*instance.Spec.CNI.InstallMode).To(Equal(operator.CNIInstallModeAll))
 		Expect(instance.Spec.CalicoNetwork).NotTo(BeNil())
 		Expect(instance.Spec.CalicoNetwork.LinuxDataplane).ToNot(BeNil())
 		Expect(*instance.Spec.CalicoNetwork.LinuxDataplane).To(Equal(operator.LinuxDataplaneIptables))
@@ -454,6 +455,30 @@ var _ = Describe("Defaulting logic tests", func() {
 		Expect(fillDefaults(instance, nil)).NotTo(HaveOccurred())
 		Expect(instance.Spec.CNI.Type).To(Equal(operator.PluginCalico))
 		Expect(validateCustomResource(instance)).NotTo(HaveOccurred())
+	})
+
+	It("should default CNI InstallMode to CalicoOnly on the Kind provider", func() {
+		instance := &operator.Installation{
+			Spec: operator.InstallationSpec{
+				KubernetesProvider: operator.ProviderKind,
+				CNI:                &operator.CNISpec{},
+			},
+		}
+		Expect(fillDefaults(instance, nil)).NotTo(HaveOccurred())
+		Expect(*instance.Spec.CNI.InstallMode).To(Equal(operator.CNIInstallModeCalicoOnly))
+		Expect(validateCustomResource(instance)).NotTo(HaveOccurred())
+	})
+
+	It("should not override an explicit CNI InstallMode on the Kind provider", func() {
+		all := operator.CNIInstallModeAll
+		instance := &operator.Installation{
+			Spec: operator.InstallationSpec{
+				KubernetesProvider: operator.ProviderKind,
+				CNI:                &operator.CNISpec{InstallMode: &all},
+			},
+		}
+		Expect(fillDefaults(instance, nil)).NotTo(HaveOccurred())
+		Expect(*instance.Spec.CNI.InstallMode).To(Equal(operator.CNIInstallModeAll))
 	})
 
 	It("should set default values for CNILogging if CNI is set to Calico", func() {


### PR DESCRIPTION
## Description

The operator now defaults the CNI install mode to CalicoOnly on the Kind provider. kind node images already ship the upstream CNI plugins (host-local, portmap, loopback, tuning, flannel), so there's no need to run the cni-plugins init container to stage them onto the host. Every other provider continues to default to All for backward compatibility, and an explicitly-set installMode is always respected.

Relates to https://github.com/projectcalico/calico/pull/12997.

Related: [CORE-13311](https://tigera.atlassian.net/browse/CORE-13311)

## Release Note

```release-note
On Kind clusters, Calico defaults to not installing the bundled upstream CNI plugins, since the Kind node image already provides them.
```



[CORE-13311]: https://tigera.atlassian.net/browse/CORE-13311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ