### PR TITLE
Add operator-api-standards Claude Code skill

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -73,9 +73,16 @@ make gen-files
 ```
 After `gen-files`, verify the scope of existing resources wasn't changed to "Namespaced".
 
-## Design Principles
+## Design Principles & Documentation Map
 
-See [`docs/principles.md`](../docs/principles.md) for code architecture and design principles, and [`docs/dev_guidelines.md`](../docs/dev_guidelines.md) for developer workflow and procedures.
+Read the relevant doc before working in these areas:
+
+| Task | Read |
+|------|------|
+| Architecture & design rationale (the "why") | [`docs/principles.md`](../docs/principles.md) |
+| API design & changing CRD types in `api/v1` (principles, conventions, checklist) | [`docs/api_design.md`](../docs/api_design.md) |
+| Developer workflow, code generation, cherry-picks | [`docs/dev_guidelines.md`](../docs/dev_guidelines.md) |
+| Common dev procedures (run, test, debug) | [`docs/common_tasks.md`](../docs/common_tasks.md) |
 
 ## Build Environment
 - Tests and builds run in a containerized environment (`calico/go-build`) by default

--- a/.claude/skills/operator-api-standards/SKILL.md
+++ b/.claude/skills/operator-api-standards/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: operator-api-standards
+description: Standards, conventions, and dos/don'ts for adding or changing CRD types in the tigera/operator API (api/v1). Use this skill whenever editing or creating files under api/v1/ (any *_types.go), adding/removing/renaming a CRD field, introducing a new Kind/CRD, adding kubebuilder validation or defaulting markers, or designing an overrides/configuration field. Trigger even if the user doesn't mention "standards" — any change to operator CRD types should follow these conventions.
+---
+
+# Operator API Standards
+
+When adding or changing CRD types under `api/v1/`:
+
+1. **Read [`docs/api_design.md`](../../../docs/api_design.md)** — the API design
+   principles plus the concrete Go/kubebuilder coding conventions (optional vs
+   required fields, the `Enabled`/`Disabled` enum idiom, validation/CEL markers,
+   the top-level Kind marker block, shared-type reuse, the Deployment override
+   pattern) and the end-of-file **checklist**. Apply all of it, and run the
+   checklist before you finish.
+2. **Read [`docs/principles.md`](../../../docs/principles.md)** for related rules
+   ("Respect User Input", "Resource Ownership") when a judgement call isn't
+   settled by `api_design.md`.
+3. Follow the post-change workflow in
+   [`docs/dev_guidelines.md`](../../../docs/dev_guidelines.md) — `make gen-files`,
+   verify scope didn't flip to `Namespaced`, update `convert` if relevant, and
+   `make dirty-check`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,42 @@
+# Copilot instructions: tigera/operator
+
+Kubernetes operator (operator-sdk / controller-runtime) that manages the
+lifecycle of Calico and Calico Enterprise installations. Each component has its
+own CRD (`api/v1`), controller (`pkg/controller/<component>`), and rendering code
+(`pkg/render`).
+
+## Where the standards live
+
+- **API design / CRD types in `api/v1`:** [`docs/api_design.md`](../docs/api_design.md)
+- **Architecture & design rationale:** [`docs/principles.md`](../docs/principles.md)
+- **Developer workflow, code generation, cherry-picks:** [`docs/dev_guidelines.md`](../docs/dev_guidelines.md)
+- **Running, testing, debugging:** [`docs/common_tasks.md`](../docs/common_tasks.md)
+
+## Reviewing changes to `api/v1` CRD types
+
+When a pull request changes CRD types under `api/v1/` (the `*_types.go` files),
+review them against [`docs/api_design.md`](../docs/api_design.md) and flag
+violations of:
+
+- Optional fields are a pointer + `omitempty` + `// +optional` + a doc comment;
+  required fields omit the pointer/`omitempty` and use `// +required`.
+- On/off toggles use an `Enabled`/`Disabled` enum (a named string type), not a
+  `*bool`.
+- Constrained values carry markers: `+kubebuilder:validation:Enum` / `Minimum` /
+  `Maximum` / `Pattern`.
+- Fields used in a CEL `XValidation` rule set `MaxLength` / `MaxItems`; use
+  `size(self.field) == 0`, never `self.field == ''` (single quotes break
+  goimports).
+- Prefer kubebuilder markers/CEL over reconcile-loop logic for
+  defaulting/validation.
+- Reuse shared types (`Metadata`, `ProbeOverride`, `corev1`/`appsv1`) instead of
+  redefining them.
+- Changes are additive and backward-compatible — don't change the meaning of an
+  existing field or tighten validation on one.
+- Every file carries the Tigera Apache-2.0 copyright header.
+
+See `docs/api_design.md` for the full conventions, the Deployment override
+pattern, and the per-field checklist. After API/CRD changes, `make gen-files`
+then `make dirty-check` must be run; generated files
+(`zz_generated.deepcopy.go`, `pkg/imports/crds/`, `pkg/components/`) are not
+hand-edited.

--- a/docs/api_design.md
+++ b/docs/api_design.md
@@ -1,0 +1,139 @@
+# API Design
+
+Design principles and the concrete Go/kubebuilder coding conventions for CRD
+types under `api/v1/`. The post-change workflow (code generation, validation)
+is in [`dev_guidelines.md`](dev_guidelines.md).
+
+When adding or changing a CRD field, follow these and finish with the
+[checklist](#checklist-for-a-new-field). APIs follow the
+[Kubernetes API conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md);
+when in doubt, mirror the upstream Kubernetes type you're configuring, and match
+a recent similar `*_types.go` file (e.g. `whisker_types.go`,
+`whisker_deployment_types.go`).
+
+## Design principles
+
+- **APIs are declarative.** The final state of the system should depend only on
+  the current desired state, not on the order of transitions that got there.
+- **Minimal API surface.** Prefer auto-detection over configuration. Every new
+  field is a maintenance burden and a potential source of user confusion — only
+  add fields when there's a clear, concrete need.
+- **Prefer `projectcalico.org/v3` over `crd.projectcalico.org/v1`.** The v3 API
+  group is the standard going forward.
+- **Every container needs overrides.** Resource requirements/requests,
+  scheduling, topology, and similar configuration must be overridable for every
+  container. Use the overrides mechanism, and model the API after the upstream
+  Kubernetes API being configured (see [the override pattern](#deployment--container-override-pattern)).
+- **Prefer kubebuilder defaulting and validation.** Use kubebuilder markers and
+  CEL expressions wherever possible. Fall back to reconcile-loop logic only when
+  kubebuilder can't express it (e.g. cross-resource validation, dynamic defaults
+  based on cluster state).
+- **Validation must be bounded.** Fields used in CEL `XValidation` expressions
+  require `MaxLength` / `MaxItems` bounds (details under
+  [Validation markers](#validation-and-defaulting-markers)).
+
+## Optional vs. required fields
+
+Optional fields — the overwhelming default — are a pointer + `omitempty` + an
+`// +optional` marker, with a doc comment:
+
+```go
+// Notifications enables calls to an external API for banner text in the Whisker UI.
+// +optional
+Notifications *NotificationMode `json:"notifications,omitempty"`
+```
+
+Use a pointer whenever "unset" must be distinguishable from the zero value
+(almost always for optional scalars/bools/ints). Required fields omit the
+pointer and `omitempty` and carry `// +required`.
+
+## On/off toggles
+
+Use a named string type with `Enabled`/`Disabled` constants and an Enum marker —
+**not** a `*bool`. This is the established repo idiom:
+
+```go
+type NotificationMode string
+
+const (
+    Disabled NotificationMode = "Disabled"
+    Enabled  NotificationMode = "Enabled"
+)
+// +kubebuilder:validation:Enum=Enabled;Disabled
+```
+
+## Validation and defaulting markers
+
+- Any closed set of string values gets `// +kubebuilder:validation:Enum=A;B;C`.
+- Numeric fields get `// +kubebuilder:validation:Minimum=`/`Maximum=`.
+- **CEL `XValidation`**: any field referenced in a CEL rule **must** have a
+  `MaxLength` (strings) or `MaxItems` (lists) bound, or the apiserver rejects the
+  CRD. Use `size(self.field) == 0` rather than `self.field == ''` — goimports
+  corrupts single quotes in CEL expressions.
+
+## Top-level Kind types
+
+Carry the standard marker block, embed `TypeMeta`/`ObjectMeta`, and add a
+`<Kind>List` type plus `SchemeBuilder.Register` in `init()`:
+
+```go
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:scope=Cluster
+type Whisker struct {
+    metav1.TypeMeta   `json:",inline"`
+    metav1.ObjectMeta `json:"metadata,omitempty"`
+    Spec   WhiskerSpec   `json:"spec,omitempty"`
+    Status WhiskerStatus `json:"status,omitempty"`
+}
+```
+
+Singleton CRDs pin the name to `default` via an `XValidation` rule
+(`self.metadata.name == 'default'`). Status uses `[]metav1.Condition`
+(Ready/Progressing/Degraded); status messages are user-facing and actionable —
+never internal errors or stack traces.
+
+Every file starts with the `Copyright (c) <years> Tigera, Inc.` Apache-2.0
+header — copy it from a neighbouring file.
+
+## Reuse shared types
+
+Don't redefine: `Metadata` (`common_types.go`), `ProbeOverride`
+(`probe_types.go`), and `corev1`/`appsv1` types (`Affinity`, `Toleration`,
+`ResourceRequirements`, `TopologySpreadConstraint`, `RollingUpdateDeployment`).
+
+## Deployment / container override pattern
+
+Every container's resources, scheduling, tolerations, topology, and probe timing
+must be overridable. When a component runs a Deployment/DaemonSet that needs to be
+customizable, follow the established nesting (see `whisker_deployment_types.go`):
+`<Comp>Deployment` → `Metadata` + `Spec` (`<Comp>DeploymentSpec`) → `Template`
+(`...PodTemplateSpec`) → `Metadata` + `Spec` (`...PodSpec`) →
+`Containers []<Comp>DeploymentContainer`. The container type pins `Name` with an
+Enum and exposes `Resources` and `ReadinessProbe`/`LivenessProbe` (as
+`*ProbeOverride`). Mirror upstream Kubernetes field names and semantics.
+
+## After every API change
+
+See [`dev_guidelines.md`](dev_guidelines.md) for detail. In short:
+
+1. `make gen-files` — regenerates CRD manifests, `zz_generated.deepcopy.go`, and
+   client sets. Never hand-edit generated files.
+2. Verify cluster-scoped resources weren't flipped to `Namespaced`.
+3. If the new config is settable during a manifest-based Calico OSS → operator
+   migration, update [`pkg/controller/migration/convert`](https://github.com/tigera/operator/tree/master/pkg/controller/migration/convert).
+4. Add cross-field/code-level checks to `pkg/common/validation/` if needed.
+5. `make ut UT_DIR=./api/...` (and relevant render/controller packages), then
+   `make dirty-check` to confirm generated output is committed.
+
+## Checklist for a new field
+
+- [ ] Genuinely needed (auto-detection isn't enough)?
+- [ ] `*T` + `omitempty` + `// +optional` + doc comment (or `// +required`)?
+- [ ] Enum/Minimum/Maximum/Pattern markers where the value is constrained?
+- [ ] If used in a CEL rule: `MaxLength`/`MaxItems` bound set, no single quotes?
+- [ ] On/off toggle modeled as an `Enabled`/`Disabled` enum, not `*bool`?
+- [ ] Reuses shared types rather than redefining them?
+- [ ] Backward-compatible (additive; doesn't change an existing field's meaning)?
+- [ ] `make gen-files` run, scope unchanged, `make dirty-check` clean?
+- [ ] `convert` package updated if migration-relevant?

--- a/docs/principles.md
+++ b/docs/principles.md
@@ -4,12 +4,7 @@ Code architecture and design principles for the tigera/operator repository. For 
 
 ## API Design
 
-- **APIs are declarative.** The final state of the system should depend only on the current desired state, not on the order of transitions that got there. Going A -> B -> C should leave you in the same state as B -> A -> C, or C -> B -> C.
-- **Minimal API surface.** Prefer auto-detection over configuration. Every new field is a maintenance burden and a potential source of user confusion — only add fields when there's a clear, concrete need.
-- **Prefer `projectcalico.org/v3` over `crd.projectcalico.org/v1`.** The v3 API group is the standard going forward.
-- **Every container needs overrides.** Resource requirements/requests, scheduling, topology, and similar configuration must be overridable for every container. Use the overrides mechanism, and model the API after the upstream Kubernetes API being configured.
-- **Prefer kubebuilder defaulting and validation.** Use kubebuilder markers and CEL expressions for defaulting and validation wherever possible. Fall back to reconcile-loop defaulting and validation only when kubebuilder can't express the logic (e.g., cross-resource validation, dynamic defaults based on cluster state).
-- **CEL validation rules require bounds.** Always set `MaxLength` / `MaxItems` on fields used in CEL `XValidation` expressions. Use `size(self.field) == 0` instead of `self.field == ''` (goimports corrupts single quotes in CEL).
+API design principles and the Go/kubebuilder coding conventions for `api/v1` CRD types have their own guide: see [api_design.md](api_design.md).
 
 ## Respect User Input
 


### PR DESCRIPTION
## Description

Adds a project-scoped [Claude Code skill](https://docs.claude.com/en/docs/claude-code/skills) that guides contributors on conventions and dos/don'ts when adding or changing CRD types under `api/v1/`.

The skill distills the rationale already captured in `docs/principles.md` ("API Design", "Respect User Input", "Resource Ownership") and `docs/dev_guidelines.md` ("API code") into concrete, checkable rules, and pairs them with the repo's actual kubebuilder/Go coding conventions observed across the existing `*_types.go` files:

- **Design rules**: minimal API surface, declarative convergence, kubebuilder-over-reconcile-loop defaulting/validation, every-container-needs-overrides, backward compatibility.
- **Respect user input**: never overwrite/delete user fields or resources, error don't guess, no OwnerRefs on user-provided resources.
- **Coding conventions**: pointer + `omitempty` + `+optional` for optional fields, the `Enabled`/`Disabled` enum idiom over `*bool`, CEL `MaxLength`/`MaxItems` bounds and the single-quote gotcha, the top-level Kind marker block + `List` + `init()` registration, copyright header, shared-type reuse.
- **Deployment/container override pattern** modeled on `whisker_deployment_types.go`.
- **Required post-change workflow**: `make gen-files`, cluster-scope check, `convert` package, `pkg/common/validation`, `make dirty-check`.
- A copy-paste **checklist** for adding a new field.

It auto-triggers whenever a contributor (using Claude Code) edits files under `api/v1/`, so the guidance surfaces at the moment it's relevant.

## For PR author

- [x] Added or updated tests for any new code _(n/a — docs/tooling only)_
- [x] If changing programmatic behavior of the operator, my commit message explains _what_ behavior changed _(n/a)_

## For PR reviewers

This is purely additive (a new `.claude/skills/` markdown file); no operator behavior changes. Feedback welcome on the conventions themselves — whether anything is inaccurate, missing, or too prescriptive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)