### PR TITLE
fix(applicationlayer): run dikastes from combined calico binary

### DIFF
--- a/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_bgpconfigurations.yaml
+++ b/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_bgpconfigurations.yaml
@@ -11,7 +11,6 @@ spec:
     listKind: BGPConfigurationList
     plural: bgpconfigurations
     singular: bgpconfiguration
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - name: v1

--- a/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_bgpfilters.yaml
+++ b/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_bgpfilters.yaml
@@ -11,7 +11,6 @@ spec:
     listKind: BGPFilterList
     plural: bgpfilters
     singular: bgpfilter
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - name: v1

--- a/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_bgppeers.yaml
+++ b/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_bgppeers.yaml
@@ -11,7 +11,6 @@ spec:
     listKind: BGPPeerList
     plural: bgppeers
     singular: bgppeer
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - name: v1

--- a/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_blockaffinities.yaml
+++ b/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_blockaffinities.yaml
@@ -11,7 +11,6 @@ spec:
     listKind: BlockAffinityList
     plural: blockaffinities
     singular: blockaffinity
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - name: v1

--- a/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_caliconodestatuses.yaml
+++ b/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_caliconodestatuses.yaml
@@ -11,7 +11,6 @@ spec:
     listKind: CalicoNodeStatusList
     plural: caliconodestatuses
     singular: caliconodestatus
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - name: v1

--- a/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_clusterinformations.yaml
+++ b/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_clusterinformations.yaml
@@ -11,7 +11,6 @@ spec:
     listKind: ClusterInformationList
     plural: clusterinformations
     singular: clusterinformation
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - name: v1

--- a/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_felixconfigurations.yaml
@@ -11,7 +11,6 @@ spec:
     listKind: FelixConfigurationList
     plural: felixconfigurations
     singular: felixconfiguration
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - name: v1

--- a/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_globalnetworkpolicies.yaml
+++ b/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_globalnetworkpolicies.yaml
@@ -11,7 +11,6 @@ spec:
     listKind: GlobalNetworkPolicyList
     plural: globalnetworkpolicies
     singular: globalnetworkpolicy
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - name: v1

--- a/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_globalnetworksets.yaml
+++ b/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_globalnetworksets.yaml
@@ -11,7 +11,6 @@ spec:
     listKind: GlobalNetworkSetList
     plural: globalnetworksets
     singular: globalnetworkset
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - name: v1

--- a/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_hostendpoints.yaml
+++ b/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_hostendpoints.yaml
@@ -11,7 +11,6 @@ spec:
     listKind: HostEndpointList
     plural: hostendpoints
     singular: hostendpoint
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - name: v1

--- a/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_ipamblocks.yaml
+++ b/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_ipamblocks.yaml
@@ -11,7 +11,6 @@ spec:
     listKind: IPAMBlockList
     plural: ipamblocks
     singular: ipamblock
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - name: v1

--- a/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_ipamconfigs.yaml
+++ b/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_ipamconfigs.yaml
@@ -11,7 +11,6 @@ spec:
     listKind: IPAMConfigList
     plural: ipamconfigs
     singular: ipamconfig
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - name: v1

--- a/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_ipamhandles.yaml
+++ b/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_ipamhandles.yaml
@@ -11,7 +11,6 @@ spec:
     listKind: IPAMHandleList
     plural: ipamhandles
     singular: ipamhandle
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - name: v1

--- a/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_ippools.yaml
+++ b/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_ippools.yaml
@@ -11,7 +11,6 @@ spec:
     listKind: IPPoolList
     plural: ippools
     singular: ippool
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - name: v1

--- a/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_ipreservations.yaml
+++ b/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_ipreservations.yaml
@@ -11,7 +11,6 @@ spec:
     listKind: IPReservationList
     plural: ipreservations
     singular: ipreservation
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - name: v1

--- a/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_kubecontrollersconfigurations.yaml
+++ b/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_kubecontrollersconfigurations.yaml
@@ -11,7 +11,6 @@ spec:
     listKind: KubeControllersConfigurationList
     plural: kubecontrollersconfigurations
     singular: kubecontrollersconfiguration
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - name: v1

--- a/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_networkpolicies.yaml
+++ b/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_networkpolicies.yaml
@@ -11,7 +11,6 @@ spec:
     listKind: NetworkPolicyList
     plural: networkpolicies
     singular: networkpolicy
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
     - name: v1

--- a/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_networksets.yaml
+++ b/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_networksets.yaml
@@ -11,7 +11,6 @@ spec:
     listKind: NetworkSetList
     plural: networksets
     singular: networkset
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
     - name: v1

--- a/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_stagedglobalnetworkpolicies.yaml
+++ b/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_stagedglobalnetworkpolicies.yaml
@@ -11,7 +11,6 @@ spec:
     listKind: StagedGlobalNetworkPolicyList
     plural: stagedglobalnetworkpolicies
     singular: stagedglobalnetworkpolicy
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - name: v1

--- a/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_stagedkubernetesnetworkpolicies.yaml
+++ b/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_stagedkubernetesnetworkpolicies.yaml
@@ -11,7 +11,6 @@ spec:
     listKind: StagedKubernetesNetworkPolicyList
     plural: stagedkubernetesnetworkpolicies
     singular: stagedkubernetesnetworkpolicy
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
     - name: v1

--- a/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_stagednetworkpolicies.yaml
+++ b/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_stagednetworkpolicies.yaml
@@ -11,7 +11,6 @@ spec:
     listKind: StagedNetworkPolicyList
     plural: stagednetworkpolicies
     singular: stagednetworkpolicy
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
     - name: v1

--- a/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_tiers.yaml
+++ b/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_tiers.yaml
@@ -11,7 +11,6 @@ spec:
     listKind: TierList
     plural: tiers
     singular: tier
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - name: v1

--- a/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_bgpconfigurations.yaml
+++ b/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_bgpconfigurations.yaml
@@ -14,7 +14,6 @@ spec:
       - bgpconfig
       - bgpconfigs
     singular: bgpconfiguration
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - name: v3

--- a/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_bgpfilters.yaml
+++ b/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_bgpfilters.yaml
@@ -11,7 +11,6 @@ spec:
     listKind: BGPFilterList
     plural: bgpfilters
     singular: bgpfilter
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - name: v3

--- a/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_bgppeers.yaml
+++ b/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_bgppeers.yaml
@@ -11,7 +11,6 @@ spec:
     listKind: BGPPeerList
     plural: bgppeers
     singular: bgppeer
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - additionalPrinterColumns:

--- a/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_blockaffinities.yaml
+++ b/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_blockaffinities.yaml
@@ -14,7 +14,6 @@ spec:
       - affinity
       - affinities
     singular: blockaffinity
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - additionalPrinterColumns:

--- a/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_caliconodestatuses.yaml
+++ b/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_caliconodestatuses.yaml
@@ -11,7 +11,6 @@ spec:
     listKind: CalicoNodeStatusList
     plural: caliconodestatuses
     singular: caliconodestatus
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - additionalPrinterColumns:

--- a/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_clusterinformations.yaml
+++ b/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_clusterinformations.yaml
@@ -14,7 +14,6 @@ spec:
       - clusterinfo
       - clusterinfos
     singular: clusterinformation
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - additionalPrinterColumns:

--- a/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_felixconfigurations.yaml
+++ b/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_felixconfigurations.yaml
@@ -11,7 +11,6 @@ spec:
     listKind: FelixConfigurationList
     plural: felixconfigurations
     singular: felixconfiguration
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - name: v3

--- a/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_globalnetworkpolicies.yaml
+++ b/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_globalnetworkpolicies.yaml
@@ -14,7 +14,6 @@ spec:
       - gnp
       - cgnp
     singular: globalnetworkpolicy
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - additionalPrinterColumns:

--- a/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_globalnetworksets.yaml
+++ b/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_globalnetworksets.yaml
@@ -13,7 +13,6 @@ spec:
     shortNames:
       - gns
     singular: globalnetworkset
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - additionalPrinterColumns:

--- a/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_hostendpoints.yaml
+++ b/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_hostendpoints.yaml
@@ -14,7 +14,6 @@ spec:
       - hep
       - heps
     singular: hostendpoint
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - additionalPrinterColumns:

--- a/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_ipamblocks.yaml
+++ b/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_ipamblocks.yaml
@@ -11,7 +11,6 @@ spec:
     listKind: IPAMBlockList
     plural: ipamblocks
     singular: ipamblock
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - additionalPrinterColumns:

--- a/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_ipamconfigurations.yaml
+++ b/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_ipamconfigurations.yaml
@@ -14,7 +14,6 @@ spec:
       - ipamconfig
       - ipamconfigs
     singular: ipamconfiguration
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - additionalPrinterColumns:

--- a/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_ipamhandles.yaml
+++ b/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_ipamhandles.yaml
@@ -11,7 +11,6 @@ spec:
     listKind: IPAMHandleList
     plural: ipamhandles
     singular: ipamhandle
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - additionalPrinterColumns:

--- a/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_ippools.yaml
+++ b/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_ippools.yaml
@@ -11,7 +11,6 @@ spec:
     listKind: IPPoolList
     plural: ippools
     singular: ippool
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - additionalPrinterColumns:

--- a/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_ipreservations.yaml
+++ b/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_ipreservations.yaml
@@ -11,7 +11,6 @@ spec:
     listKind: IPReservationList
     plural: ipreservations
     singular: ipreservation
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - name: v3

--- a/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_kubecontrollersconfigurations.yaml
+++ b/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_kubecontrollersconfigurations.yaml
@@ -14,7 +14,6 @@ spec:
       - kcc
       - kccs
     singular: kubecontrollersconfiguration
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - name: v3

--- a/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_networkpolicies.yaml
+++ b/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_networkpolicies.yaml
@@ -14,7 +14,6 @@ spec:
       - cnp
       - caliconetworkpolicy
     singular: networkpolicy
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
     - additionalPrinterColumns:

--- a/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_networksets.yaml
+++ b/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_networksets.yaml
@@ -11,7 +11,6 @@ spec:
     listKind: NetworkSetList
     plural: networksets
     singular: networkset
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
     - name: v3

--- a/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_stagedglobalnetworkpolicies.yaml
+++ b/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_stagedglobalnetworkpolicies.yaml
@@ -13,7 +13,6 @@ spec:
     shortNames:
       - sgnp
     singular: stagedglobalnetworkpolicy
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - additionalPrinterColumns:

--- a/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_stagedkubernetesnetworkpolicies.yaml
+++ b/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_stagedkubernetesnetworkpolicies.yaml
@@ -13,7 +13,6 @@ spec:
     shortNames:
       - sknp
     singular: stagedkubernetesnetworkpolicy
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
     - name: v3

--- a/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_stagednetworkpolicies.yaml
+++ b/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_stagednetworkpolicies.yaml
@@ -14,7 +14,6 @@ spec:
       - scnp
       - snp
     singular: stagednetworkpolicy
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
     - additionalPrinterColumns:

--- a/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_tiers.yaml
+++ b/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_tiers.yaml
@@ -11,7 +11,6 @@ spec:
     listKind: TierList
     plural: tiers
     singular: tier
-  preserveUnknownFields: false
   scope: Cluster
   versions:
     - additionalPrinterColumns:

--- a/pkg/imports/crds/enterprise/v1.crd.projectcalico.org/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/imports/crds/enterprise/v1.crd.projectcalico.org/crd.projectcalico.org_felixconfigurations.yaml
@@ -1397,12 +1397,14 @@ spec:
                     - Disabled
                   type: string
                 istioDSCPMark:
+                  anyOf:
+                    - type: integer
+                    - type: string
                   description: |-
                     IstioDSCPMark sets the value to use when directing traffic to Istio ZTunnel, when Istio is enabled. The mark is set only on
                     SYN packets at the final hop to avoid interference with other protocols. This value is reserved by Calico and must not be used
                     with other Istio installation. [Default: 23]
                   pattern: ^.*
-                  type: integer
                   x-kubernetes-int-or-string: true
                 kubeMasqueradeBit:
                   description: |-

--- a/pkg/imports/crds/enterprise/v1.crd.projectcalico.org/crd.projectcalico.org_ipamblocks.yaml
+++ b/pkg/imports/crds/enterprise/v1.crd.projectcalico.org/crd.projectcalico.org_ipamblocks.yaml
@@ -54,10 +54,8 @@ spec:
                     For non-nil entries at index i, the index is the ordinal of the allocation within this block
                     and the value is the index of the associated attributes in the Attributes array.
                   items:
-                    type: integer
-                    # TODO: This nullable is manually added in. We should update controller-gen
-                    # to handle []*int properly itself.
                     nullable: true
+                    type: integer
                   type: array
                 attributes:
                   description: |-

--- a/pkg/imports/crds/enterprise/v3.projectcalico.org/projectcalico.org_felixconfigurations.yaml
+++ b/pkg/imports/crds/enterprise/v3.projectcalico.org/projectcalico.org_felixconfigurations.yaml
@@ -1396,12 +1396,14 @@ spec:
                     - Disabled
                   type: string
                 istioDSCPMark:
+                  anyOf:
+                    - type: integer
+                    - type: string
                   description: |-
                     IstioDSCPMark sets the value to use when directing traffic to Istio ZTunnel, when Istio is enabled. The mark is set only on
                     SYN packets at the final hop to avoid interference with other protocols. This value is reserved by Calico and must not be used
                     with other Istio installation. [Default: 23]
                   pattern: ^.*
-                  type: integer
                   x-kubernetes-int-or-string: true
                 kubeMasqueradeBit:
                   description: |-

--- a/pkg/imports/crds/enterprise/v3.projectcalico.org/projectcalico.org_ipamblocks.yaml
+++ b/pkg/imports/crds/enterprise/v3.projectcalico.org/projectcalico.org_ipamblocks.yaml
@@ -69,10 +69,8 @@ spec:
                     For non-nil entries at index i, the index is the ordinal of the allocation within this block
                     and the value is the index of the associated attributes in the Attributes array.
                   items:
-                    type: integer
-                    # TODO: This nullable is manually added in. We should update controller-gen
-                    # to handle []*int properly itself.
                     nullable: true
+                    type: integer
                   type: array
                   x-kubernetes-list-type: atomic
                 attributes:

--- a/pkg/render/applicationlayer/applicationlayer.go
+++ b/pkg/render/applicationlayer/applicationlayer.go
@@ -301,7 +301,7 @@ func (c *component) containers() []corev1.Container {
 		// Web Application Firewall (WAF) and ApplicationLayer Policies (ALP) specific container
 
 		commandArgs := []string{
-			"/dikastes",
+			components.CalicoBinaryPath, "component", "dikastes",
 			"server",
 			"--dial", "/var/run/felix/nodeagent/socket",
 			"--listen", "/var/run/dikastes/dikastes.sock",

--- a/pkg/render/applicationlayer/applicationlayer_test.go
+++ b/pkg/render/applicationlayer/applicationlayer_test.go
@@ -286,6 +286,16 @@ var _ = Describe("Tigera Secure Application Layer rendering tests", func() {
 		container = test.GetContainer(ds.Spec.Template.Spec.Containers, "dikastes")
 		Expect(container).NotTo(BeNil())
 		Expect(container.Resources).To(Equal(l7LogCollectorResources))
+		// dikastes runs from the combined "calico" binary, not a top-level /dikastes.
+		Expect(container.Command).To(Equal([]string{
+			"/usr/bin/calico", "component", "dikastes",
+			"server",
+			"--dial", "/var/run/felix/nodeagent/socket",
+			"--listen", "/var/run/dikastes/dikastes.sock",
+			"--waf-ruleset-root-dir", "/etc/waf",
+			"--waf-ruleset-file", "tigera.conf",
+			"--per-host-waf-enabled",
+		}))
 
 	})
 


### PR DESCRIPTION
## Description

This is a bug fix for Calico Enterprise.

Companion fix: https://github.com/tigera/calico-private/pull/12462 fixes the same root cause in the L7 sidecar webhook (`/dikastes init-sidecar`). The two are coordinated. This operator change fixes the per-host l7-log-collector DaemonSet, which serves the ext_authz socket the injected sidecar talks to, so both are needed for sidecar-injection mode.

The `l7-log-collector` DaemonSet has a `dikastes` container. It still ran the old top-level `/dikastes` binary. But the dikastes image was rebuilt around the combined `calico` binary. Its entrypoint is now `/usr/bin/calico component dikastes`, and `/dikastes` is gone. So the container crash-looped:

```
exec: "/dikastes": stat /dikastes: no such file or directory: unknown
```

That one failure took down all three L7 features at once: WAF, Application Layer Policy, and L7 HTTP logs. It showed up as failing L7 test cases on the 3.24-EP1 hashrelease. The sibling `l7-collector` container was already moved to the new binary (`/usr/bin/calico component l7-collector`). Only the dikastes command was missed.

The fix renders the dikastes command through the combined binary, the same way `l7-collector` does. No image change is needed. The `tigera/dikastes` image already ships the combined binary plus everything dikastes needs at runtime: iptables and nft, the WAF rulesets, and the GeoIP database. Only the command was stale.

Affected code: `pkg/render/applicationlayer` (WAF, ALP, and L7 logs).

Testing:

- Unit: I added a `Command` check on the dikastes container in `applicationlayer_test.go`. `go test ./pkg/render/applicationlayer/` passes.
- Manual: on a 3.24-EP1 cluster I patched the live DaemonSet to use the new command against the same image. All `l7-log-collector` pods went to `2/2 Running` with zero restarts. The dikastes log showed "connected and in sync with policy server" and registered the coraza (WAF) and application-layer-policy (ALP) providers.

## Release Note

```release-note
NONE
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.

