### PR TITLE
Add egress to Goldmane and Guardian network policies

### DIFF
--- a/pkg/render/goldmane/component.go
+++ b/pkg/render/goldmane/component.go
@@ -384,14 +384,40 @@ func (c *Component) networkPolicy() *v3.NetworkPolicy {
 			},
 		})
 	}
+
+	egressRules := networkpolicy.AppendDNSEgressRules([]v3.Rule{}, c.cfg.OpenShift)
+
+	// Allow egress to the Kubernetes API server. Goldmane reads the
+	// flow-emitter-state ConfigMap. Match on port only, since OSS policy can't
+	// rely on service-based selectors.
+	egressRules = append(egressRules, v3.Rule{
+		Action:   v3.Allow,
+		Protocol: &networkpolicy.TCPProtocol,
+		Destination: v3.EntityRule{
+			Ports: networkpolicy.Ports(443, 6443, 12388),
+		},
+	})
+
+	// In a managed cluster Goldmane posts flows to Guardian, which tunnels them
+	// to the management cluster.
+	if c.cfg.ManagementClusterConnection != nil {
+		egressRules = append(egressRules, v3.Rule{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: render.GuardianEntityRule,
+		})
+	}
+
 	return &v3.NetworkPolicy{
 		TypeMeta:   metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"},
 		ObjectMeta: metav1.ObjectMeta{Name: GoldmanePolicyName, Namespace: GoldmaneNamespace},
 		Spec: v3.NetworkPolicySpec{
+			Order:    &networkpolicy.HighPrecedenceOrder,
 			Tier:     networkpolicy.CalicoTierName,
 			Selector: networkpolicy.KubernetesAppSelector(GoldmaneDeploymentName),
-			Types:    []v3.PolicyType{v3.PolicyTypeIngress},
+			Types:    []v3.PolicyType{v3.PolicyTypeIngress, v3.PolicyTypeEgress},
 			Ingress:  ingressRules,
+			Egress:   egressRules,
 		},
 	}
 }

--- a/pkg/render/goldmane/component.go
+++ b/pkg/render/goldmane/component.go
@@ -388,14 +388,11 @@ func (c *Component) networkPolicy() *v3.NetworkPolicy {
 	egressRules := networkpolicy.AppendDNSEgressRules([]v3.Rule{}, c.cfg.OpenShift)
 
 	// Allow egress to the Kubernetes API server. Goldmane reads the
-	// flow-emitter-state ConfigMap. Match on port only, since OSS policy can't
-	// rely on service-based selectors.
+	// flow-emitter-state ConfigMap.
 	egressRules = append(egressRules, v3.Rule{
-		Action:   v3.Allow,
-		Protocol: &networkpolicy.TCPProtocol,
-		Destination: v3.EntityRule{
-			Ports: networkpolicy.Ports(443, 6443, 12388),
-		},
+		Action:      v3.Allow,
+		Protocol:    &networkpolicy.TCPProtocol,
+		Destination: networkpolicy.KubeAPIServerEntityRule,
 	})
 
 	// In a managed cluster Goldmane posts flows to Guardian, which tunnels them

--- a/pkg/render/goldmane/component_test.go
+++ b/pkg/render/goldmane/component_test.go
@@ -31,7 +31,9 @@ import (
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/components"
+	"github.com/tigera/operator/pkg/render"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
+	"github.com/tigera/operator/pkg/render/common/networkpolicy"
 	"github.com/tigera/operator/pkg/render/common/securitycontext"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
 	"github.com/tigera/operator/pkg/render/goldmane"
@@ -276,6 +278,55 @@ var _ = Describe("ComponentRendering", func() {
 		np, err := rtest.GetResourceOfType[*v3.NetworkPolicy](objsToCreate, goldmane.GoldmanePolicyName, goldmane.GoldmaneNamespace)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(np.Spec.Ingress).To(HaveLen(1))
+	})
+
+	It("Should render locked-down egress in a standalone cluster", func() {
+		cfg := &goldmane.Configuration{
+			ClusterDomain: "cluster.local",
+			Installation: &operatorv1.InstallationSpec{
+				KubernetesProvider: operatorv1.ProviderGKE,
+				Variant:            operatorv1.Calico,
+			},
+			TrustedCertBundle:     certificatemanagement.CreateTrustedBundle(nil),
+			GoldmaneServerKeyPair: defaultTLSKeyPair,
+			Goldmane:              &operatorv1.Goldmane{},
+		}
+		objsToCreate, _ := goldmane.Goldmane(cfg).Objects()
+
+		np, err := rtest.GetResourceOfType[*v3.NetworkPolicy](objsToCreate, goldmane.GoldmanePolicyName, goldmane.GoldmaneNamespace)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(np.Spec.Types).To(ConsistOf(v3.PolicyTypeIngress, v3.PolicyTypeEgress))
+
+		// Goldmane's egress is fully specified (DNS + kube API), so every rule is an
+		// explicit Allow - no Pass that would defer to lower tiers.
+		Expect(np.Spec.Egress).NotTo(BeEmpty())
+		for _, rule := range np.Spec.Egress {
+			Expect(rule.Action).To(Equal(v3.Allow))
+			Expect(rule.Destination).NotTo(Equal(render.GuardianEntityRule))
+		}
+	})
+
+	It("Should render egress to Guardian in a managed cluster", func() {
+		cfg := &goldmane.Configuration{
+			ClusterDomain: "cluster.local",
+			Installation: &operatorv1.InstallationSpec{
+				KubernetesProvider: operatorv1.ProviderGKE,
+				Variant:            operatorv1.Calico,
+			},
+			TrustedCertBundle:           certificatemanagement.CreateTrustedBundle(nil),
+			GoldmaneServerKeyPair:       defaultTLSKeyPair,
+			Goldmane:                    &operatorv1.Goldmane{},
+			ManagementClusterConnection: &operatorv1.ManagementClusterConnection{},
+		}
+		objsToCreate, _ := goldmane.Goldmane(cfg).Objects()
+
+		np, err := rtest.GetResourceOfType[*v3.NetworkPolicy](objsToCreate, goldmane.GoldmanePolicyName, goldmane.GoldmaneNamespace)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(np.Spec.Egress).To(ContainElement(v3.Rule{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: render.GuardianEntityRule,
+		}))
 	})
 
 	It("Should apply overrides", func() {

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -547,14 +547,11 @@ func (c *GuardianComponent) annotations() map[string]string {
 func ossNetworkPolicy(cfg *GuardianConfiguration) *v3.NetworkPolicy {
 	egressRules := networkpolicy.AppendDNSEgressRules([]v3.Rule{}, cfg.OpenShift)
 
-	// Allow egress to the Kubernetes API server. Match on port only, since OSS
-	// policy can't rely on the service-based selectors the enterprise path uses.
+	// Allow egress to the Kubernetes API server.
 	egressRules = append(egressRules, v3.Rule{
-		Action:   v3.Allow,
-		Protocol: &networkpolicy.TCPProtocol,
-		Destination: v3.EntityRule{
-			Ports: networkpolicy.Ports(443, 6443, 12388),
-		},
+		Action:      v3.Allow,
+		Protocol:    &networkpolicy.TCPProtocol,
+		Destination: networkpolicy.KubeAPIServerEntityRule,
 	})
 
 	// Guardian's tunnel destination is the management cluster, whose address is

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -544,7 +544,25 @@ func (c *GuardianComponent) annotations() map[string]string {
 	return annotations
 }
 
-func ossNetworkPolicy() *v3.NetworkPolicy {
+func ossNetworkPolicy(cfg *GuardianConfiguration) *v3.NetworkPolicy {
+	egressRules := networkpolicy.AppendDNSEgressRules([]v3.Rule{}, cfg.OpenShift)
+
+	// Allow egress to the Kubernetes API server. Match on port only, since OSS
+	// policy can't rely on the service-based selectors the enterprise path uses.
+	egressRules = append(egressRules, v3.Rule{
+		Action:   v3.Allow,
+		Protocol: &networkpolicy.TCPProtocol,
+		Destination: v3.EntityRule{
+			Ports: networkpolicy.Ports(443, 6443, 12388),
+		},
+	})
+
+	// Guardian's tunnel destination is the management cluster, whose address is
+	// environment-specific and often a hostname. OSS policy can't express a
+	// domain-based egress rule, so Pass and let the cluster's default posture
+	// govern the tunnel (and the management cluster's queries back to Goldmane).
+	egressRules = append(egressRules, v3.Rule{Action: v3.Pass})
+
 	return &v3.NetworkPolicy{
 		TypeMeta:   metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"},
 		ObjectMeta: metav1.ObjectMeta{Name: GuardianPolicyName, Namespace: GuardianNamespace},
@@ -552,7 +570,7 @@ func ossNetworkPolicy() *v3.NetworkPolicy {
 			Order:    &networkpolicy.HighPrecedenceOrder,
 			Tier:     networkpolicy.CalicoTierName,
 			Selector: networkpolicy.KubernetesAppSelector(GuardianName),
-			Types:    []v3.PolicyType{v3.PolicyTypeIngress},
+			Types:    []v3.PolicyType{v3.PolicyTypeIngress, v3.PolicyTypeEgress},
 			Ingress: []v3.Rule{
 				{
 					Action:   v3.Allow,
@@ -564,21 +582,15 @@ func ossNetworkPolicy() *v3.NetworkPolicy {
 						Ports: networkpolicy.Ports(GuardianTargetPort),
 					},
 				},
-				{
-					Action:   v3.Allow,
-					Protocol: &networkpolicy.UDPProtocol,
-					Destination: v3.EntityRule{
-						Ports: networkpolicy.Ports(53),
-					},
-				},
 			},
+			Egress: egressRules,
 		},
 	}
 }
 
 func guardianCalicoSystemPolicy(cfg *GuardianConfiguration) (*v3.NetworkPolicy, error) {
 	if !cfg.Installation.Variant.IsEnterprise() {
-		return ossNetworkPolicy(), nil
+		return ossNetworkPolicy(cfg), nil
 	}
 
 	egressRules := []v3.Rule{

--- a/pkg/render/guardian_test.go
+++ b/pkg/render/guardian_test.go
@@ -339,9 +339,16 @@ var _ = Describe("Rendering tests", func() {
 				policy := testutils.GetCalicoSystemPolicyFromResources(policyName, resources)
 				Expect(policy).NotTo(BeNil(), "OSS variant should always render a network policy")
 
-				// Verify it's the OSS policy (should only have Ingress type, no Egress)
-				Expect(policy.Spec.Types).To(ConsistOf(v3.PolicyTypeIngress))
-				Expect(policy.Spec.Egress).To(BeEmpty())
+				// The OSS policy has both Ingress and Egress, ending in a Pass so the
+				// tunnel to the management cluster isn't dropped by the default-deny.
+				Expect(policy.Spec.Types).To(ConsistOf(v3.PolicyTypeIngress, v3.PolicyTypeEgress))
+				Expect(policy.Spec.Egress).NotTo(BeEmpty())
+				Expect(policy.Spec.Egress[len(policy.Spec.Egress)-1].Action).To(Equal(v3.Pass))
+
+				// OSS can't express domain-based egress rules.
+				for _, rule := range policy.Spec.Egress {
+					Expect(rule.Destination.Domains).To(BeEmpty())
+				}
 			})
 
 			It("should render Enterprise network policy without domain-based egress when IncludeEgressNetworkPolicy is false", func() {


### PR DESCRIPTION
## Description

On Calico OSS clusters, the Goldmane and Guardian pods lost connectivity once the network policy tier was enabled for OSS in 3.32. The calico-system tier's default-deny policy started applying to these pods, but their policies only defined ingress rules, so their egress was dropped: DNS to CoreDNS, the Kubernetes API, and Guardian's tunnel to the management cluster. This showed up as denied flows in Whisker and broke flow visibility on Calico Cloud-connected clusters.

This adds the missing egress:
- Goldmane: DNS, the Kubernetes API, and (in managed clusters) Guardian. These destinations are all in-cluster, so the policy stays fully locked down.
- Guardian: DNS and the Kubernetes API, plus a Pass for the tunnel to the management cluster. The management cluster address is environment-specific and often a hostname, which OSS policy can't express as a selector, so we defer it to the cluster's default posture - the same approach the enterprise policy already uses.

Enterprise policy is unchanged.

Fixes #4804
Related: #4772

## Release Note

```release-note
Fixes a regression where the Goldmane and Guardian pods were unable to reach DNS or the management cluster, which could break flow visibility (including on Calico Cloud-connected clusters).
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
