### PR TITLE
[CI-1951] fix(podiprecovery): add Pod watch so recovery is level-triggered

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -53,7 +53,6 @@ import (
 	"github.com/tigera/operator/version"
 
 	operatortigeraiov1 "github.com/tigera/operator/api/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -531,23 +530,6 @@ If a value other than 'all' is specified, the first CRD with a prefix of the spe
 	// Before we start any controllers, make sure our options are valid.
 	if err := verifyConfiguration(ctx, clientset, options); err != nil {
 		setupLog.Error(err, "Invalid configuration")
-		os.Exit(1)
-	}
-
-	// Register a field-selector index on Pod spec.nodeName. The podiprecovery
-	// controller uses this to list operator-managed pods on a specific node
-	// in a single server-side query. Indexes must be registered before the
-	// manager starts (and before any controllers attempt server-side field
-	// lookups via the cached client).
-	if err := mgr.GetFieldIndexer().IndexField(
-		ctx,
-		&corev1.Pod{},
-		"spec.nodeName",
-		func(obj client.Object) []string {
-			return []string{obj.(*corev1.Pod).Spec.NodeName}
-		},
-	); err != nil {
-		setupLog.Error(err, "unable to register field index for pod spec.nodeName")
 		os.Exit(1)
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -53,6 +53,7 @@ import (
 	"github.com/tigera/operator/version"
 
 	operatortigeraiov1 "github.com/tigera/operator/api/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/controller/egressgateway/egressgateway_controller_test.go
+++ b/pkg/controller/egressgateway/egressgateway_controller_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -829,6 +830,11 @@ type mockController struct {
 }
 
 func (m *mockController) WatchObject(object client.Object, eventhandler handler.EventHandler, predicates ...predicate.Predicate) error {
+	m.watchedObjects = append(m.watchedObjects, object)
+	return nil
+}
+
+func (m *mockController) WatchObjectInCache(_ cache.Cache, object client.Object, eventhandler handler.EventHandler, predicates ...predicate.Predicate) error {
 	m.watchedObjects = append(m.watchedObjects, object)
 	return nil
 }

--- a/pkg/controller/logcollector/logcollector_controller_test.go
+++ b/pkg/controller/logcollector/logcollector_controller_test.go
@@ -33,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -1135,6 +1136,11 @@ type mockController struct {
 }
 
 func (m *mockController) WatchObject(object client.Object, eventhandler handler.EventHandler, predicates ...predicate.Predicate) error {
+	m.watchedObjects = append(m.watchedObjects, object)
+	return nil
+}
+
+func (m *mockController) WatchObjectInCache(_ cache.Cache, object client.Object, eventhandler handler.EventHandler, predicates ...predicate.Predicate) error {
 	m.watchedObjects = append(m.watchedObjects, object)
 	return nil
 }

--- a/pkg/controller/podiprecovery/podiprecovery_controller.go
+++ b/pkg/controller/podiprecovery/podiprecovery_controller.go
@@ -33,6 +33,15 @@
 // spec.hostNetwork == true as a side effect of the normal apply path.
 // The controller additionally verifies spec.hostNetwork == true on each
 // candidate as a safety net before deleting.
+//
+// Recovery is triggered by two watches so it stays level-triggered rather
+// than reacting to a single node event: a Node watch (fires when a node's
+// host IPs change) and a Pod watch (fires when a host-networked pod finishes
+// (re)starting). The Pod watch is what catches a pod that was still
+// restarting at the moment its node's IP changed and only later comes back
+// reporting its old, stale IP — after which no further Node event would
+// fire. Both watches enqueue the same Node key and share one idempotent
+// Reconcile.
 package podiprecovery
 
 import (
@@ -41,6 +50,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -83,7 +93,32 @@ func Add(mgr manager.Manager, _ options.ControllerOptions) error {
 		return fmt.Errorf("podiprecovery-controller failed to watch Nodes: %w", err)
 	}
 
+	// Watch host-networked pods too, and re-enqueue the pod's node when one
+	// settles into a Running-with-IPs state. The Node watch catches the
+	// instant a node's IP changes, but a pod that is still restarting at
+	// that instant has no status.podIPs yet and is skipped by Reconcile;
+	// when the kubelet finishes (re)starting it, the surviving pod reports
+	// its old (now stale) IP and no further Node event ever fires. Without
+	// this second watch that late-settling pod would never be re-evaluated
+	// (the recovery would be edge-triggered on the node event alone). The
+	// map function keys back to the Node, and Reconcile is idempotent, so
+	// the extra enqueues for already-healthy pods are cheap no-ops.
+	if err := c.WatchObject(&corev1.Pod{}, handler.EnqueueRequestsFromMapFunc(podToNode), hostNetPodSettledPredicate()); err != nil {
+		return fmt.Errorf("podiprecovery-controller failed to watch Pods: %w", err)
+	}
+
 	return nil
+}
+
+// podToNode maps a Pod event to a reconcile request for the Node the pod
+// runs on. Recovery is keyed on the Node, so a settling pod triggers a full
+// re-evaluation of every host-networked pod on its node.
+func podToNode(_ context.Context, obj client.Object) []reconcile.Request {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok || pod.Spec.NodeName == "" {
+		return nil
+	}
+	return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: pod.Spec.NodeName}}}
 }
 
 // hostIPsChangedPredicate filters Node events so reconciles only fire when
@@ -110,6 +145,73 @@ func hostIPsChangedPredicate() predicate.Predicate {
 			return false
 		},
 	}
+}
+
+// hostNetPodSettledPredicate filters Pod events down to operator-managed
+// hostNetwork pods that have just settled into a state where their
+// status.podIPs can be meaningfully compared against their node's host IPs.
+//
+// This is the second half of the recovery trigger (see the Pod watch in
+// Add). It fires when such a pod finishes (re)starting — either its reported
+// IPs change, or it transitions to Ready — which is the moment a pod that
+// survived a node-IP change comes back reporting its old, now-stale IP.
+func hostNetPodSettledPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			pod, ok := e.Object.(*corev1.Pod)
+			// An already-running host-net pod observed on (re)start of the
+			// controller: evaluate it if it already reports IPs.
+			return ok && isManagedHostNetPod(pod) && len(pod.Status.PodIPs) > 0
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldPod, oldOK := e.ObjectOld.(*corev1.Pod)
+			newPod, newOK := e.ObjectNew.(*corev1.Pod)
+			if !oldOK || !newOK {
+				return false
+			}
+			if !isManagedHostNetPod(newPod) || len(newPod.Status.PodIPs) == 0 {
+				return false
+			}
+			// Re-evaluate when the pod's reported IPs change or when it
+			// transitions to Ready — both mark the point at which a
+			// (re)started pod's final status.podIPs becomes observable.
+			if !podIPSet(oldPod).Equal(podIPSet(newPod)) {
+				return true
+			}
+			return !podReady(oldPod) && podReady(newPod)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
+// isManagedHostNetPod reports whether the pod is an operator-managed
+// hostNetwork pod — the only kind the recovery controller acts on.
+func isManagedHostNetPod(pod *corev1.Pod) bool {
+	return pod.Spec.HostNetwork && pod.Labels[common.HostNetworkedPodLabel] == "true"
+}
+
+// podIPSet returns the set of IPs reported in the pod's status.podIPs.
+func podIPSet(pod *corev1.Pod) sets.Set[string] {
+	out := sets.New[string]()
+	for _, pip := range pod.Status.PodIPs {
+		out.Insert(pip.IP)
+	}
+	return out
+}
+
+// podReady reports whether the pod's Ready condition is currently True.
+func podReady(pod *corev1.Pod) bool {
+	for _, c := range pod.Status.Conditions {
+		if c.Type == corev1.PodReady {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+	return false
 }
 
 // nodeHostIPSet returns the set of addresses that the kubelet would use to

--- a/pkg/controller/podiprecovery/podiprecovery_controller.go
+++ b/pkg/controller/podiprecovery/podiprecovery_controller.go
@@ -50,9 +50,11 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -70,14 +72,50 @@ import (
 
 var log = logf.Log.WithName("controller_podiprecovery")
 
-// podNodeNameIndex is the field-index registered in cmd/main.go that lets
-// us list pods by their `spec.nodeName` with a server-side field selector.
+// podNodeNameIndex is the field-index (registered on this controller's
+// dedicated host-networked pod cache) that lets us list pods by their
+// `spec.nodeName` with a server-side field selector.
 const podNodeNameIndex = "spec.nodeName"
 
 // Add wires the controller into the manager.
 func Add(mgr manager.Manager, _ options.ControllerOptions) error {
+	// Build a dedicated cache scoped server-side to operator-managed
+	// host-networked pods. Both the Pod watch and the per-node pod List read
+	// from this cache, so the controller only ever lists/watches/holds the
+	// handful of host-networked pods cluster-wide — it does not force the
+	// manager's shared cache to watch every pod in the cluster (which, at
+	// scale, would be a sizable memory cost).
+	podCache, err := cache.New(mgr.GetConfig(), cache.Options{
+		Scheme: mgr.GetScheme(),
+		Mapper: mgr.GetRESTMapper(),
+		ByObject: map[client.Object]cache.ByObject{
+			&corev1.Pod{}: {
+				Label: labels.SelectorFromSet(labels.Set{common.HostNetworkedPodLabel: "true"}),
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("podiprecovery-controller failed to create host-networked pod cache: %w", err)
+	}
+
+	// Index the scoped cache by spec.nodeName so Reconcile can list a node's
+	// pods with a server-side field selector.
+	if err := podCache.IndexField(context.Background(), &corev1.Pod{}, podNodeNameIndex,
+		func(obj client.Object) []string {
+			return []string{obj.(*corev1.Pod).Spec.NodeName}
+		},
+	); err != nil {
+		return fmt.Errorf("podiprecovery-controller failed to index host-networked pod cache: %w", err)
+	}
+
+	// Run the scoped cache as part of the manager so it starts/stops with it.
+	if err := mgr.Add(podCache); err != nil {
+		return fmt.Errorf("podiprecovery-controller failed to add host-networked pod cache to manager: %w", err)
+	}
+
 	r := &Reconciler{
-		client: mgr.GetClient(),
+		client:            mgr.GetClient(),
+		hostNetworkedPods: hostNetworkedPodLister{reader: podCache},
 	}
 
 	c, err := ctrlruntime.NewController("podiprecovery-controller", mgr, controller.Options{Reconciler: r})
@@ -103,7 +141,10 @@ func Add(mgr manager.Manager, _ options.ControllerOptions) error {
 	// (the recovery would be edge-triggered on the node event alone). The
 	// map function keys back to the Node, and Reconcile is idempotent, so
 	// the extra enqueues for already-healthy pods are cheap no-ops.
-	if err := c.WatchObject(&corev1.Pod{}, handler.EnqueueRequestsFromMapFunc(podToNode), hostNetPodSettledPredicate()); err != nil {
+	//
+	// The watch uses the label-scoped podCache above, so the informer only
+	// receives events for host-networked pods.
+	if err := c.WatchObjectInCache(podCache, &corev1.Pod{}, handler.EnqueueRequestsFromMapFunc(podToNode), hostNetPodSettledPredicate()); err != nil {
 		return fmt.Errorf("podiprecovery-controller failed to watch Pods: %w", err)
 	}
 
@@ -245,10 +286,44 @@ func nodeHostIPSet(addrs []corev1.NodeAddress) sets.Set[string] {
 
 // Reconciler implements reconcile.Reconciler.
 type Reconciler struct {
+	// client is the manager's shared cached client, used for Node reads, the
+	// Installation gate, and pod deletes.
 	client client.Client
+	// hostNetworkedPods reads operator-managed host-networked pods from a
+	// label-scoped cache, so the controller never forces the shared cache to
+	// watch every pod cluster-wide.
+	hostNetworkedPods hostNetworkedPodLister
 }
 
 var _ reconcile.Reconciler = &Reconciler{}
+
+// hostNetworkedPodLister lists operator-managed host-networked pods from a
+// cache scoped server-side to the host-networked marker label.
+//
+// It deliberately wraps the scoped reader and exposes ONLY a node-scoped list
+// of host-networked pods, rather than being a general client.Reader. This
+// guards against the one dangerous mistake with a scoped cache: reading from
+// it expecting the full set of cluster pods would silently drop every
+// non-host-networked pod. There is intentionally no way to Get/List arbitrary
+// pods through this type.
+type hostNetworkedPodLister struct {
+	reader client.Reader
+}
+
+// onNode returns the operator-managed host-networked pods scheduled on the
+// given node. The label selector is a redundant guard (the backing cache is
+// already label-scoped); the field selector narrows by node using the index
+// registered on that cache.
+func (l hostNetworkedPodLister) onNode(ctx context.Context, nodeName string) ([]corev1.Pod, error) {
+	var pl corev1.PodList
+	if err := l.reader.List(ctx, &pl,
+		client.MatchingLabels{common.HostNetworkedPodLabel: "true"},
+		client.MatchingFields{podNodeNameIndex: nodeName},
+	); err != nil {
+		return nil, err
+	}
+	return pl.Items, nil
+}
 
 // Reconcile is called for a Node when its host IPs change (or on initial
 // creation). It lists operator-managed pods on the node and deletes any
@@ -284,21 +359,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, nil
 	}
 
-	// List operator-managed hostNetwork pods on this node. The label is
-	// applied at render time across all hostNetwork workloads; the field
-	// selector narrows by node server-side using the index registered in
-	// cmd/main.go.
-	var pl corev1.PodList
-	if err := r.client.List(ctx, &pl,
-		client.MatchingLabels{common.HostNetworkedPodLabel: "true"},
-		client.MatchingFields{podNodeNameIndex: node.Name},
-	); err != nil {
+	// List operator-managed host-networked pods on this node from the scoped
+	// cache (host-networked pods only — never the full pod set).
+	pods, err := r.hostNetworkedPods.onNode(ctx, node.Name)
+	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to list pods on node %q: %w", node.Name, err)
 	}
 
 	var firstErr error
 	deleted := 0
-	for _, pod := range pl.Items {
+	for _, pod := range pods {
 		if !pod.Spec.HostNetwork {
 			// Safety check: only delete hostNetwork pods. A non-hostNetwork
 			// pod that happens to carry our label has a CNI-assigned IP

--- a/pkg/controller/podiprecovery/podiprecovery_controller.go
+++ b/pkg/controller/podiprecovery/podiprecovery_controller.go
@@ -131,17 +131,6 @@ func Add(mgr manager.Manager, _ options.ControllerOptions) error {
 		return fmt.Errorf("podiprecovery-controller failed to watch Nodes: %w", err)
 	}
 
-	// Watch host-networked pods too, and re-enqueue the pod's node when one
-	// settles into a Running-with-IPs state. The Node watch catches the
-	// instant a node's IP changes, but a pod that is still restarting at
-	// that instant has no status.podIPs yet and is skipped by Reconcile;
-	// when the kubelet finishes (re)starting it, the surviving pod reports
-	// its old (now stale) IP and no further Node event ever fires. Without
-	// this second watch that late-settling pod would never be re-evaluated
-	// (the recovery would be edge-triggered on the node event alone). The
-	// map function keys back to the Node, and Reconcile is idempotent, so
-	// the extra enqueues for already-healthy pods are cheap no-ops.
-	//
 	// The watch uses the label-scoped podCache above, so the informer only
 	// receives events for host-networked pods.
 	if err := c.WatchObjectInCache(podCache, &corev1.Pod{}, handler.EnqueueRequestsFromMapFunc(podToNode), hostNetPodSettledPredicate()); err != nil {
@@ -232,6 +221,13 @@ func hostNetPodSettledPredicate() predicate.Predicate {
 
 // isManagedHostNetPod reports whether the pod is an operator-managed
 // hostNetwork pod — the only kind the recovery controller acts on.
+// The label check is defense-in-depth: the Pod watch is backed by a cache
+// scoped server-side to this same label (see Add), so events reaching the
+// predicate already carry it. It's kept intentionally so the predicate stays
+// correct independently of how the watch is wired — if the watch is ever
+// pointed back at a non-label-scoped cache, this still prevents enqueuing a
+// reconcile for every pod in the cluster. The spec.HostNetwork check is not
+// covered by the label selector.
 func isManagedHostNetPod(pod *corev1.Pod) bool {
 	return pod.Spec.HostNetwork && pod.Labels[common.HostNetworkedPodLabel] == "true"
 }

--- a/pkg/controller/podiprecovery/podiprecovery_controller_test.go
+++ b/pkg/controller/podiprecovery/podiprecovery_controller_test.go
@@ -335,6 +335,102 @@ var _ = Describe("PodIPRecovery controller", func() {
 			Expect(pred.Update(event.UpdateEvent{ObjectOld: old, ObjectNew: new})).To(BeTrue())
 		})
 	})
+
+	Context("hostNetPodSettledPredicate", func() {
+		pred := hostNetPodSettledPredicate()
+
+		// settledPod builds a managed host-networked pod on node1 with the
+		// given IPs and readiness. Tests override individual fields as needed.
+		settledPod := func(podIPs []string, ready bool) *corev1.Pod {
+			p := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "p1",
+					Namespace: ns,
+					Labels:    map[string]string{common.HostNetworkedPodLabel: "true"},
+				},
+				Spec: corev1.PodSpec{NodeName: "node1", HostNetwork: true},
+			}
+			for _, ip := range podIPs {
+				p.Status.PodIPs = append(p.Status.PodIPs, corev1.PodIP{IP: ip})
+			}
+			cond := corev1.ConditionFalse
+			if ready {
+				cond = corev1.ConditionTrue
+			}
+			p.Status.Conditions = []corev1.PodCondition{{Type: corev1.PodReady, Status: cond}}
+			return p
+		}
+
+		It("enqueues on Create when a managed host-net pod already reports IPs", func() {
+			Expect(pred.Create(event.CreateEvent{Object: settledPod([]string{"10.0.0.1"}, true)})).To(BeTrue())
+		})
+
+		It("does not enqueue on Create when the pod has no IPs yet", func() {
+			Expect(pred.Create(event.CreateEvent{Object: settledPod(nil, false)})).To(BeFalse())
+		})
+
+		It("does not enqueue on Create for a pod without the host-net marker label", func() {
+			p := settledPod([]string{"10.0.0.1"}, true)
+			p.Labels = nil
+			Expect(pred.Create(event.CreateEvent{Object: p})).To(BeFalse())
+		})
+
+		It("does not enqueue on Create for a non-hostNetwork pod", func() {
+			p := settledPod([]string{"10.0.0.1"}, true)
+			p.Spec.HostNetwork = false
+			Expect(pred.Create(event.CreateEvent{Object: p})).To(BeFalse())
+		})
+
+		It("enqueues on Update when the pod's IPs appear (empty -> set)", func() {
+			old := settledPod(nil, false)
+			new := settledPod([]string{"10.0.0.1"}, false)
+			Expect(pred.Update(event.UpdateEvent{ObjectOld: old, ObjectNew: new})).To(BeTrue())
+		})
+
+		It("enqueues on Update when the pod becomes Ready (this is the late-settling survivor case)", func() {
+			// The surviving pod comes back reporting its old, now-stale IP;
+			// its IPs don't change but it transitions to Ready. This is the
+			// exact edge the Node watch alone would miss.
+			old := settledPod([]string{"10.0.0.1"}, false)
+			new := settledPod([]string{"10.0.0.1"}, true)
+			Expect(pred.Update(event.UpdateEvent{ObjectOld: old, ObjectNew: new})).To(BeTrue())
+		})
+
+		It("does not enqueue on Update when nothing relevant changed (steady-state heartbeat)", func() {
+			old := settledPod([]string{"10.0.0.1"}, true)
+			new := settledPod([]string{"10.0.0.1"}, true)
+			Expect(pred.Update(event.UpdateEvent{ObjectOld: old, ObjectNew: new})).To(BeFalse())
+		})
+
+		It("does not enqueue on Update for a pod without the host-net marker label", func() {
+			old := settledPod(nil, false)
+			old.Labels = nil
+			new := settledPod([]string{"10.0.0.1"}, true)
+			new.Labels = nil
+			Expect(pred.Update(event.UpdateEvent{ObjectOld: old, ObjectNew: new})).To(BeFalse())
+		})
+
+		It("does not enqueue on Delete", func() {
+			Expect(pred.Delete(event.DeleteEvent{Object: settledPod([]string{"10.0.0.1"}, true)})).To(BeFalse())
+		})
+	})
+
+	Context("podToNode", func() {
+		It("maps a pod to a reconcile request for its node", func() {
+			pod := newPod("p1", "node7", "10.0.0.1", true)
+			reqs := podToNode(ctx, pod)
+			Expect(reqs).To(ConsistOf(reconcile.Request{NamespacedName: types.NamespacedName{Name: "node7"}}))
+		})
+
+		It("returns nothing for a pod not yet scheduled to a node", func() {
+			pod := newPod("p1", "", "10.0.0.1", true)
+			Expect(podToNode(ctx, pod)).To(BeEmpty())
+		})
+
+		It("returns nothing for a non-pod object", func() {
+			Expect(podToNode(ctx, newNode("node1", "10.0.0.1"))).To(BeEmpty())
+		})
+	})
 })
 
 // newPodWithLabels is the lower-level helper used by the `newPod` shortcut.

--- a/pkg/controller/podiprecovery/podiprecovery_controller_test.go
+++ b/pkg/controller/podiprecovery/podiprecovery_controller_test.go
@@ -86,7 +86,11 @@ var _ = Describe("PodIPRecovery controller", func() {
 				return []string{obj.(*corev1.Pod).Spec.NodeName}
 			}).
 			Build()
-		r = &Reconciler{client: c}
+		// In production the lister wraps a label-scoped cache; the fake client
+		// (which carries the same spec.nodeName index) stands in for it here.
+		// onNode keeps a redundant label selector, so unlabeled pods in this
+		// unscoped fake client are still filtered out.
+		r = &Reconciler{client: c, hostNetworkedPods: hostNetworkedPodLister{reader: c}}
 
 		// By default, create the Installation so Reconcile proceeds.
 		// The Installation-gate test overrides this expectation.

--- a/pkg/controller/utils/utils_test.go
+++ b/pkg/controller/utils/utils_test.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -339,6 +340,11 @@ type mockController struct {
 
 func (m *mockController) WatchObject(obj client.Object, eventhandler handler.EventHandler, predicates ...predicate.Predicate) error {
 	args := m.Called(obj, eventhandler, predicates)
+	return args.Error(0)
+}
+
+func (m *mockController) WatchObjectInCache(cch cache.Cache, obj client.Object, eventhandler handler.EventHandler, predicates ...predicate.Predicate) error {
+	args := m.Called(cch, obj, eventhandler, predicates)
 	return args.Error(0)
 }
 

--- a/pkg/ctrlruntime/controller.go
+++ b/pkg/ctrlruntime/controller.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2024-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,6 +45,13 @@ type Controller interface {
 
 	// WatchObject creates a watch for the specific object, using the cache stored internal to the Controller.
 	WatchObject(object client.Object, eventhandler handler.EventHandler, predicates ...predicate.Predicate) error
+
+	// WatchObjectInCache creates a watch for the specific object using the
+	// provided cache instead of the manager's shared cache. Use this when a
+	// controller needs a scoped (e.g. label-filtered) informer for a type so
+	// it does not force the manager's shared cache to list/watch every object
+	// of that type cluster-wide.
+	WatchObjectInCache(cch cache.Cache, object client.Object, eventhandler handler.EventHandler, predicates ...predicate.Predicate) error
 }
 
 // controler is an implementation of Controller. It stores the cache from the manager it was created from and uses it
@@ -65,4 +72,8 @@ func NewController(name string, mgr manager.Manager, options controller.Options)
 
 func (c *controler) WatchObject(object client.Object, eventhandler handler.EventHandler, predicates ...predicate.Predicate) error {
 	return c.Watch(source.Kind(c.cach, object, eventhandler, predicates...))
+}
+
+func (c *controler) WatchObjectInCache(cch cache.Cache, object client.Object, eventhandler handler.EventHandler, predicates ...predicate.Predicate) error {
+	return c.Watch(source.Kind(cch, object, eventhandler, predicates...))
 }

--- a/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_felixconfigurations.yaml
@@ -1115,6 +1115,25 @@ spec:
                     blocks traffic with a "drop" action. If you want to use a "reject" action instead you can configure it here.
                   pattern: ^(?i)(Drop|Reject)?$
                   type: string
+                nftablesFlowTableDataIfacePattern:
+                  description: |-
+                    NFTablesFlowTableDataIfacePattern is a regular expression that controls which host
+                    interfaces are added to the nftables flowtable, so that traffic forwarded between those
+                    interfaces and local workloads is offloaded to the flowtable fast path. Leave empty to
+                    offload only workload-to-workload traffic. Only takes effect when NFTablesFlowTableOffload
+                    is not Disabled. [Default: ""]
+                  type: string
+                nftablesFlowTableOffload:
+                  default: Disabled
+                  description: |-
+                    NFTablesFlowTableOffload controls which traffic nftables flowtable offload is enabled for,
+                    for improved forwarding performance. When set to "All", established connections accepted by
+                    Calico policy are offloaded to the kernel's flowtable fast path. Only applies when
+                    nftables mode is active. [Default: Disabled]
+                  enum:
+                    - All
+                    - Disabled
+                  type: string
                 nftablesMangleAllowAction:
                   description: |-
                     NftablesMangleAllowAction controls the nftables action that Felix uses to represent the "allow" policy verdict

--- a/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_felixconfigurations.yaml
+++ b/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_felixconfigurations.yaml
@@ -1114,6 +1114,25 @@ spec:
                     blocks traffic with a "drop" action. If you want to use a "reject" action instead you can configure it here.
                   pattern: ^(?i)(Drop|Reject)?$
                   type: string
+                nftablesFlowTableDataIfacePattern:
+                  description: |-
+                    NFTablesFlowTableDataIfacePattern is a regular expression that controls which host
+                    interfaces are added to the nftables flowtable, so that traffic forwarded between those
+                    interfaces and local workloads is offloaded to the flowtable fast path. Leave empty to
+                    offload only workload-to-workload traffic. Only takes effect when NFTablesFlowTableOffload
+                    is not Disabled. [Default: ""]
+                  type: string
+                nftablesFlowTableOffload:
+                  default: Disabled
+                  description: |-
+                    NFTablesFlowTableOffload controls which traffic nftables flowtable offload is enabled for,
+                    for improved forwarding performance. When set to "All", established connections accepted by
+                    Calico policy are offloaded to the kernel's flowtable fast path. Only applies when
+                    nftables mode is active. [Default: Disabled]
+                  enum:
+                    - All
+                    - Disabled
+                  type: string
                 nftablesMangleAllowAction:
                   description: |-
                     NftablesMangleAllowAction controls the nftables action that Felix uses to represent the "allow" policy verdict


### PR DESCRIPTION
Follow-up to #4784. Two fixes to the podiprecovery controller.

## 1. Recovery was edge-triggered (add a Pod watch)

The Node watch alone fired only when a node's host IPs changed. On a KubeVirt
reboot, the node's new IP is reported while its host-networked pods are still
restarting (empty `status.podIPs`), so the reconcile skips them; when a
surviving pod later comes back with its old, now-stale IP, the node IP has
already settled and no further Node event fires — so the stale pod is never
re-checked.

Add a second watch on operator-managed host-networked Pods that re-enqueues a
pod's node when it settles (IPs appear/change, or it becomes Ready). Both
watches feed the same idempotent, node-keyed Reconcile, making recovery
level-triggered on both inputs (node addresses + pod IPs) while staying
event-driven. The predicate is gated on the host-networked label +
`spec.hostNetwork`.

## 2. Don't force a cluster-wide Pod cache (use a scoped cache)

As written, #4784 registered a `Pod.spec.nodeName` field index in
`cmd/main.go` and read pods via the shared cache — either forces a
cluster-wide Pod informer holding every pod in memory, always-on from startup.
That's a sizable memory cost at scale and a regression (the operator's other
pod readers are conditional, so the shared Pod informer was previously
lazy/absent).

Give the controller its own `cache.New` scoped **server-side** to the
`operator.tigera.io/host-networked` label; the watch, the per-node List, and
the `spec.nodeName` index all live on it, so only the handful of
host-networked pods are cached and the shared cache is untouched. The
`cmd/main.go` field index is removed (supersedes that part of #4784). The
scoped reader is wrapped in a `hostNetworkedPodLister` exposing only
"list host-networked pods on a node", so it can't be misused as a full-pod
reader (which would silently drop non-host-networked pods).

## Changes
- `podiprecovery`: Pod watch + `podToNode` + `hostNetPodSettledPredicate`;
  dedicated label-scoped `cache.New` (with `spec.nodeName` index), wrapped in
  `hostNetworkedPodLister`.
- `ctrlruntime`: add `WatchObjectInCache` (watch via a supplied cache).
- `cmd/main.go`: remove the shared-cache `Pod.spec.nodeName` index from #4784.
- update `mockController` in utils/egressgateway tests for the new method.

## Testing
Unit tests for the pod-settle predicate and `podToNode` mapping;
`go build`/`go vet ./...` clean; podiprecovery/utils/egressgateway tests pass.

## Release Note

```release-note
None
```

For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run make gen-files
- [ ] If changing versions, run make gen-versions

For PR reviewers

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - [x] kind/bug
  - [ ] kind/enhancement
  - [ ] enterprise
