### PR TITLE
[v3.24] fix(apiserver): grant WAF v3 RBAC to network-admin and ui-user roles

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1783,6 +1783,19 @@ func (c *apiServerComponent) tigeraUserClusterRole() *rbacv1.ClusterRole {
 			Resources: []string{"applicationlayers", "packetcaptureapis", "compliances", "intrusiondetections"},
 			Verbs:     []string{"get"},
 		},
+		// Allow the user to view WAF policies, plugins, and validation policies.
+		{
+			APIGroups: []string{"applicationlayer.projectcalico.org"},
+			Resources: []string{
+				"globalwafpolicies",
+				"globalwafplugins",
+				"globalwafvalidationpolicies",
+				"wafpolicies",
+				"wafplugins",
+				"wafvalidationpolicies",
+			},
+			Verbs: []string{"get", "watch", "list"},
+		},
 		{
 			APIGroups: []string{"apps"},
 			Resources: []string{"deployments"},
@@ -1985,6 +1998,19 @@ func (c *apiServerComponent) tigeraNetworkAdminClusterRole() *rbacv1.ClusterRole
 			APIGroups: []string{"operator.tigera.io"},
 			Resources: []string{"applicationlayers", "packetcaptureapis", "compliances", "intrusiondetections"},
 			Verbs:     []string{"get", "update", "patch", "create", "delete"},
+		},
+		// Allow the user to manage WAF policies, plugins, and validation policies.
+		{
+			APIGroups: []string{"applicationlayer.projectcalico.org"},
+			Resources: []string{
+				"globalwafpolicies",
+				"globalwafplugins",
+				"globalwafvalidationpolicies",
+				"wafpolicies",
+				"wafplugins",
+				"wafvalidationpolicies",
+			},
+			Verbs: []string{"create", "update", "delete", "patch", "get", "watch", "list"},
 		},
 		// Allow the user to read deployments to view WAF configuration.
 		{

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -1699,6 +1699,18 @@ var (
 			Verbs:     []string{"get"},
 		},
 		{
+			APIGroups: []string{"applicationlayer.projectcalico.org"},
+			Resources: []string{
+				"globalwafpolicies",
+				"globalwafplugins",
+				"globalwafvalidationpolicies",
+				"wafpolicies",
+				"wafplugins",
+				"wafvalidationpolicies",
+			},
+			Verbs: []string{"get", "watch", "list"},
+		},
+		{
 			APIGroups: []string{"apps"},
 			Resources: []string{"deployments"},
 			Verbs:     []string{"get", "list", "watch"},
@@ -1857,6 +1869,18 @@ var (
 			APIGroups: []string{"operator.tigera.io"},
 			Resources: []string{"applicationlayers", "packetcaptureapis", "compliances", "intrusiondetections"},
 			Verbs:     []string{"get", "update", "patch", "create", "delete"},
+		},
+		{
+			APIGroups: []string{"applicationlayer.projectcalico.org"},
+			Resources: []string{
+				"globalwafpolicies",
+				"globalwafplugins",
+				"globalwafvalidationpolicies",
+				"wafpolicies",
+				"wafplugins",
+				"wafvalidationpolicies",
+			},
+			Verbs: []string{"create", "update", "delete", "patch", "get", "watch", "list"},
 		},
 		{
 			APIGroups: []string{"apps"},


### PR DESCRIPTION
Cherry-pick of #4964.

## Description

Bug fix. The `tigera-network-admin` (Cluster Operator) and read-only `tigera-ui-user` ClusterRoles both granted the `operator.tigera.io/applicationlayers` toggle (enable/disable WAF) but had **no** rule for the `applicationlayer.projectcalico.org` WAF v3 resources. As a result, a user bound to `tigera-network-admin` could not create/manage — and a `tigera-ui-user` could not view — `GlobalWAFPolicy`, `GlobalWAFPlugin`, `GlobalWAFValidationPolicy`, or the namespaced `WAFPolicy`/`WAFPlugin`/`WAFValidationPolicy` resources.

This adds:
- `tigera-network-admin`: `create, update, delete, patch, get, watch, list` on the WAF v3 resources (mirrors the existing network policy grants).
- `tigera-ui-user`: `get, watch, list` (read-only parity).

**Components:** apiserver render (`pkg/render/apiserver.go`) — RBAC only. No API/CRD or version changes.

**Testing:** TDD (failing fixture first, then implementation). Full `pkg/render` unit suite passes: `546 Passed | 0 Failed`.

**Issue:** https://tigera.atlassian.net/browse/EV-6723

## Release Note

```release-note
Granted the tigera-network-admin and tigera-ui-user roles RBAC access to the WAF (applicationlayer.projectcalico.org) policy resources.
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files` (n/a — no API change)
- [ ] If changing versions, run `make gen-versions` (n/a — no version change)

## For PR reviewers

- [ ] Milestone set according to targeted release.
- [x] Appropriate labels:
  - `kind/bug` — bugfix.
  - `enterprise` — Calico Enterprise only.

