### PR TITLE
[release-v1.43] Bump ECK operator 3.3.2 -> 3.4.0

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -74,7 +74,7 @@ components:
   # eck-elasticsearch-operator holds the version of the ECK operator used to manage
   # Elasticsearch
   eck-elasticsearch-operator:
-    version: 3.3.2
+    version: 3.4.0
   gateway-l7-collector:
     image: gateway-l7-collector
     version: release-calient-v3.24-1

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -71,7 +71,7 @@ var (
 	}
 
 	ComponentECKElasticsearchOperator = Component{
-		Version: "3.3.2",
+		Version: "3.4.0",
 		variant: enterpriseVariant,
 	}
 


### PR DESCRIPTION
**Release note:**
```release-note
Bump ECK operator from 3.3.2 to 3.4.0
```

### Description

Bumps the pinned ECK Elasticsearch operator version to `3.4.0` on `release-v1.43`, to match calico-private `release-calient-v3.24-1` (PR tigera/calico-private#12409).

Base `release-v1.43` already carries `3.3.2` (via #4926), so this PR is now the `3.3.2 -> 3.4.0` step (rebased onto current base).

- `pkg/components/enterprise.go`: `ComponentECKElasticsearchOperator` -> 3.4.0
- `config/enterprise_versions.yml`: `eck-elasticsearch-operator` -> 3.4.0

`v3.4.0` introduces no new CRDs (their RBAC was added for the v3.3.0 upgrade).

### Type
- [x] Dependency bump (backport)
