### PR TITLE
[release-v1.40] Bump ECK operator 2.16.1 -> 3.4.0

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -138,7 +138,7 @@ components:
     image: tigera/eck-operator
     version: v3.22.6
   eck-elasticsearch-operator:
-    version: 2.16.1
+    version: 3.4.0
   l7-collector:
     image: tigera/l7-collector
     version: v3.22.6

--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -2,7 +2,7 @@
 title: v3.22.6
 components:
   libcalico-go:
-    version: v3.22.6
+    version: release-calient-v3.22
   manager:
     image: tigera/manager
     version: v3.22.6

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -91,7 +91,7 @@ var (
 	}
 
 	ComponentECKElasticsearchOperator = Component{
-		Version:  "2.16.1",
+		Version:  "3.4.0",
 		Registry: "",
 	}
 

--- a/pkg/crds/enterprise/01-crd-eck-bundle.yaml
+++ b/pkg/crds/enterprise/01-crd-eck-bundle.yaml
@@ -1,14 +1,15 @@
+---
 # Source: eck-operator-crds/templates/all-crds.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.20.0
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '2.16.1'
+    app.kubernetes.io/version: '3.3.0'
   name: agents.agent.k8s.elastic.co
 spec:
   group: agent.k8s.elastic.co
@@ -496,12 +497,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.20.0
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '2.16.1'
+    app.kubernetes.io/version: '3.3.0'
   name: apmservers.apm.k8s.elastic.co
 spec:
   group: apm.k8s.elastic.co
@@ -1018,12 +1019,129 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.20.0
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '2.16.1'
+    app.kubernetes.io/version: '3.3.0'
+  name: autoopsagentpolicies.autoops.k8s.elastic.co
+spec:
+  group: autoops.k8s.elastic.co
+  names:
+    categories:
+      - elastic
+    kind: AutoOpsAgentPolicy
+    listKind: AutoOpsAgentPolicyList
+    plural: autoopsagentpolicies
+    shortNames:
+      - aop
+    singular: autoopsagentpolicy
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.ready
+          name: Ready
+          type: string
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                autoOpsRef:
+                  properties:
+                    secretName:
+                      type: string
+                  type: object
+                image:
+                  type: string
+                podTemplate:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                resourceSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                          - key
+                          - operator
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                  x-kubernetes-map-type: atomic
+                revisionHistoryLimit:
+                  format: int32
+                  type: integer
+                serviceAccountName:
+                  type: string
+                version:
+                  type: string
+              required:
+                - version
+              type: object
+            status:
+              properties:
+                errors:
+                  type: integer
+                observedGeneration:
+                  format: int64
+                  type: integer
+                phase:
+                  type: string
+                ready:
+                  type: integer
+                resources:
+                  type: integer
+              required:
+                - errors
+                - ready
+                - resources
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: eck-operator-crds/templates/all-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+    helm.sh/resource-policy: keep
+  labels:
+    app.kubernetes.io/instance: 'elastic-operator'
+    app.kubernetes.io/name: 'eck-operator-crds'
+    app.kubernetes.io/version: '3.3.0'
   name: beats.beat.k8s.elastic.co
 spec:
   group: beat.k8s.elastic.co
@@ -1257,12 +1375,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.20.0
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '2.16.1'
+    app.kubernetes.io/version: '3.3.0'
   name: elasticmapsservers.maps.k8s.elastic.co
 spec:
   group: maps.k8s.elastic.co
@@ -1514,12 +1632,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.20.0
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '2.16.1'
+    app.kubernetes.io/version: '3.3.0'
   name: elasticsearchautoscalers.autoscaling.k8s.elastic.co
 spec:
   group: autoscaling.k8s.elastic.co
@@ -1771,12 +1889,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.20.0
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '2.16.1'
+    app.kubernetes.io/version: '3.3.0'
   name: elasticsearches.elasticsearch.k8s.elastic.co
 spec:
   group: elasticsearch.k8s.elastic.co
@@ -2219,6 +2337,121 @@ spec:
                   properties:
                     enabled:
                       type: boolean
+                    service:
+                      properties:
+                        metadata:
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            finalizers:
+                              items:
+                                type: string
+                              type: array
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                        spec:
+                          properties:
+                            allocateLoadBalancerNodePorts:
+                              type: boolean
+                            clusterIP:
+                              type: string
+                            clusterIPs:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            externalIPs:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            externalName:
+                              type: string
+                            externalTrafficPolicy:
+                              type: string
+                            healthCheckNodePort:
+                              format: int32
+                              type: integer
+                            internalTrafficPolicy:
+                              type: string
+                            ipFamilies:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            ipFamilyPolicy:
+                              type: string
+                            loadBalancerClass:
+                              type: string
+                            loadBalancerIP:
+                              type: string
+                            loadBalancerSourceRanges:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            ports:
+                              items:
+                                properties:
+                                  appProtocol:
+                                    type: string
+                                  name:
+                                    type: string
+                                  nodePort:
+                                    format: int32
+                                    type: integer
+                                  port:
+                                    format: int32
+                                    type: integer
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                  targetPort:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                  - port
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - port
+                                - protocol
+                              x-kubernetes-list-type: map
+                            publishNotReadyAddresses:
+                              type: boolean
+                            selector:
+                              additionalProperties:
+                                type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            sessionAffinity:
+                              type: string
+                            sessionAffinityConfig:
+                              properties:
+                                clientIP:
+                                  properties:
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                              type: object
+                            trafficDistribution:
+                              type: string
+                            type:
+                              type: string
+                          type: object
+                      type: object
                   type: object
                 remoteClusters:
                   items:
@@ -3025,12 +3258,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.20.0
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '2.16.1'
+    app.kubernetes.io/version: '3.3.0'
   name: enterprisesearches.enterprisesearch.k8s.elastic.co
 spec:
   group: enterprisesearch.k8s.elastic.co
@@ -3503,12 +3736,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.20.0
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '2.16.1'
+    app.kubernetes.io/version: '3.3.0'
   name: kibanas.kibana.k8s.elastic.co
 spec:
   group: kibana.k8s.elastic.co
@@ -3753,6 +3986,17 @@ spec:
                           type: array
                       type: object
                   type: object
+                packageRegistryRef:
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    secretName:
+                      type: string
+                    serviceName:
+                      type: string
+                  type: object
                 podTemplate:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
@@ -3809,6 +4053,8 @@ spec:
                 observedGeneration:
                   format: int64
                   type: integer
+                packageRegistryAssociationStatus:
+                  type: string
                 selector:
                   type: string
                 version:
@@ -4058,12 +4304,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.20.0
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '2.16.1'
+    app.kubernetes.io/version: '3.3.0'
   name: logstashes.logstash.k8s.elastic.co
 spec:
   group: logstash.k8s.elastic.co
@@ -4601,12 +4847,254 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.20.0
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '2.16.1'
+    app.kubernetes.io/version: '3.3.0'
+  name: packageregistries.packageregistry.k8s.elastic.co
+spec:
+  group: packageregistry.k8s.elastic.co
+  names:
+    categories:
+      - elastic
+    kind: PackageRegistry
+    listKind: PackageRegistryList
+    plural: packageregistries
+    shortNames:
+      - epr
+    singular: packageregistry
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.health
+          name: health
+          type: string
+        - jsonPath: .status.availableNodes
+          name: nodes
+          type: integer
+        - jsonPath: .status.version
+          name: version
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                config:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                configRef:
+                  properties:
+                    secretName:
+                      type: string
+                  type: object
+                count:
+                  format: int32
+                  type: integer
+                http:
+                  properties:
+                    service:
+                      properties:
+                        metadata:
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            finalizers:
+                              items:
+                                type: string
+                              type: array
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                        spec:
+                          properties:
+                            allocateLoadBalancerNodePorts:
+                              type: boolean
+                            clusterIP:
+                              type: string
+                            clusterIPs:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            externalIPs:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            externalName:
+                              type: string
+                            externalTrafficPolicy:
+                              type: string
+                            healthCheckNodePort:
+                              format: int32
+                              type: integer
+                            internalTrafficPolicy:
+                              type: string
+                            ipFamilies:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            ipFamilyPolicy:
+                              type: string
+                            loadBalancerClass:
+                              type: string
+                            loadBalancerIP:
+                              type: string
+                            loadBalancerSourceRanges:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            ports:
+                              items:
+                                properties:
+                                  appProtocol:
+                                    type: string
+                                  name:
+                                    type: string
+                                  nodePort:
+                                    format: int32
+                                    type: integer
+                                  port:
+                                    format: int32
+                                    type: integer
+                                  protocol:
+                                    default: TCP
+                                    type: string
+                                  targetPort:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                  - port
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - port
+                                - protocol
+                              x-kubernetes-list-type: map
+                            publishNotReadyAddresses:
+                              type: boolean
+                            selector:
+                              additionalProperties:
+                                type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            sessionAffinity:
+                              type: string
+                            sessionAffinityConfig:
+                              properties:
+                                clientIP:
+                                  properties:
+                                    timeoutSeconds:
+                                      format: int32
+                                      type: integer
+                                  type: object
+                              type: object
+                            trafficDistribution:
+                              type: string
+                            type:
+                              type: string
+                          type: object
+                      type: object
+                    tls:
+                      properties:
+                        certificate:
+                          properties:
+                            secretName:
+                              type: string
+                          type: object
+                        selfSignedCertificate:
+                          properties:
+                            disabled:
+                              type: boolean
+                            subjectAltNames:
+                              items:
+                                properties:
+                                  dns:
+                                    type: string
+                                  ip:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                  type: object
+                image:
+                  type: string
+                podTemplate:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                revisionHistoryLimit:
+                  format: int32
+                  type: integer
+                version:
+                  type: string
+              required:
+                - version
+              type: object
+            status:
+              properties:
+                availableNodes:
+                  format: int32
+                  type: integer
+                count:
+                  format: int32
+                  type: integer
+                health:
+                  type: string
+                observedGeneration:
+                  format: int64
+                  type: integer
+                selector:
+                  type: string
+                version:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        scale:
+          labelSelectorPath: .status.selector
+          specReplicasPath: .spec.count
+          statusReplicasPath: .status.count
+        status: {}
+---
+# Source: eck-operator-crds/templates/all-crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+    helm.sh/resource-policy: keep
+  labels:
+    app.kubernetes.io/instance: 'elastic-operator'
+    app.kubernetes.io/name: 'eck-operator-crds'
+    app.kubernetes.io/version: '3.3.0'
   name: stackconfigpolicies.stackconfigpolicy.k8s.elastic.co
 spec:
   group: stackconfigpolicy.k8s.elastic.co
@@ -4631,6 +5119,9 @@ spec:
         - jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
+        - jsonPath: .spec.weight
+          name: Weight
+          type: integer
       name: v1alpha1
       schema:
         openAPIV3Schema:
@@ -4781,6 +5272,10 @@ spec:
                       - secretName
                     type: object
                   type: array
+                weight:
+                  default: 0
+                  format: int32
+                  type: integer
               type: object
             status:
               properties:

--- a/pkg/crds/enterprise/01-crd-eck-bundle.yaml
+++ b/pkg/crds/enterprise/01-crd-eck-bundle.yaml
@@ -4,12 +4,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.3.0'
+    app.kubernetes.io/version: '3.4.0'
   name: agents.agent.k8s.elastic.co
 spec:
   group: agent.k8s.elastic.co
@@ -497,12 +497,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.3.0'
+    app.kubernetes.io/version: '3.4.0'
   name: apmservers.apm.k8s.elastic.co
 spec:
   group: apm.k8s.elastic.co
@@ -1019,12 +1019,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.3.0'
+    app.kubernetes.io/version: '3.4.0'
   name: autoopsagentpolicies.autoops.k8s.elastic.co
 spec:
   group: autoops.k8s.elastic.co
@@ -1040,7 +1040,7 @@ spec:
   scope: Namespaced
   versions:
     - additionalPrinterColumns:
-        - jsonPath: .status.ready
+        - jsonPath: .status.readyCount
           name: Ready
           type: string
         - jsonPath: .status.phase
@@ -1068,6 +1068,32 @@ spec:
                   type: object
                 image:
                   type: string
+                namespaceSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                          - key
+                          - operator
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                  x-kubernetes-map-type: atomic
                 podTemplate:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
@@ -1109,6 +1135,19 @@ spec:
               type: object
             status:
               properties:
+                details:
+                  additionalProperties:
+                    properties:
+                      error:
+                        type: string
+                      message:
+                        type: string
+                      phase:
+                        type: string
+                    required:
+                      - phase
+                    type: object
+                  type: object
                 errors:
                   type: integer
                 observedGeneration:
@@ -1118,7 +1157,11 @@ spec:
                   type: string
                 ready:
                   type: integer
+                readyCount:
+                  type: string
                 resources:
+                  type: integer
+                skipped:
                   type: integer
               required:
                 - errors
@@ -1136,12 +1179,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.3.0'
+    app.kubernetes.io/version: '3.4.0'
   name: beats.beat.k8s.elastic.co
 spec:
   group: beat.k8s.elastic.co
@@ -1375,12 +1418,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.3.0'
+    app.kubernetes.io/version: '3.4.0'
   name: elasticmapsservers.maps.k8s.elastic.co
 spec:
   group: maps.k8s.elastic.co
@@ -1632,12 +1675,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.3.0'
+    app.kubernetes.io/version: '3.4.0'
   name: elasticsearchautoscalers.autoscaling.k8s.elastic.co
 spec:
   group: autoscaling.k8s.elastic.co
@@ -1889,12 +1932,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.3.0'
+    app.kubernetes.io/version: '3.4.0'
   name: elasticsearches.elasticsearch.k8s.elastic.co
 spec:
   group: elasticsearch.k8s.elastic.co
@@ -2079,6 +2122,11 @@ spec:
                           properties:
                             secretName:
                               type: string
+                          type: object
+                        client:
+                          properties:
+                            authentication:
+                              type: boolean
                           type: object
                         selfSignedCertificate:
                           properties:
@@ -2265,6 +2313,17 @@ spec:
                               type: object
                           type: object
                         type: array
+                      zoneAwareness:
+                        properties:
+                          topologyKey:
+                            type: string
+                          zones:
+                            items:
+                              type: string
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-type: set
+                        type: object
                     required:
                       - name
                     type: object
@@ -3258,12 +3317,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.3.0'
+    app.kubernetes.io/version: '3.4.0'
   name: enterprisesearches.enterprisesearch.k8s.elastic.co
 spec:
   group: enterprisesearch.k8s.elastic.co
@@ -3736,12 +3795,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.3.0'
+    app.kubernetes.io/version: '3.4.0'
   name: kibanas.kibana.k8s.elastic.co
 spec:
   group: kibana.k8s.elastic.co
@@ -3789,6 +3848,8 @@ spec:
                   type: integer
                 elasticsearchRef:
                   properties:
+                    clientCertificateSecretName:
+                      type: string
                     name:
                       type: string
                     namespace:
@@ -3991,8 +4052,6 @@ spec:
                     name:
                       type: string
                     namespace:
-                      type: string
-                    secretName:
                       type: string
                     serviceName:
                       type: string
@@ -4304,12 +4363,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.3.0'
+    app.kubernetes.io/version: '3.4.0'
   name: logstashes.logstash.k8s.elastic.co
 spec:
   group: logstash.k8s.elastic.co
@@ -4847,12 +4906,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.3.0'
+    app.kubernetes.io/version: '3.4.0'
   name: packageregistries.packageregistry.k8s.elastic.co
 spec:
   group: packageregistry.k8s.elastic.co
@@ -5089,12 +5148,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.3.0'
+    app.kubernetes.io/version: '3.4.0'
   name: stackconfigpolicies.stackconfigpolicy.k8s.elastic.co
 spec:
   group: stackconfigpolicy.k8s.elastic.co

--- a/pkg/render/logstorage/eck/eck.go
+++ b/pkg/render/logstorage/eck/eck.go
@@ -216,6 +216,16 @@ func (e *eck) operatorClusterRole() *rbacv1.ClusterRole {
 			Verbs:     []string{"get", "list", "watch", "create", "update", "patch"},
 		},
 		{
+			APIGroups: []string{"autoops.k8s.elastic.co"},
+			Resources: []string{"autoopsagentpolicies", "autoopsagentpolicies/status", "autoopsagentpolicies/finalizers"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+		{
+			APIGroups: []string{"packageregistry.k8s.elastic.co"},
+			Resources: []string{"packageregistries", "packageregistries/status", "packageregistries/finalizers"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+		{
 			APIGroups: []string{"storage.k8s.io"},
 			Resources: []string{"storageclasses"},
 			Verbs:     []string{"get", "list", "watch"},

--- a/pkg/render/logstorage/eck/eck_test.go
+++ b/pkg/render/logstorage/eck/eck_test.go
@@ -218,6 +218,16 @@ var _ = Describe("ECK rendering tests", func() {
 					Verbs:     []string{"get", "list", "watch", "create", "update", "patch"},
 				},
 				{
+					APIGroups: []string{"autoops.k8s.elastic.co"},
+					Resources: []string{"autoopsagentpolicies", "autoopsagentpolicies/status", "autoopsagentpolicies/finalizers"},
+					Verbs:     []string{"get", "list", "watch"},
+				},
+				{
+					APIGroups: []string{"packageregistry.k8s.elastic.co"},
+					Resources: []string{"packageregistries", "packageregistries/status", "packageregistries/finalizers"},
+					Verbs:     []string{"get", "list", "watch"},
+				},
+				{
 					APIGroups: []string{"storage.k8s.io"},
 					Resources: []string{"storageclasses"},
 					Verbs:     []string{"get", "list", "watch"},


### PR DESCRIPTION
**Release note:**
```release-note
The ECK operator is updated to v3.4.0.
```

### Description
Pins `ComponentECKElasticsearchOperator` to `3.4.0` on `release-v1.40` (operator branch for CE v3.22), matching calico-private release-calient-v3.22.

- `config/enterprise_versions.yml`: `eck-elasticsearch-operator` -> 3.4.0
- `pkg/components/enterprise.go`: regenerated via `gen-versions`

### Type
- [x] Dependency bump
