### PR TITLE
Set explicit order on the whisker network policy

### DIFF
--- a/pkg/render/whisker/component.go
+++ b/pkg/render/whisker/component.go
@@ -282,6 +282,7 @@ func (c *Component) networkPolicy() *v3.NetworkPolicy {
 		TypeMeta:   metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"},
 		ObjectMeta: metav1.ObjectMeta{Name: WhiskerPolicyName, Namespace: WhiskerNamespace},
 		Spec: v3.NetworkPolicySpec{
+			Order:    &networkpolicy.HighPrecedenceOrder,
 			Tier:     networkpolicy.CalicoTierName,
 			Types:    []v3.PolicyType{v3.PolicyTypeIngress, v3.PolicyTypeEgress},
 			Selector: networkpolicy.KubernetesAppSelector(WhiskerDeploymentName),


### PR DESCRIPTION
## Description

Whisker was the only policy in the calico-system tier without an explicit order. Every other component policy in the tier sets `order: 1`, so this just brings whisker in line. No behavior change - the implicit end-of-tier deny is still the backstop - but it makes the rendered policy set consistent and easier to reason about.

Related to #4772.

## Release Note

```release-note
NONE
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
