### PR TITLE
[release-v1.43] Bump Elasticsearch and Kibana to 8.19.17

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -26,13 +26,13 @@ components:
     version: release-calient-v3.24-1
   # eck-kibana holds the version of Kibana built for tigera/kibana
   eck-kibana:
-    version: 8.19.16
+    version: 8.19.17
   kibana:
     image: kibana
     version: release-calient-v3.24-1
   # eck-elasticsearch holds the version of Elasticsearch built for tigera/elasticsearch
   eck-elasticsearch:
-    version: 8.19.16
+    version: 8.19.17
   elasticsearch:
     image: elasticsearch
     version: release-calient-v3.24-1

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -45,12 +45,12 @@ var (
 	}
 
 	ComponentEckElasticsearch = Component{
-		Version: "8.19.16",
+		Version: "8.19.17",
 		variant: enterpriseVariant,
 	}
 
 	ComponentEckKibana = Component{
-		Version: "8.19.16",
+		Version: "8.19.17",
 		variant: enterpriseVariant,
 	}
 


### PR DESCRIPTION
**Release note:**
```release-note
Elasticsearch and Kibana are updated to the v8.19.17 release.
```

### Description

Bumps the pinned `ComponentEckElasticsearch` and `ComponentEckKibana` versions `8.19.16 -> 8.19.17` on `release-v1.43`, the operator branch for Calico Enterprise v3.24. Corresponds to calico-private `release-calient-v3.24-1` PR tigera/calico-private#12430.

- `config/enterprise_versions.yml`: `eck-elasticsearch` / `eck-kibana` -> 8.19.17
- `pkg/components/enterprise.go`: regenerated via `gen-versions`

### Type
- [x] Dependency bump
