### PR TITLE
Revert Monitor CRD alertManager field rename

### DIFF
--- a/api/v1/monitor_types.go
+++ b/api/v1/monitor_types.go
@@ -35,7 +35,7 @@ type MonitorSpec struct {
 
 	// Alertmanager is the configuration for the Alertmanager.
 	// +optional
-	Alertmanager *Alertmanager `json:"alertmanager,omitempty"`
+	Alertmanager *Alertmanager `json:"alertManager,omitempty"`
 }
 
 type ExternalPrometheus struct {

--- a/pkg/imports/crds/operator/operator.tigera.io_monitors.yaml
+++ b/pkg/imports/crds/operator/operator.tigera.io_monitors.yaml
@@ -40,7 +40,7 @@ spec:
             spec:
               description: MonitorSpec defines the desired state of Tigera monitor.
               properties:
-                alertmanager:
+                alertManager:
                   description: Alertmanager is the configuration for the Alertmanager.
                   properties:
                     spec:


### PR DESCRIPTION
## Summary

Commit c83bdb9 renamed the `Monitor` CRD's JSON field from `alertManager` to `alertmanager`, breaking backwards compatibility for existing `Monitor` CRs that specify `alertManager`.

This reverts **only** the JSON tag (line 38 in `monitor_types.go`) back to `alertManager`, plus the regenerated CRD YAML. The Go type/field renames (`Alertmanager`, `AlertmanagerSpec`) are intentionally kept, so no other source changes are needed and the field name matches Prometheus internals.

```release-note
Restore backwards compatibility for the Monitor CRD `alertManager` field, which was inadvertently renamed to `alertmanager`.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)