### PR TITLE
Bump ECK operator from 3.3.2 to 3.4.0

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -77,7 +77,7 @@ components:
   # eck-elasticsearch-operator holds the version of the ECK operator used to manage
   # Elasticsearch
   eck-elasticsearch-operator:
-    version: 3.3.2
+    version: 3.4.0
   gateway-l7-collector:
     image: gateway-l7-collector
     version: master

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -71,7 +71,7 @@ var (
 	}
 
 	ComponentECKElasticsearchOperator = Component{
-		Version: "3.3.2",
+		Version: "3.4.0",
 		variant: enterpriseVariant,
 	}
 


### PR DESCRIPTION
Companion to calico-private #12203, which builds the ECK operator at v3.4.0 and ships the matching CRD bundle. Update the operator's pinned eck-elasticsearch-operator version so operator-driven (GA) installs deploy the 3.4.0 image. CRDs (AutoOpsAgentPolicy, PackageRegistry) and their RBAC were already added for the v3.3.0 upgrade; v3.4.0 introduces no new CRDs.

Regenerated pkg/components/enterprise.go via `make gen-versions`.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
Bump ECK operator from 3.3.2 to 3.4.0
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
