### PR TITLE
Restore protect-builtin-tiers.yaml

### DIFF
--- a/pkg/imports/admission/calico/protect-builtin-tiers.yaml
+++ b/pkg/imports/admission/calico/protect-builtin-tiers.yaml
@@ -1,0 +1,28 @@
+---
+# ValidatingAdmissionPolicy that prevents deletion of the built-in Calico tiers
+# (default, kube-admin, kube-baseline). These tiers are required for correct
+# operation and should never be deleted.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: protect-builtin-tiers.projectcalico.org
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["projectcalico.org"]
+        apiVersions: ["v3"]
+        resources: ["tiers"]
+        operations: ["DELETE"]
+  validations:
+    - expression: "!(oldObject.metadata.name in ['default', 'kube-admin', 'kube-baseline'])"
+      messageExpression: "'The built-in tier ' + oldObject.metadata.name + ' cannot be deleted'"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: protect-builtin-tiers.projectcalico.org
+spec:
+  policyName: protect-builtin-tiers.projectcalico.org
+  validationActions:
+    - Deny


### PR DESCRIPTION
## Description

The operator doesn't carry Calico's admission policies by hand — at release time a script wipes its `pkg/imports/admission/calico/` directory and re-copies everything from `api/admission/` in whatever Calico version the release pins. When `release-v1.43` was cut, it pinned the Calico `v3.32.0` tag, but that tag predates a Calico commit that *moved* `protect-builtin-tiers.yaml` into `api/admission/` (it still lived at the old `api/config/admission/` path back then), so the re-copy found nothing and silently dropped the file. With the manifest gone, the operator rendered zero ValidatingAdmissionPolicies for Calico instead of the expected two — which broke the build, since the operator's tests assert that those two policies get created. This fix restores that one manifest into the operator's import directory, bringing `release-v1.43` back in line with what master already ships and re-arming the guardrail that blocks deletion of the built-in tiers.

## Release Note

```release-note
Restore the protect-builtin-tiers ValidatingAdmissionPolicy for Calico, which prevents deletion of the built-in tiers (default, kube-admin, kube-baseline).
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)