### PR TITLE
Grant kube-controllers patch permission on tiers

### DIFF
--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -449,10 +449,11 @@ func kubeControllersRoleCommonRules(cfg *KubeControllersConfiguration) []rbacv1.
 		},
 		{
 			// calico-kube-controllers requires tiers create to create the default tiers,
-			// and get permissions to access network policies in those tiers.
+			// and get permissions to access network policies in those tiers. It also
+			// patches tiers to add and remove its finalizer.
 			APIGroups: []string{"projectcalico.org", "crd.projectcalico.org"},
 			Resources: []string{"tiers"},
-			Verbs:     []string{"create", "update", "get", "list", "watch"},
+			Verbs:     []string{"create", "update", "patch", "get", "list", "watch"},
 		},
 		{
 			// Namespaces are watched for LoadBalancer IP allocation with namespace selector support

--- a/pkg/render/kubecontrollers/kube-controllers_test.go
+++ b/pkg/render/kubecontrollers/kube-controllers_test.go
@@ -188,6 +188,15 @@ var _ = Describe("kube-controllers rendering tests", func() {
 			i++
 		}
 
+		// The tier controller patches tiers to add and remove its finalizer, so
+		// the role must grant patch in addition to update.
+		clusterRole := rtest.GetResource(resources, kubecontrollers.KubeControllerRole, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
+		Expect(clusterRole.Rules).To(ContainElement(rbacv1.PolicyRule{
+			APIGroups: []string{"projectcalico.org", "crd.projectcalico.org"},
+			Resources: []string{"tiers"},
+			Verbs:     []string{"create", "update", "patch", "get", "list", "watch"},
+		}))
+
 		// The Deployment should have the correct configuration.
 		ds := rtest.GetResource(resources, kubecontrollers.KubeController, common.CalicoNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
 		Expect(ds.Spec.Template.Spec.Containers).To(HaveLen(1))


### PR DESCRIPTION
## Description

calico-kube-controllers is switching to a merge patch, rather than a full update, when it adds and removes the tier finalizer (see projectcalico/calico#13082). The ClusterRole grants `update` on tiers but not `patch`, and those are distinct RBAC verbs, so the patch would be rejected in operator-managed clusters. This adds `patch` to the tiers rule.

Related: projectcalico/calico#13082

## Release Note

```release-note
Grant calico-kube-controllers permission to patch tiers.
```
