### PR TITLE
[CVE] Bump GO_BUILD_VER and bundled Istio on release-v1.42

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ endif
 REPO?=tigera/operator
 PACKAGE_NAME?=github.com/tigera/operator
 LOCAL_USER_ID?=$(shell id -u $$USER)
-GO_BUILD_VER?=1.26.3-llvm20.1.8-k8s1.35.4
+GO_BUILD_VER?=1.26.4-llvm21.1.8-k8s1.35.6
 CALICO_BASE_VER ?= ubi9-1771532994
 CALICO_BUILD?=calico/go-build:$(GO_BUILD_VER)-$(BUILDARCH)
 CALICO_BASE ?= calico/base:$(CALICO_BASE_VER)
@@ -232,7 +232,7 @@ endif
 
 # To update the Istio version, see "Updating the bundled version of Istio" in docs/common_tasks.md.
 ISTIO_HELM_REPO ?= https://istio-release.storage.googleapis.com/charts
-ISTIO_VERSION ?= 1.29.2
+ISTIO_VERSION ?= 1.29.4
 ISTIO_RESOURCES_DIR = pkg/render/istio
 ISTIO_CHARTS = base istiod cni ztunnel
 ISTIO_CHART_FILES = $(addprefix $(ISTIO_RESOURCES_DIR)/,$(addsuffix .tgz,$(ISTIO_CHARTS)))


### PR DESCRIPTION
## Summary

CVE remediation for `release-v1.42`. Both changes are single-line `Makefile` edits.

- **`GO_BUILD_VER`: `1.26.3-llvm20.1.8-k8s1.35.4` → `1.26.4-llvm21.1.8-k8s1.35.6`**
  Picks up Go 1.26.4 and LLVM 21.1.8 to address stdlib CVEs. The operator compiles with `GOTOOLCHAIN=local`, so the fix lands by building with the new image. The `k8s1.35.6` portion is the bundled k8s tooling in the build image only — the `k8s.io/*` libraries in `go.mod` (v0.36.1) are independent and unchanged.
- **`ISTIO_VERSION`: `1.29.2` → `1.29.4`**
  Patch-level upstream chart bump. The chart `.tgz` files are git-ignored and `go:embed`-ed at build time (re-downloaded via `make istio_charts`), so they are not committed — the `Makefile` line is the only tracked change, consistent with prior Istio bumps (#4733).

## go.mod

No `go.mod` change is required:
- The Go bump is a patch; `go.mod`'s `go 1.26.3` directive is a minimum and is satisfied by the 1.26.4 toolchain.
- The k8s portion of the image tag is bundled tooling, not the client libraries.

## Testing

- Istio render + controller unit tests pass against the re-downloaded 1.29.4 charts (`go test ./pkg/render/istio/... ./pkg/controller/istio/...`).
- Re-downloaded charts confirmed at `version: 1.29.4` for `base`/`istiod`/`cni`/`ztunnel`.
- Pre-commit hook ran successfully inside the new `1.26.4-llvm21.1.8-k8s1.35.6` build image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)