### PR TITLE
Revert Monitor CRD alertManager field rename

### DIFF
--- a/api/v1/monitor_types.go
+++ b/api/v1/monitor_types.go
@@ -35,7 +35,7 @@ type MonitorSpec struct {
 
 	// Alertmanager is the configuration for the Alertmanager.
 	// +optional
-	Alertmanager *Alertmanager `json:"alertmanager,omitempty"`
+	Alertmanager *Alertmanager `json:"alertManager,omitempty"`
 }
 
 type ExternalPrometheus struct {

--- a/pkg/imports/crds/operator/operator.tigera.io_monitors.yaml
+++ b/pkg/imports/crds/operator/operator.tigera.io_monitors.yaml
@@ -40,7 +40,7 @@ spec:
             spec:
               description: MonitorSpec defines the desired state of Tigera monitor.
               properties:
-                alertmanager:
+                alertManager:
                   description: Alertmanager is the configuration for the Alertmanager.
                   properties:
                     spec:


### PR DESCRIPTION
## Description

Bug fix. Commit c83bdb9 renamed the `Monitor` CRD's JSON field from `alertManager` to `alertmanager`, breaking backwards compatibility for existing `Monitor` CRs that specify `alertManager`.

This reverts **only** the JSON tag back to `alertManager` (plus the regenerated CRD YAML). The Go type/field renames (`Alertmanager`, `AlertmanagerSpec`) are intentionally kept, so no other source changes are needed. Verified with `make build`.

Affected component: monitor / CRDs. Same fix as #4984 (release-v1.43), cherry-picked to master.

## Release Note

```release-note
Restore backwards compatibility for the Monitor CRD `alertManager` field, which was inadvertently renamed to `alertmanager`.
```

## For PR author

- [ ] Tests for change.
- [x] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
