### PR TITLE
feat(gatewayapi): add gatewayAPIChannel for Gateway API CRD channel selection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,14 +247,25 @@ $(ISTIO_RESOURCES_DIR)/%.tgz:
 # To update the Envoy Gateway version, see "Updating the bundled version of
 # Envoy Gateway" in docs/common_tasks.md.
 ENVOY_GATEWAY_HELM_CHART ?= oci://docker.io/envoyproxy/gateway-helm
+ENVOY_GATEWAY_CRDS_HELM_CHART ?= oci://docker.io/envoyproxy/gateway-crds-helm
 ENVOY_GATEWAY_VERSION ?= v1.8.0
 ENVOY_GATEWAY_CHART = pkg/render/gatewayapi/gateway-helm.tgz
+ENVOY_GATEWAY_CRDS_CHART = pkg/render/gatewayapi/gateway-crds-helm.tgz
 
 $(ENVOY_GATEWAY_CHART): $(HACK_BIN)/helm-$(BUILDARCH)
 	$(HELM_BUILDARCH_BINARY) pull $(ENVOY_GATEWAY_HELM_CHART) \
 		--version $(ENVOY_GATEWAY_VERSION) \
 		--destination pkg/render/gatewayapi/
 	@mv pkg/render/gatewayapi/gateway-helm-$(ENVOY_GATEWAY_VERSION).tgz $@
+
+# gateway-crds-helm provides the Gateway API + Envoy Gateway CRDs and, unlike gateway-helm,
+# supports channel selection (standard|experimental).  The operator renders it to install CRDs
+# for the channel chosen via GatewayAPI.spec.gatewayAPIChannel.
+$(ENVOY_GATEWAY_CRDS_CHART): $(HACK_BIN)/helm-$(BUILDARCH)
+	$(HELM_BUILDARCH_BINARY) pull $(ENVOY_GATEWAY_CRDS_HELM_CHART) \
+		--version $(ENVOY_GATEWAY_VERSION) \
+		--destination pkg/render/gatewayapi/
+	@mv pkg/render/gatewayapi/gateway-crds-helm-$(ENVOY_GATEWAY_VERSION).tgz $@
 
 $(HELM_BUILDARCH_BINARY): $(HELM_BUILDARCH_VERSIONED_BINARY)
 	$(info ░▒▓ symlink $(HELM_BUILDARCH_VERSIONED_BINARY) -> $(HELM_BUILDARCH_BINARY))
@@ -268,7 +279,7 @@ $(HELM_BUILDARCH_VERSIONED_BINARY): | $(HACK_BIN)
 
 
 build: $(BINDIR)/operator-$(ARCH)
-$(BINDIR)/operator-$(ARCH): $(SRC_FILES) $(ENVOY_GATEWAY_CHART) $(ISTIO_CHART_FILES)
+$(BINDIR)/operator-$(ARCH): $(SRC_FILES) $(ENVOY_GATEWAY_CHART) $(ENVOY_GATEWAY_CRDS_CHART) $(ISTIO_CHART_FILES)
 	mkdir -p $(BINDIR)
 	$(CONTAINERIZED) -e CGO_ENABLED=$(CGO_ENABLED) -e GOEXPERIMENT=$(GOEXPERIMENT) $(CALICO_BUILD) \
 	sh -c '$(GIT_CONFIG_SSH) \
@@ -331,7 +342,7 @@ GINKGO_FOCUS?=.*
 ENVTEST_K8S_VERSION?=1.34.x
 
 .PHONY: ut
-ut: $(ENVOY_GATEWAY_CHART) $(ISTIO_CHART_FILES)
+ut: $(ENVOY_GATEWAY_CHART) $(ENVOY_GATEWAY_CRDS_CHART) $(ISTIO_CHART_FILES)
 	-mkdir -p .go-pkg-cache report
 	$(CONTAINERIZED) $(CALICO_BUILD) sh -c '$(GIT_CONFIG_SSH) \
 	go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22 && \
@@ -340,7 +351,7 @@ ut: $(ENVOY_GATEWAY_CHART) $(ISTIO_CHART_FILES)
 
 ## Run the functional tests
 fv: cluster-create load-container-images run-fvs cluster-destroy
-run-fvs: $(ENVOY_GATEWAY_CHART) $(ISTIO_CHART_FILES)
+run-fvs: $(ENVOY_GATEWAY_CHART) $(ENVOY_GATEWAY_CRDS_CHART) $(ISTIO_CHART_FILES)
 	-mkdir -p .go-pkg-cache report
 	$(CONTAINERIZED) $(CALICO_BUILD) sh -c '$(GIT_CONFIG_SSH) \
 	ginkgo -focus="$(GINKGO_FOCUS)" $(GINKGO_ARGS) "$(FV_DIR)"'

--- a/api/v1/gatewayapi_types.go
+++ b/api/v1/gatewayapi_types.go
@@ -80,12 +80,36 @@ type GatewayAPISpec struct {
 	// +optional
 	CRDManagement *CRDManagement `json:"crdManagement,omitempty"`
 
+	// Configures which channel of the upstream Gateway API CRDs the operator installs.
+	// The "Experimental" channel - which is the default, used when this field is not set -
+	// includes the standard CRDs plus the experimental-only resources, notably TCPRoute and
+	// UDPRoute, that Envoy Gateway relies on.  The "Standard" channel installs only the
+	// standard-channel CRDs and therefore omits those experimental route types.  Most
+	// installations should keep the default; choose "Standard" only if you do not need the
+	// experimental route types and prefer the smaller, stable CRD set.  This setting is
+	// independent of crdManagement, which governs whether the operator creates or overwrites
+	// the CRDs at all.
+	// +kubebuilder:default=Experimental
+	// +optional
+	GatewayAPIChannel *GatewayAPIChannel `json:"gatewayAPIChannel,omitempty"`
+
 	// Extensions enables and configures Tigera-built add-ons that sit on top of the
 	// Gateway API data plane.  Each add-on is opt-in: an unset Extensions, an unset
 	// add-on field, and an empty add-on object all leave the add-on disabled.
 	// +optional
 	Extensions *GatewayAPIExtensions `json:"extensions,omitempty"`
 }
+
+// GatewayAPIChannel selects which release channel of the upstream Gateway API CRDs the
+// operator installs.  "Experimental" includes the experimental-only route types (TCPRoute,
+// UDPRoute) that Envoy Gateway needs; "Standard" installs only the standard-channel CRDs.
+// +kubebuilder:validation:Enum=Standard;Experimental
+type GatewayAPIChannel string
+
+const (
+	GatewayAPIChannelStandard     GatewayAPIChannel = "Standard"
+	GatewayAPIChannelExperimental GatewayAPIChannel = "Experimental"
+)
 
 // GatewayAPIExtensions enables and configures Tigera-built Gateway API add-ons.
 type GatewayAPIExtensions struct {

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -4449,6 +4449,11 @@ func (in *GatewayAPISpec) DeepCopyInto(out *GatewayAPISpec) {
 		*out = new(CRDManagement)
 		**out = **in
 	}
+	if in.GatewayAPIChannel != nil {
+		in, out := &in.GatewayAPIChannel, &out.GatewayAPIChannel
+		*out = new(GatewayAPIChannel)
+		**out = **in
+	}
 	if in.Extensions != nil {
 		in, out := &in.Extensions, &out.Extensions
 		*out = new(GatewayAPIExtensions)

--- a/docs/common_tasks.md
+++ b/docs/common_tasks.md
@@ -182,9 +182,9 @@ spec:
 
 1. In `Makefile`, update `ENVOY_GATEWAY_VERSION`.
 
-1. Delete `pkg/render/gatewayapi/gateway-helm.tgz`.
+1. Delete `pkg/render/gatewayapi/gateway-helm.tgz` and `pkg/render/gatewayapi/gateway-crds-helm.tgz`.  Both are pinned to `ENVOY_GATEWAY_VERSION`: `gateway-helm` provides the controller resources, and `gateway-crds-helm` provides the Gateway API + Envoy CRDs (and is the chart that supports `GatewayAPI.spec.gatewayAPIChannel` channel selection).
 
-1. Run `make build`.  This will download the new version of the Envoy Gateway helm chart and build the operator image.  The chart is embedded in the binary and rendered at runtime using the Helm SDK.
+1. Run `make build`.  This will download the new versions of both Envoy Gateway helm charts and build the operator image.  The charts are embedded in the binary and rendered at runtime using the Helm SDK.
 
 1. Address build issues if there are any.
 

--- a/pkg/controller/gatewayapi/gatewayapi_controller.go
+++ b/pkg/controller/gatewayapi/gatewayapi_controller.go
@@ -243,7 +243,8 @@ func (r *ReconcileGatewayAPI) Reconcile(ctx context.Context, request reconcile.R
 	// not already exist and cannot be installed.  The "optional" set is everything else that we
 	// would ideally install, to provide more options to our users; but this controller will
 	// only warn if any of those cannot be installed (and do not already exist).
-	essentialCRDs, optionalCRDs, err := gatewayapi.GatewayAPICRDs(installationSpec.KubernetesProvider, r.scheme)
+	channel := gatewayapi.ResolveChannel(gatewayAPI.Spec.GatewayAPIChannel)
+	essentialCRDs, optionalCRDs, err := gatewayapi.GatewayAPICRDs(installationSpec.KubernetesProvider, r.scheme, channel)
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceReadError, "Error rendering gateway API CRDs", err, log)
 		return reconcile.Result{}, err

--- a/pkg/controller/istio/istio_controller.go
+++ b/pkg/controller/istio/istio_controller.go
@@ -198,8 +198,9 @@ func (r *ReconcileIstio) Reconcile(ctx context.Context, request reconcile.Reques
 		return reconcile.Result{}, err
 	}
 
-	// Get the Kubernetes Gateway API CRDs.
-	essentialCRDs, optionalCRDs, err := gatewayapi.K8SGatewayAPICRDs(installationSpec.KubernetesProvider, r.scheme)
+	// Get the Kubernetes Gateway API CRDs.  Istio uses the experimental channel (matching the
+	// historical CRD set); channel selection is exposed only on the GatewayAPI CR.
+	essentialCRDs, optionalCRDs, err := gatewayapi.K8SGatewayAPICRDs(installationSpec.KubernetesProvider, r.scheme, operatorv1.GatewayAPIChannelExperimental)
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceReadError, "Error rendering gateway API CRDs", err, log)
 		return reconcile.Result{}, err

--- a/pkg/imports/crds/operator/operator.tigera.io_gatewayapis.yaml
+++ b/pkg/imports/crds/operator/operator.tigera.io_gatewayapis.yaml
@@ -108,6 +108,22 @@ spec:
                           type: string
                       type: object
                   type: object
+                gatewayAPIChannel:
+                  default: Experimental
+                  description: |-
+                    Configures which channel of the upstream Gateway API CRDs the operator installs.
+                    The "Experimental" channel - which is the default, used when this field is not set -
+                    includes the standard CRDs plus the experimental-only resources, notably TCPRoute and
+                    UDPRoute, that Envoy Gateway relies on.  The "Standard" channel installs only the
+                    standard-channel CRDs and therefore omits those experimental route types.  Most
+                    installations should keep the default; choose "Standard" only if you do not need the
+                    experimental route types and prefer the smaller, stable CRD set.  This setting is
+                    independent of crdManagement, which governs whether the operator creates or overwrites
+                    the CRDs at all.
+                  enum:
+                    - Standard
+                    - Experimental
+                  type: string
                 gatewayCertgenJob:
                   description: Allows customization of the gateway certgen job.
                   properties:

--- a/pkg/render/gatewayapi/gateway_api.go
+++ b/pkg/render/gatewayapi/gateway_api.go
@@ -60,6 +60,9 @@ var (
 	//go:embed gateway-helm.tgz
 	gatewayHelmChart []byte
 
+	//go:embed gateway-crds-helm.tgz
+	gatewayCRDsHelmChart []byte
+
 	AccessLogType envoyapi.ProxyAccessLogType = "Route"
 
 	log = logf.Log.WithName("gateway_api")
@@ -176,6 +179,26 @@ type helmDeploy struct {
 	Type string `json:"type,omitempty"`
 }
 
+// crdHelmOpts represents the helm values passed when rendering the gateway-crds-helm chart,
+// which installs the Gateway API and Envoy Gateway CRDs and supports channel selection.
+type crdHelmOpts struct {
+	Crds *crdConfig `json:"crds,omitempty"`
+}
+
+type crdConfig struct {
+	GatewayAPI   *crdGatewayAPI   `json:"gatewayAPI,omitempty"`
+	EnvoyGateway *crdEnvoyGateway `json:"envoyGateway,omitempty"`
+}
+
+type crdGatewayAPI struct {
+	Enabled bool   `json:"enabled"`
+	Channel string `json:"channel,omitempty"`
+}
+
+type crdEnvoyGateway struct {
+	Enabled bool `json:"enabled"`
+}
+
 func toMap(v any) (map[string]any, error) {
 	b, err := json.Marshal(v)
 	if err != nil {
@@ -188,8 +211,14 @@ func toMap(v any) (map[string]any, error) {
 	return out, nil
 }
 
-// Chart output is deterministic for our single render, so it's cached by
-// sync.Once. Callers must deep-copy any object they intend to mutate.
+// chartResourcesFor renders the embedded gateway-helm chart, which provides the controller
+// Deployment, RBAC, config, certgen, webhooks and the safe-upgrades ValidatingAdmissionPolicy.
+// The Gateway API / Envoy CRDs that this chart also renders are intentionally NOT applied; the
+// CRD set that gets installed comes from gateway-crds-helm via crdResourcesFor, which supports
+// channel selection.  (gateway-helm is still rendered with CRDs included because the upstream
+// chart ships the safe-upgrades policy alongside the CRD bundle, and the controller component
+// needs that policy.)  Output is deterministic, so it is cached by sync.Once.  Callers must
+// deep-copy any object they intend to mutate.
 var (
 	chartOnce    sync.Once
 	chartResults *gatewayAPIResources
@@ -203,21 +232,50 @@ func chartResourcesFor(scheme *runtime.Scheme) (*gatewayAPIResources, error) {
 	return chartResults, chartErr
 }
 
-// renderChart renders the embedded Envoy Gateway helm chart.
-func renderChart(scheme *runtime.Scheme) (*gatewayAPIResources, error) {
-	chart, err := loader.LoadArchive(bytes.NewReader(gatewayHelmChart))
-	if err != nil {
-		return nil, fmt.Errorf("failed to load gateway-helm chart: %w", err)
+// crdResourcesFor renders the embedded gateway-crds-helm chart for the given channel, yielding
+// the Gateway API CRDs for that channel plus the Envoy Gateway CRDs.  Output depends on the
+// channel, so it is memoized per channel.  Callers must deep-copy any object they intend to
+// mutate.
+var (
+	crdCacheMu sync.Mutex
+	crdCache   = map[operatorv1.GatewayAPIChannel]*gatewayAPIResources{}
+	crdErrs    = map[operatorv1.GatewayAPIChannel]error{}
+)
+
+func crdResourcesFor(scheme *runtime.Scheme, channel operatorv1.GatewayAPIChannel) (*gatewayAPIResources, error) {
+	crdCacheMu.Lock()
+	defer crdCacheMu.Unlock()
+	if res, ok := crdCache[channel]; ok {
+		return res, crdErrs[channel]
 	}
+	res, err := renderCRDChart(scheme, channel)
+	crdCache[channel] = res
+	crdErrs[channel] = err
+	return res, err
+}
 
-	actionConfig := new(action.Configuration)
-	helmClient := action.NewInstall(actionConfig)
-	helmClient.DryRun = true
-	helmClient.ClientOnly = true
-	helmClient.IncludeCRDs = true
-	helmClient.Namespace = DeploymentNamespace
-	helmClient.ReleaseName = ReleaseName
+// ResolveChannel returns the effective Gateway API CRD channel, defaulting to Experimental
+// when the field is unset.
+func ResolveChannel(channel *operatorv1.GatewayAPIChannel) operatorv1.GatewayAPIChannel {
+	if channel == nil {
+		return operatorv1.GatewayAPIChannelExperimental
+	}
+	return *channel
+}
 
+// channelHelmValue maps the API channel enum onto the gateway-crds-helm "channel" value.
+func channelHelmValue(channel operatorv1.GatewayAPIChannel) string {
+	if channel == operatorv1.GatewayAPIChannelStandard {
+		return "standard"
+	}
+	return "experimental"
+}
+
+// renderChart renders the embedded gateway-helm chart for the controller-side resources.  It is
+// rendered with IncludeCRDs=true so that the safe-upgrades ValidatingAdmissionPolicy (shipped in
+// the chart's CRD bundle) is captured; the CRD objects it produces are not applied (the installed
+// CRD set comes from gateway-crds-helm via crdResourcesFor - see chartResourcesFor).
+func renderChart(scheme *runtime.Scheme) (*gatewayAPIResources, error) {
 	opts := &helmOpts{
 		Config: &helmConfig{EnvoyGateway: &helmEnvoyGateway{
 			Provider: &helmProvider{
@@ -227,15 +285,48 @@ func renderChart(scheme *runtime.Scheme) (*gatewayAPIResources, error) {
 			},
 		}},
 	}
-
 	values, err := toMap(opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert helm values: %w", err)
 	}
+	return renderHelmChart(scheme, gatewayHelmChart, "gateway-helm", values, true)
+}
+
+// renderCRDChart renders the embedded gateway-crds-helm chart, installing the Gateway API CRDs
+// for the requested channel plus the Envoy Gateway CRDs.
+func renderCRDChart(scheme *runtime.Scheme, channel operatorv1.GatewayAPIChannel) (*gatewayAPIResources, error) {
+	opts := &crdHelmOpts{
+		Crds: &crdConfig{
+			GatewayAPI:   &crdGatewayAPI{Enabled: true, Channel: channelHelmValue(channel)},
+			EnvoyGateway: &crdEnvoyGateway{Enabled: true},
+		},
+	}
+	values, err := toMap(opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert helm values: %w", err)
+	}
+	return renderHelmChart(scheme, gatewayCRDsHelmChart, "gateway-crds-helm", values, true)
+}
+
+// renderHelmChart loads and renders an embedded helm chart, combining the main and hook
+// manifests and parsing them into typed gatewayAPIResources.
+func renderHelmChart(scheme *runtime.Scheme, chartBytes []byte, chartName string, values map[string]any, includeCRDs bool) (*gatewayAPIResources, error) {
+	chart, err := loader.LoadArchive(bytes.NewReader(chartBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to load %s chart: %w", chartName, err)
+	}
+
+	actionConfig := new(action.Configuration)
+	helmClient := action.NewInstall(actionConfig)
+	helmClient.DryRun = true
+	helmClient.ClientOnly = true
+	helmClient.IncludeCRDs = includeCRDs
+	helmClient.Namespace = DeploymentNamespace
+	helmClient.ReleaseName = ReleaseName
 
 	rel, err := helmClient.Run(chart, values)
 	if err != nil {
-		return nil, fmt.Errorf("failed to render gateway-helm chart: %w", err)
+		return nil, fmt.Errorf("failed to render %s chart: %w", chartName, err)
 	}
 
 	// Combine the main manifest with hook manifests (certgen, webhooks, etc.).
@@ -248,7 +339,7 @@ func renderChart(scheme *runtime.Scheme) (*gatewayAPIResources, error) {
 
 	resources, err := parseManifest(scheme, allManifests.String())
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse rendered manifest: %w", err)
+		return nil, fmt.Errorf("failed to parse rendered %s manifest: %w", chartName, err)
 	}
 	return resources, nil
 }
@@ -341,15 +432,15 @@ func parseManifest(scheme *runtime.Scheme, manifest string) (*gatewayAPIResource
 		default:
 			// Fail loudly so a chart bump that adds a new kind we don't handle
 			// trips CI rather than silently dropping the object at runtime.
-			return nil, fmt.Errorf("unhandled object kind %T in rendered gateway-helm manifest", typedObj)
+			return nil, fmt.Errorf("unhandled object kind %T in rendered gateway helm manifest", typedObj)
 		}
 	}
 
 	return resources, nil
 }
 
-func K8SGatewayAPICRDs(provider operatorv1.Provider, scheme *runtime.Scheme) (essentialCRDs, optionalCRDs []client.Object, err error) {
-	resources, err := chartResourcesFor(scheme)
+func K8SGatewayAPICRDs(provider operatorv1.Provider, scheme *runtime.Scheme, channel operatorv1.GatewayAPIChannel) (essentialCRDs, optionalCRDs []client.Object, err error) {
+	resources, err := crdResourcesFor(scheme, channel)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to render chart for CRDs: %w", err)
 	}
@@ -374,12 +465,12 @@ func K8SGatewayAPICRDs(provider operatorv1.Provider, scheme *runtime.Scheme) (es
 
 // GatewayAPICRDs returns the k8s GatewayAPI CRDs and the Envoy CRDs together,
 // necessary for the deployment of Calico Gateway API.
-func GatewayAPICRDs(provider operatorv1.Provider, scheme *runtime.Scheme) (essentialCRDs, optionalCRDs []client.Object, err error) {
-	resources, err := chartResourcesFor(scheme)
+func GatewayAPICRDs(provider operatorv1.Provider, scheme *runtime.Scheme, channel operatorv1.GatewayAPIChannel) (essentialCRDs, optionalCRDs []client.Object, err error) {
+	resources, err := crdResourcesFor(scheme, channel)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to render chart for CRDs: %w", err)
 	}
-	essentialCRDs, optionalCRDs, err = K8SGatewayAPICRDs(provider, scheme)
+	essentialCRDs, optionalCRDs, err = K8SGatewayAPICRDs(provider, scheme, channel)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/render/gatewayapi/gateway_api_test.go
+++ b/pkg/render/gatewayapi/gateway_api_test.go
@@ -175,7 +175,7 @@ var _ = Describe("Gateway API rendering tests", func() {
 
 	It("should report UDPRoute as required when platform is not OpenShift", func() {
 		s := testScheme()
-		essentialCRDs, optionalCRDs, err := GatewayAPICRDs(operatorv1.ProviderAKS, s)
+		essentialCRDs, optionalCRDs, err := GatewayAPICRDs(operatorv1.ProviderAKS, s, operatorv1.GatewayAPIChannelExperimental)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(essentialCRDs).To(ContainElement(&matchObject{name: "udproutes.gateway.networking.k8s.io"}))
 		Expect(optionalCRDs).NotTo(ContainElement(&matchObject{name: "udproutes.gateway.networking.k8s.io"}))
@@ -183,10 +183,40 @@ var _ = Describe("Gateway API rendering tests", func() {
 
 	It("should report UDPRoute as optional when platform is OpenShift", func() {
 		s := testScheme()
-		essentialCRDs, optionalCRDs, err := GatewayAPICRDs(operatorv1.ProviderOpenShift, s)
+		essentialCRDs, optionalCRDs, err := GatewayAPICRDs(operatorv1.ProviderOpenShift, s, operatorv1.GatewayAPIChannelExperimental)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(essentialCRDs).NotTo(ContainElement(&matchObject{name: "udproutes.gateway.networking.k8s.io"}))
 		Expect(optionalCRDs).To(ContainElement(&matchObject{name: "udproutes.gateway.networking.k8s.io"}))
+	})
+
+	It("should install the experimental route types and GA ListenerSet on the Experimental channel", func() {
+		s := testScheme()
+		essentialCRDs, optionalCRDs, err := GatewayAPICRDs(operatorv1.ProviderAKS, s, operatorv1.GatewayAPIChannelExperimental)
+		Expect(err).ShouldNot(HaveOccurred())
+		all := append(append([]client.Object{}, essentialCRDs...), optionalCRDs...)
+		// Experimental-only route types are present.
+		Expect(all).To(ContainElement(&matchObject{name: "tcproutes.gateway.networking.k8s.io"}))
+		Expect(all).To(ContainElement(&matchObject{name: "udproutes.gateway.networking.k8s.io"}))
+		// GA ListenerSet (group gateway.networking.k8s.io) is present in both channels.
+		Expect(all).To(ContainElement(&matchObject{name: "listenersets.gateway.networking.k8s.io"}))
+		// Envoy Gateway CRDs are always installed.
+		Expect(all).To(ContainElement(&matchObject{name: "envoyproxies.gateway.envoyproxy.io"}))
+	})
+
+	It("should omit the experimental route types on the Standard channel", func() {
+		s := testScheme()
+		essentialCRDs, optionalCRDs, err := GatewayAPICRDs(operatorv1.ProviderAKS, s, operatorv1.GatewayAPIChannelStandard)
+		Expect(err).ShouldNot(HaveOccurred())
+		all := append(append([]client.Object{}, essentialCRDs...), optionalCRDs...)
+		// Experimental-only route types are absent on the standard channel.
+		Expect(all).NotTo(ContainElement(&matchObject{name: "tcproutes.gateway.networking.k8s.io"}))
+		Expect(all).NotTo(ContainElement(&matchObject{name: "udproutes.gateway.networking.k8s.io"}))
+		// Standard CRDs, including the GA ListenerSet, are present.
+		Expect(all).To(ContainElement(&matchObject{name: "gateways.gateway.networking.k8s.io"}))
+		Expect(all).To(ContainElement(&matchObject{name: "httproutes.gateway.networking.k8s.io"}))
+		Expect(all).To(ContainElement(&matchObject{name: "listenersets.gateway.networking.k8s.io"}))
+		// Envoy Gateway CRDs are installed regardless of channel.
+		Expect(all).To(ContainElement(&matchObject{name: "envoyproxies.gateway.envoyproxy.io"}))
 	})
 
 	It("should apply overrides from GatewayAPI CR", func() {

--- a/test/gatewayapi_test.go
+++ b/test/gatewayapi_test.go
@@ -27,6 +27,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apiextenv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	kerror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -204,6 +205,71 @@ var _ = Describe("GatewayAPI tests", func() {
 		var d appsv1.Deployment
 		err := c.Get(shutdownContext, types.NamespacedName{Namespace: "tigera-gateway", Name: "envoy-gateway"}, &d)
 		Expect(kerror.IsNotFound(err)).To(BeTrue(), fmt.Sprintf("unexpected envoy-gateway in tigera-gateway: %v", err))
+	})
+
+	It("installs the Experimental channel CRDs by default", func() {
+		By("Creating Installation")
+		instance := &operator.Installation{
+			TypeMeta:   metav1.TypeMeta{Kind: "Installation", APIVersion: "operator.tigera.io/v1"},
+			ObjectMeta: metav1.ObjectMeta{Name: "default"},
+			Spec:       operator.InstallationSpec{Variant: operator.CalicoEnterprise},
+		}
+		Expect(c.Create(shutdownContext, instance)).NotTo(HaveOccurred())
+		Expect(c.Get(shutdownContext, utils.DefaultInstanceKey, instance)).NotTo(HaveOccurred())
+		instance.Status.Variant = operator.CalicoEnterprise
+		Expect(c.Status().Update(shutdownContext, instance)).NotTo(HaveOccurred())
+
+		By("Creating a GatewayAPI without a channel (defaults to Experimental) and crdManagement Reconcile")
+		reconcile := operator.CRDManagementReconcile
+		gatewayAPI := &operator.GatewayAPI{
+			TypeMeta:   metav1.TypeMeta{Kind: "GatewayAPI", APIVersion: "operator.tigera.io/v1"},
+			ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"},
+			Spec:       operator.GatewayAPISpec{CRDManagement: &reconcile},
+		}
+		Expect(c.Create(shutdownContext, gatewayAPI)).NotTo(HaveOccurred())
+
+		By("Checking the gateways CRD is installed on the experimental channel")
+		Eventually(func() (string, error) {
+			return gatewayCRDChannel(c, shutdownContext, "gateways.gateway.networking.k8s.io")
+		}, "60s", "2s").Should(Equal("experimental"))
+
+		By("Checking the experimental-only TCPRoute CRD is installed")
+		Eventually(func() error {
+			return gatewayCRDExists(c, shutdownContext, "tcproutes.gateway.networking.k8s.io")
+		}, "60s", "2s").ShouldNot(HaveOccurred())
+	})
+
+	It("installs the Standard channel CRDs when gatewayAPIChannel is Standard", func() {
+		By("Creating Installation")
+		instance := &operator.Installation{
+			TypeMeta:   metav1.TypeMeta{Kind: "Installation", APIVersion: "operator.tigera.io/v1"},
+			ObjectMeta: metav1.ObjectMeta{Name: "default"},
+			Spec:       operator.InstallationSpec{Variant: operator.CalicoEnterprise},
+		}
+		Expect(c.Create(shutdownContext, instance)).NotTo(HaveOccurred())
+		Expect(c.Get(shutdownContext, utils.DefaultInstanceKey, instance)).NotTo(HaveOccurred())
+		instance.Status.Variant = operator.CalicoEnterprise
+		Expect(c.Status().Update(shutdownContext, instance)).NotTo(HaveOccurred())
+
+		By("Creating a GatewayAPI with the Standard channel and crdManagement Reconcile")
+		standard := operator.GatewayAPIChannelStandard
+		reconcile := operator.CRDManagementReconcile
+		gatewayAPI := &operator.GatewayAPI{
+			TypeMeta:   metav1.TypeMeta{Kind: "GatewayAPI", APIVersion: "operator.tigera.io/v1"},
+			ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"},
+			Spec: operator.GatewayAPISpec{
+				GatewayAPIChannel: &standard,
+				CRDManagement:     &reconcile,
+			},
+		}
+		Expect(c.Create(shutdownContext, gatewayAPI)).NotTo(HaveOccurred())
+
+		By("Checking the gateways CRD is reconciled onto the standard channel")
+		// crdManagement Reconcile overwrites the existing CRD, so the channel
+		// annotation flips from experimental (the default) to standard.
+		Eventually(func() (string, error) {
+			return gatewayCRDChannel(c, shutdownContext, "gateways.gateway.networking.k8s.io")
+		}, "60s", "2s").Should(Equal("standard"))
 	})
 
 	It("provisions and cleans up per-namespace resources for namespaced-class Gateways", func() {
@@ -635,4 +701,26 @@ func cleanupGatewayResources(c client.Client) {
 		}
 		return nil
 	}, "60s").ShouldNot(HaveOccurred())
+}
+
+// gatewayCRDChannel returns the gateway.networking.k8s.io/channel annotation of the named CRD,
+// which the upstream CRD bundle stamps as "standard" or "experimental".
+func gatewayCRDChannel(c client.Client, ctx context.Context, name string) (string, error) {
+	crd := &apiextenv1.CustomResourceDefinition{
+		TypeMeta:   metav1.TypeMeta{Kind: "CustomResourceDefinition", APIVersion: "apiextensions.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}
+	if err := c.Get(ctx, client.ObjectKey{Name: name}, crd); err != nil {
+		return "", err
+	}
+	return crd.Annotations["gateway.networking.k8s.io/channel"], nil
+}
+
+// gatewayCRDExists returns nil once the named CRD is present.
+func gatewayCRDExists(c client.Client, ctx context.Context, name string) error {
+	crd := &apiextenv1.CustomResourceDefinition{
+		TypeMeta:   metav1.TypeMeta{Kind: "CustomResourceDefinition", APIVersion: "apiextensions.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}
+	return c.Get(ctx, client.ObjectKey{Name: name}, crd)
 }


### PR DESCRIPTION
## Description

Today the operator installs a fixed, experimental set of Gateway API CRDs. This PR adds a `GatewayAPI.spec.gatewayAPIChannel` field so you can pick the channel: `Standard` or `Experimental` (the default).

Why a second chart: the packaged `gateway-helm` chart ships only a static experimental CRD set and has no channel switch. That switch lives in the separate `gateway-crds-helm` chart. So the operator now also embeds `gateway-crds-helm` and renders it for the chosen channel to install the Gateway API and Envoy CRDs. `gateway-helm` still provides the controller resources and the `safe-upgrades` ValidatingAdmissionPolicy.

The default stays `Experimental` because Envoy Gateway uses the experimental-only `TCPRoute` and `UDPRoute` types; `Standard` drops those. This field is independent of `crdManagement`, which decides whether the operator creates or overwrites the CRDs.

- Type: new feature.
- Components: gatewayapi render + controller, istio controller (a caller of the CRD render), CRD manifests.

Testing:
- `make gen-files` is clean.
- Unit tests in `pkg/render/gatewayapi` render the real charts and check the CRD set per channel: `Experimental` includes `TCPRoute`/`UDPRoute`; `Standard` does not; the GA `ListenerSet` and the Envoy CRDs are present in both.
- FV specs in `test/gatewayapi_test.go` run the GatewayAPI controller against a kind cluster and assert the operator installs the matching channel, checked via the `gateway.networking.k8s.io/channel` annotation on the `gateways` CRD: the default installs the experimental channel (with `TCPRoute` present), and `Standard` reconciles `gateways` onto the standard channel. Verified locally (`Ran 2 of 2 Specs ... 2 Passed`).
- `pkg/controller/gatewayapi` and `pkg/controller/istio` unit tests pass.

## Release Note

```release-note
Added GatewayAPI.spec.gatewayAPIChannel (Standard or Experimental, default Experimental) to select which Gateway API CRD channel the operator installs.
```

## For PR author

- [x] Tests for change.
- [x] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions` (not applicable)
