### PR TITLE
Don't autoscale typha after the autoscaler is shut down

### DIFF
--- a/pkg/controller/installation/typha_autoscaler.go
+++ b/pkg/controller/installation/typha_autoscaler.go
@@ -147,8 +147,7 @@ func (t *typhaAutoscaler) start(ctx context.Context) {
 			}
 		}
 
-		// If we were cancelled while waiting for the informers to sync, don't autoscale or
-		// report degraded - we're shutting down.
+		// Don't autoscale or report degraded if the context has been cancelled - we're shutting down.
 		if ctx.Err() != nil {
 			typhaLog.Info("typha autoscaler shutting down")
 			return

--- a/pkg/controller/installation/typha_autoscaler.go
+++ b/pkg/controller/installation/typha_autoscaler.go
@@ -57,6 +57,9 @@ type typhaAutoscaler struct {
 	typhaIndexer   cache.Store
 	nonClusterHost bool
 
+	// done is closed when the autoscaler goroutine exits, so callers can wait for shutdown.
+	done chan struct{}
+
 	// Number of currently running replicas.
 	activeReplicas int32
 }
@@ -124,7 +127,9 @@ func newTyphaAutoscaler(cs kubernetes.Interface, indexInformer cache.SharedIndex
 // can be used to trigger an auto scale run immediately, while the isDegradedChan can be used to get the degraded status
 // of the last run. The triggerRun and isDegraded functions should be used instead of instead of access these channels directly.
 func (t *typhaAutoscaler) start(ctx context.Context) {
+	t.done = make(chan struct{})
 	go func() {
+		defer close(t.done)
 		degraded := false
 		ticker := time.NewTicker(t.syncPeriod)
 		defer ticker.Stop()
@@ -132,9 +137,21 @@ func (t *typhaAutoscaler) start(ctx context.Context) {
 
 		// Start the informer.
 		go t.typhaInformer.Run(ctx.Done())
-		// Wait for the informers to sync.
+		// Wait for the informers to sync, bailing out if we're asked to shut down first.
 		for !t.indexInformer.HasSynced() || !t.typhaInformer.HasSynced() {
-			time.Sleep(100 * time.Millisecond)
+			select {
+			case <-ctx.Done():
+				typhaLog.Info("typha autoscaler shutting down")
+				return
+			case <-time.After(100 * time.Millisecond):
+			}
+		}
+
+		// If we were cancelled while waiting for the informers to sync, don't autoscale or
+		// report degraded - we're shutting down.
+		if ctx.Err() != nil {
+			typhaLog.Info("typha autoscaler shutting down")
+			return
 		}
 
 		// Autoscale on start up then do it again every tick.
@@ -179,6 +196,14 @@ func (t *typhaAutoscaler) start(ctx context.Context) {
 			}
 		}
 	}()
+}
+
+// waitForShutdown blocks until the autoscaler goroutine started by start() has exited. It is a no-op
+// if the autoscaler was never started. Cancel the context passed to start() to trigger shutdown.
+func (t *typhaAutoscaler) waitForShutdown() {
+	if t.done != nil {
+		<-t.done
+	}
 }
 
 func (t *typhaAutoscaler) triggerRun() error {

--- a/pkg/controller/installation/typha_autoscaler_test.go
+++ b/pkg/controller/installation/typha_autoscaler_test.go
@@ -43,8 +43,10 @@ var _ = Describe("Test typha autoscaler ", func() {
 	var cancel context.CancelFunc
 	var nlw, tlw cache.ListerWatcher
 	var nodeIndexInformer cache.SharedIndexInformer
+	var ta *typhaAutoscaler
 
 	BeforeEach(func() {
+		ta = nil
 		statusManager = new(status.MockStatus)
 
 		objs := []runtime.Object{
@@ -70,11 +72,17 @@ var _ = Describe("Test typha autoscaler ", func() {
 	})
 
 	AfterEach(func() {
+		// Cancel the context and wait for the autoscaler goroutine to exit before the next spec
+		// runs. Otherwise a leaked goroutine can call SetDegraded on this spec's mock after the
+		// spec has ended, panicking a later, unrelated spec.
 		cancel()
+		if ta != nil {
+			ta.waitForShutdown()
+		}
 	})
 
 	It("should initialize an autoscaler", func() {
-		ta := newTyphaAutoscaler(c, nodeIndexInformer, tlw, statusManager)
+		ta = newTyphaAutoscaler(c, nodeIndexInformer, tlw, statusManager)
 		ta.start(ctx)
 	})
 
@@ -85,7 +93,7 @@ var _ = Describe("Test typha autoscaler ", func() {
 		// Don't start the autoscaler - this test only exercises getNodeCounts(), which reads
 		// from the nodeIndexInformer directly. Starting it would race with node creation,
 		// since autoscaleReplicas() can fire before the informer has picked up the new nodes.
-		ta := newTyphaAutoscaler(c, nodeIndexInformer, tlw, statusManager)
+		ta = newTyphaAutoscaler(c, nodeIndexInformer, tlw, statusManager)
 
 		Eventually(func() error {
 			schedulableNodes, linuxNodes := ta.getNodeCounts()
@@ -136,7 +144,7 @@ var _ = Describe("Test typha autoscaler ", func() {
 		CreateNode(c, "node2", map[string]string{"kubernetes.io/os": "linux"}, nil)
 
 		// Create the autoscaler and run it
-		ta := newTyphaAutoscaler(c, nodeIndexInformer, tlw, statusManager, typhaAutoscalerOptionPeriod(10*time.Millisecond))
+		ta = newTyphaAutoscaler(c, nodeIndexInformer, tlw, statusManager, typhaAutoscalerOptionPeriod(10*time.Millisecond))
 		ta.start(ctx)
 
 		// For clusters smaller than 3 nodes we only expect 1 replica.
@@ -190,7 +198,7 @@ var _ = Describe("Test typha autoscaler ", func() {
 		}).Should(HaveLen(5))
 
 		// Create the autoscaler and run it
-		ta := newTyphaAutoscaler(c, nodeIndexInformer, tlw, statusManager, typhaAutoscalerOptionPeriod(10*time.Millisecond))
+		ta = newTyphaAutoscaler(c, nodeIndexInformer, tlw, statusManager, typhaAutoscalerOptionPeriod(10*time.Millisecond))
 		ta.start(ctx)
 
 		verifyTyphaReplicas(c, 3)
@@ -225,7 +233,7 @@ var _ = Describe("Test typha autoscaler ", func() {
 		}).Should(HaveLen(5))
 
 		// Create the autoscaler and run it
-		ta := newTyphaAutoscaler(c, nodeIndexInformer, tlw, statusManager, typhaAutoscalerOptionPeriod(10*time.Millisecond))
+		ta = newTyphaAutoscaler(c, nodeIndexInformer, tlw, statusManager, typhaAutoscalerOptionPeriod(10*time.Millisecond))
 		ta.start(ctx)
 
 		// normally we'd expect to see three replicas for five nodes, but since one node is a virtual-kubelet,
@@ -265,13 +273,28 @@ var _ = Describe("Test typha autoscaler ", func() {
 		}).Should(HaveLen(5))
 
 		// Create the autoscaler and run it
-		ta := newTyphaAutoscaler(c, nodeIndexInformer, tlw, statusManager, typhaAutoscalerOptionPeriod(10*time.Millisecond))
+		ta = newTyphaAutoscaler(c, nodeIndexInformer, tlw, statusManager, typhaAutoscalerOptionPeriod(10*time.Millisecond))
 		ta.start(ctx)
 
 		// This blocks until the first run is done.
 		ta.isDegraded()
 
 		statusManager.AssertExpectations(GinkgoT())
+	})
+
+	It("should not autoscale or report degraded once its context is cancelled", func() {
+		// statusManager has no SetDegraded expectation configured, so the mock panics if it's
+		// called. With zero linux nodes the startup autoscale would normally report degraded, so
+		// a cancelled autoscaler that still runs the startup autoscale would panic here.
+		cancelledCtx, cancelStart := context.WithCancel(context.Background())
+		cancelStart()
+
+		ta = newTyphaAutoscaler(c, nodeIndexInformer, tlw, statusManager)
+		ta.start(cancelledCtx)
+
+		// The goroutine should observe the cancelled context and exit without autoscaling.
+		ta.waitForShutdown()
+		statusManager.AssertNotCalled(GinkgoT(), "SetDegraded", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	})
 })
 


### PR DESCRIPTION
The typha autoscaler unit tests flake intermittently with a panic from an unexpected mock call (a degraded-status update fired after the test had already finished).

The "initialize an autoscaler" test starts an autoscaler with no nodes. Its goroutine waits for the informer to sync, then runs a startup autoscale that reports degraded (one typha wanted, zero linux nodes). The test never cancels and waits for that goroutine, so the degraded call lands on a later spec's mock and crashes the suite. Ginkgo's randomized ordering decides which spec gets hit, which is why it only shows up sometimes.

The autoscaler now bails out of its startup path as soon as its context is cancelled, and exposes a way to wait for the goroutine to exit. The tests cancel and wait in AfterEach so a leaked goroutine can't contaminate a later spec.

```release-note
None
```