### PR TITLE
[v3.24] fix(applicationlayer): run dikastes from combined calico binary

### DIFF
--- a/pkg/render/applicationlayer/applicationlayer.go
+++ b/pkg/render/applicationlayer/applicationlayer.go
@@ -301,7 +301,7 @@ func (c *component) containers() []corev1.Container {
 		// Web Application Firewall (WAF) and ApplicationLayer Policies (ALP) specific container
 
 		commandArgs := []string{
-			"/dikastes",
+			components.CalicoBinaryPath, "component", "dikastes",
 			"server",
 			"--dial", "/var/run/felix/nodeagent/socket",
 			"--listen", "/var/run/dikastes/dikastes.sock",

--- a/pkg/render/applicationlayer/applicationlayer_test.go
+++ b/pkg/render/applicationlayer/applicationlayer_test.go
@@ -287,6 +287,16 @@ var _ = Describe("Tigera Secure Application Layer rendering tests", func() {
 		container = test.GetContainer(ds.Spec.Template.Spec.Containers, "dikastes")
 		Expect(container).NotTo(BeNil())
 		Expect(container.Resources).To(Equal(l7LogCollectorResources))
+		// dikastes runs from the combined "calico" binary, not a top-level /dikastes.
+		Expect(container.Command).To(Equal([]string{
+			"/usr/bin/calico", "component", "dikastes",
+			"server",
+			"--dial", "/var/run/felix/nodeagent/socket",
+			"--listen", "/var/run/dikastes/dikastes.sock",
+			"--waf-ruleset-root-dir", "/etc/waf",
+			"--waf-ruleset-file", "tigera.conf",
+			"--per-host-waf-enabled",
+		}))
 
 	})
 


### PR DESCRIPTION
Cherry-pick of #4971.

## Description

This is a bug fix for Calico Enterprise.

Companion fix: https://github.com/tigera/calico-private/pull/12462 fixes the same root cause in the L7 sidecar webhook (`/dikastes init-sidecar`). The two are coordinated. This operator change fixes the per-host l7-log-collector DaemonSet, which serves the ext_authz socket the injected sidecar talks to, so both are needed for sidecar-injection mode.

The `l7-log-collector` DaemonSet has a `dikastes` container. It still ran the old top-level `/dikastes` binary. But the dikastes image was rebuilt around the combined `calico` binary. Its entrypoint is now `/usr/bin/calico component dikastes`, and `/dikastes` is gone. So the container crash-looped:

```
exec: "/dikastes": stat /dikastes: no such file or directory: unknown
```

That one failure took down all three L7 features at once: WAF, Application Layer Policy, and L7 HTTP logs. It showed up as failing L7 test cases on the 3.24-EP1 hashrelease. The sibling `l7-collector` container was already moved to the new binary (`/usr/bin/calico component l7-collector`). Only the dikastes command was missed.

The fix renders the dikastes command through the combined binary, the same way `l7-collector` does. No image change is needed. The `tigera/dikastes` image already ships the combined binary plus everything dikastes needs at runtime: iptables and nft, the WAF rulesets, and the GeoIP database. Only the command was stale.

Affected code: `pkg/render/applicationlayer` (WAF, ALP, and L7 logs).

Testing:

- Unit: I added a `Command` check on the dikastes container in `applicationlayer_test.go`. `go test ./pkg/render/applicationlayer/` passes.
- Manual: on a 3.24-EP1 cluster I patched the live DaemonSet to use the new command against the same image. All `l7-log-collector` pods went to `2/2 Running` with zero restarts. The dikastes log showed "connected and in sync with policy server" and registered the coraza (WAF) and application-layer-policy (ALP) providers.

## Release Note

```release-note
NONE
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.


