### PR TITLE
build(gatewayapi): remove the bundled Envoy Gateway chart in make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -314,6 +314,7 @@ $(BINDIR)/kind:
 clean:
 	rm -rf $(BUILD_DIR)
 	rm -rf $(ISTIO_CHART_FILES)
+	rm -rf $(ENVOY_GATEWAY_CHART)
 	rm -rf build/init/bin
 	rm -rf hack/bin
 	rm -rf .go-pkg-cache


### PR DESCRIPTION
## Description

Bug fix, build tooling.

The bundled Envoy Gateway helm chart `pkg/render/gatewayapi/gateway-helm.tgz` is gitignored and `go:embed`'d into the operator binary, fetched by a rule whose only prerequisite is the helm binary, not `ENVOY_GATEWAY_VERSION`:

```
$(ENVOY_GATEWAY_CHART): $(HACK_BIN)/helm-$(BUILDARCH)
	$(HELM_BUILDARCH_BINARY) pull ... --version $(ENVOY_GATEWAY_VERSION) ...
```

So once the tgz exists, Make calls it up to date and never re-pulls, even after the pinned version is bumped. `clean` already removes `$(ISTIO_CHART_FILES)` but not this one, so `make clean && make image` keeps the stale chart too. A chart left over from an earlier build then gets embedded into the image, shipping Gateway API CRDs and RBAC that don't match the pinned Envoy Gateway version.

I hit this building after the EG v1.7.2 to v1.8.0 bump: the image kept embedding the old v1.7.2 chart (Gateway API v1.4.1 CRDs, `xlistenersets` RBAC) while `ENVOY_GATEWAY_VERSION` was `v1.8.0`, and the EG v1.8.0 control plane crash-looped with `no matches for kind "ListenerSet" in gateway.networking.k8s.io/v1`.

This adds the EG chart to `clean`, matching how `$(ISTIO_CHART_FILES)` is already handled, so `make clean` forces a fresh pull on the next build.

Testing: on a build host, `make pkg/render/gatewayapi/gateway-helm.tgz` with the file present reports "is up to date" and keeps the stale chart; removing it (what this makes `clean` do) triggers the pull of the pinned version. A follow-up `make image` then embeds the correct chart and the EG control plane starts clean.

Components: `Makefile` (build), Gateway API.

## Release Note

```release-note
NONE
```

Please swap `release-note-required` for `release-note-not-required` and `docs-pr-required` for `docs-not-required`: this is build tooling with no change to operator runtime behavior.

## For PR author

- [x] Tests for change. (N/A: Makefile-only build-hygiene change)
- [ ] If changing pkg/apis/, run `make gen-files` (N/A)
- [ ] If changing versions, run `make gen-versions` (N/A)
