### PR TITLE
feat(apiserver): provision per-tenant calico-apiserver Linseed RBAC

### DIFF
--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -255,14 +255,25 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	reqLogger.V(2).Info("Reconciling APIServer")
 
-	// In multi-tenant mode a request scoped to a tenant namespace is handled by the per-tenant path: the
-	// aggregated API server itself is a cluster-scoped, calico-system component (reconciled by the
-	// empty-namespace request), so all a tenant namespace needs is the calico-apiserver ServiceAccount.
-	// That ServiceAccount is the subject the shared calico-apiserver ClusterRoleBinding grants Linseed
-	// access to, allowing this tenant's managed clusters to reach Linseed. We short-circuit here to avoid
-	// running any of the cluster-scoped API server setup (certificates, deployment, etc.) for tenants.
+	// In multi-tenant mode, a request scoped to a tenant namespace is handled by the per-tenant path, which
+	// provisions only that tenant's Linseed-access RBAC. The aggregated API server itself is a single
+	// cluster-scoped component in calico-system, reconciled by the cluster-scoped path below.
+	//
+	// We must only divert to the per-tenant path for genuine tenant namespaces. Many of this controller's
+	// watches (secrets and config maps in the operator namespace, the API server deployment in calico-system,
+	// etc.) enqueue requests carrying a non-empty, non-tenant namespace; those must fall through to the
+	// cluster-scoped reconcile, or the API server would stop reconciling on those events. A namespace is a
+	// tenant namespace iff it contains a Tenant, so we key off that rather than "namespace is non-empty".
 	if r.opts.MultiTenant && request.Namespace != "" {
-		return r.reconcileTenant(ctx, request.Namespace, reqLogger)
+		tenant, _, err := utils.GetTenant(ctx, true, r.client, request.Namespace)
+		if err != nil && !errors.IsNotFound(err) {
+			r.status.SetDegraded(operatorv1.ResourceReadError, "An error occurred while querying Tenant", err, reqLogger)
+			return reconcile.Result{}, err
+		}
+		if tenant != nil {
+			return r.reconcileTenant(ctx, tenant, reqLogger)
+		}
+		// No Tenant in this namespace - fall through to the cluster-scoped reconcile.
 	}
 
 	// Check if a datastore migration is in progress. If so, the migration controller
@@ -645,23 +656,14 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 	return reconcile.Result{}, nil
 }
 
-// reconcileTenant handles a reconcile request scoped to a single tenant namespace in multi-tenant mode.
-// The aggregated API server itself is a cluster-scoped calico-system component; what a tenant namespace needs
-// is the calico-apiserver ServiceAccount plus the per-tenant Linseed-access ClusterRole and ClusterRoleBinding
-// that authorize that ServiceAccount against Linseed. These are rendered by render.TenantAPIServerRBAC and are
-// owned by the Tenant, so they are garbage collected when the tenant namespace is torn down.
-func (r *ReconcileAPIServer) reconcileTenant(ctx context.Context, namespace string, reqLogger logr.Logger) (reconcile.Result, error) {
-	tenant, _, err := utils.GetTenant(ctx, true, r.client, namespace)
-	if errors.IsNotFound(err) {
-		reqLogger.V(1).Info("No Tenant in this namespace, skipping")
-		return reconcile.Result{}, nil
-	} else if err != nil {
-		r.status.SetDegraded(operatorv1.ResourceReadError, "An error occurred while querying Tenant", err, reqLogger)
-		return reconcile.Result{}, err
-	}
-
+// reconcileTenant handles a reconcile request scoped to a single tenant namespace in multi-tenant mode. The
+// aggregated API server itself is a cluster-scoped calico-system component; what a tenant namespace needs is
+// the per-tenant Linseed-access ClusterRole and ClusterRoleBinding that authorize the tenant's calico-apiserver
+// identity against Linseed. These are rendered by render.TenantAPIServerRBAC. The Tenant is passed as the owner
+// so the handler attributes the resources to it (cluster-scoped resources do not receive an owner reference).
+func (r *ReconcileAPIServer) reconcileTenant(ctx context.Context, tenant *operatorv1.Tenant, reqLogger logr.Logger) (reconcile.Result, error) {
 	handler := utils.NewComponentHandler(log, r.client, r.scheme, tenant)
-	component := render.TenantAPIServerRBAC(namespace)
+	component := render.TenantAPIServerRBAC(tenant.Namespace)
 	if err := handler.CreateOrUpdateOrDelete(ctx, component, r.status); err != nil {
 		r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error creating / updating tenant API server RBAC", err, reqLogger)
 		return reconcile.Result{}, err

--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -492,10 +492,9 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 	// For zero/single-tenant clusters this is empty (the calico-system API server is covered by its own
 	// ClusterRoleBinding); for multi-tenant management clusters it is every tenant namespace, so each tenant's
 	// calico-apiserver identity is authorized against Linseed.
-	nsHelper := utils.NewNamespaceHelper(r.opts.MultiTenant, render.APIServerNamespace, "")
 	var bindingNamespaces []string
 	if r.opts.MultiTenant {
-		bindingNamespaces, err = nsHelper.TenantNamespaces(r.client)
+		bindingNamespaces, err = utils.TenantNamespaces(ctx, r.client, nil)
 		if err != nil {
 			r.status.SetDegraded(operatorv1.ResourceReadError, "Error reading tenant namespaces", err, reqLogger)
 			return reconcile.Result{}, err

--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
+
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -188,6 +190,33 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 		return fmt.Errorf("apiserver-controller failed to create periodic reconcile watch: %w", err)
 	}
 
+	if opts.MultiTenant {
+		// In multi-tenant mode the apiserver controller has two responsibilities: the cluster-scoped
+		// reconcile (request with an empty namespace) installs the aggregated API server in calico-system,
+		// while a per-tenant reconcile (request scoped to a tenant namespace) creates the calico-apiserver
+		// ServiceAccount in that tenant namespace so it can be authorized against Linseed.
+		//
+		// A Tenant change enqueues both the tenant's own namespace (to create/refresh its ServiceAccount)
+		// and the cluster-scoped request (to refresh the shared ClusterRoleBinding's subject list, which
+		// enumerates all tenant namespaces).
+		tenantHandler := handler.EnqueueRequestsFromMapFunc(func(_ context.Context, obj client.Object) []reconcile.Request {
+			return []reconcile.Request{
+				{NamespacedName: types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}},
+				{NamespacedName: types.NamespacedName{Name: ResourceName}},
+			}
+		})
+		if err = c.WatchObject(&operatorv1.Tenant{}, tenantHandler); err != nil {
+			return fmt.Errorf("apiserver-controller failed to watch Tenant resource: %w", err)
+		}
+
+		// Periodically re-reconcile every tenant namespace as a backstop so a tenant's ServiceAccount
+		// self-heals if it is deleted out-of-band. The existing periodic reconcile above only drives the
+		// cluster-scoped (empty-namespace) reconcile.
+		if err = utils.AddPeriodicReconcile(c, utils.PeriodicReconcileTime, utils.EnqueueAllTenants(mgr.GetClient())); err != nil {
+			return fmt.Errorf("apiserver-controller failed to create per-tenant periodic reconcile watch: %w", err)
+		}
+	}
+
 	// Watch DatastoreMigration CRs so the apiserver controller reacts promptly
 	// to migration phase changes (e.g., goes hands-off during Migrating).
 	// Uses ResourceVersionChangedPredicate because migration phase transitions
@@ -225,6 +254,16 @@ type ReconcileAPIServer struct {
 func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	reqLogger.V(2).Info("Reconciling APIServer")
+
+	// In multi-tenant mode a request scoped to a tenant namespace is handled by the per-tenant path: the
+	// aggregated API server itself is a cluster-scoped, calico-system component (reconciled by the
+	// empty-namespace request), so all a tenant namespace needs is the calico-apiserver ServiceAccount.
+	// That ServiceAccount is the subject the shared calico-apiserver ClusterRoleBinding grants Linseed
+	// access to, allowing this tenant's managed clusters to reach Linseed. We short-circuit here to avoid
+	// running any of the cluster-scoped API server setup (certificates, deployment, etc.) for tenants.
+	if r.opts.MultiTenant && request.Namespace != "" {
+		return r.reconcileTenant(ctx, request.Namespace, reqLogger)
+	}
 
 	// Check if a datastore migration is in progress. If so, the migration controller
 	// owns the APIService and we should not reconcile to avoid fighting over it.
@@ -476,6 +515,16 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 	// Create a component handler to manage the rendered component.
 	handler := utils.NewComponentHandler(log, r.client, r.scheme, instance)
 
+	// Determine the namespaces whose calico-apiserver service account should be bound to the calico-apiserver
+	// ClusterRole. For zero/single-tenant clusters this is calico-system; for multi-tenant management clusters it is
+	// every tenant namespace, so each tenant's calico-apiserver identity is authorized against Linseed.
+	nsHelper := utils.NewNamespaceHelper(r.opts.MultiTenant, render.APIServerNamespace, "")
+	bindingNamespaces, err := nsHelper.TenantNamespaces(r.client)
+	if err != nil {
+		r.status.SetDegraded(operatorv1.ResourceReadError, "Error reading tenant namespaces", err, reqLogger)
+		return reconcile.Result{}, err
+	}
+
 	// Render the desired objects from the CRD and create or update them.
 	reqLogger.V(3).Info("rendering components")
 
@@ -493,6 +542,7 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 		OpenShift:                    r.opts.DetectedProvider.IsOpenShift(),
 		TrustedBundle:                trustedBundle,
 		MultiTenant:                  r.opts.MultiTenant,
+		BindingNamespaces:            bindingNamespaces,
 		KeyValidatorConfig:           keyValidatorConfig,
 		KubernetesVersion:            r.opts.KubernetesVersion,
 		ClusterDomain:                r.opts.ClusterDomain,
@@ -603,6 +653,31 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 	if err = r.client.Status().Update(ctx, instance); err != nil {
 		return reconcile.Result{}, err
 	}
+	return reconcile.Result{}, nil
+}
+
+// reconcileTenant handles a reconcile request scoped to a single tenant namespace in multi-tenant mode.
+// The aggregated API server is a cluster-scoped calico-system component; the only thing a tenant
+// namespace needs is the calico-apiserver ServiceAccount, which is the subject the shared
+// calico-apiserver ClusterRoleBinding authorizes against Linseed. We create just that ServiceAccount,
+// owned by the Tenant so it is garbage collected when the tenant namespace is torn down.
+func (r *ReconcileAPIServer) reconcileTenant(ctx context.Context, namespace string, reqLogger logr.Logger) (reconcile.Result, error) {
+	tenant, _, err := utils.GetTenant(ctx, true, r.client, namespace)
+	if errors.IsNotFound(err) {
+		reqLogger.V(1).Info("No Tenant in this namespace, skipping")
+		return reconcile.Result{}, nil
+	} else if err != nil {
+		r.status.SetDegraded(operatorv1.ResourceReadError, "An error occurred while querying Tenant", err, reqLogger)
+		return reconcile.Result{}, err
+	}
+
+	handler := utils.NewComponentHandler(log, r.client, r.scheme, tenant)
+	component := render.NewCreationPassthrough(render.APIServerServiceAccount(namespace))
+	if err := handler.CreateOrUpdateOrDelete(ctx, component, r.status); err != nil {
+		r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error creating / updating tenant API server RBAC", err, reqLogger)
+		return reconcile.Result{}, err
+	}
+
 	return reconcile.Result{}, nil
 }
 

--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -194,22 +194,22 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 		// In multi-tenant mode the apiserver controller has two responsibilities: the cluster-scoped
 		// reconcile (request with an empty namespace) installs the aggregated API server in calico-system,
 		// while a per-tenant reconcile (request scoped to a tenant namespace) creates the calico-apiserver
-		// ServiceAccount in that tenant namespace so it can be authorized against Linseed.
+		// ServiceAccount and its per-tenant Linseed-access RBAC in that tenant namespace so it can be
+		// authorized against Linseed.
 		//
-		// A Tenant change enqueues both the tenant's own namespace (to create/refresh its ServiceAccount)
-		// and the cluster-scoped request (to refresh the shared ClusterRoleBinding's subject list, which
-		// enumerates all tenant namespaces).
+		// A Tenant change enqueues the tenant's own namespace so its per-tenant RBAC is created/refreshed.
+		// The per-tenant RBAC is self-contained (named per tenant), so no cluster-scoped re-reconcile is
+		// needed.
 		tenantHandler := handler.EnqueueRequestsFromMapFunc(func(_ context.Context, obj client.Object) []reconcile.Request {
 			return []reconcile.Request{
 				{NamespacedName: types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}},
-				{NamespacedName: types.NamespacedName{Name: ResourceName}},
 			}
 		})
 		if err = c.WatchObject(&operatorv1.Tenant{}, tenantHandler); err != nil {
 			return fmt.Errorf("apiserver-controller failed to watch Tenant resource: %w", err)
 		}
 
-		// Periodically re-reconcile every tenant namespace as a backstop so a tenant's ServiceAccount
+		// Periodically re-reconcile every tenant namespace as a backstop so a tenant's per-tenant RBAC
 		// self-heals if it is deleted out-of-band. The existing periodic reconcile above only drives the
 		// cluster-scoped (empty-namespace) reconcile.
 		if err = utils.AddPeriodicReconcile(c, utils.PeriodicReconcileTime, utils.EnqueueAllTenants(mgr.GetClient())); err != nil {
@@ -515,16 +515,6 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 	// Create a component handler to manage the rendered component.
 	handler := utils.NewComponentHandler(log, r.client, r.scheme, instance)
 
-	// Determine the namespaces whose calico-apiserver service account should be bound to the calico-apiserver
-	// ClusterRole. For zero/single-tenant clusters this is calico-system; for multi-tenant management clusters it is
-	// every tenant namespace, so each tenant's calico-apiserver identity is authorized against Linseed.
-	nsHelper := utils.NewNamespaceHelper(r.opts.MultiTenant, render.APIServerNamespace, "")
-	bindingNamespaces, err := nsHelper.TenantNamespaces(r.client)
-	if err != nil {
-		r.status.SetDegraded(operatorv1.ResourceReadError, "Error reading tenant namespaces", err, reqLogger)
-		return reconcile.Result{}, err
-	}
-
 	// Render the desired objects from the CRD and create or update them.
 	reqLogger.V(3).Info("rendering components")
 
@@ -542,7 +532,6 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 		OpenShift:                    r.opts.DetectedProvider.IsOpenShift(),
 		TrustedBundle:                trustedBundle,
 		MultiTenant:                  r.opts.MultiTenant,
-		BindingNamespaces:            bindingNamespaces,
 		KeyValidatorConfig:           keyValidatorConfig,
 		KubernetesVersion:            r.opts.KubernetesVersion,
 		ClusterDomain:                r.opts.ClusterDomain,
@@ -657,10 +646,10 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 }
 
 // reconcileTenant handles a reconcile request scoped to a single tenant namespace in multi-tenant mode.
-// The aggregated API server is a cluster-scoped calico-system component; the only thing a tenant
-// namespace needs is the calico-apiserver ServiceAccount, which is the subject the shared
-// calico-apiserver ClusterRoleBinding authorizes against Linseed. We create just that ServiceAccount,
-// owned by the Tenant so it is garbage collected when the tenant namespace is torn down.
+// The aggregated API server itself is a cluster-scoped calico-system component; what a tenant namespace needs
+// is the calico-apiserver ServiceAccount plus the per-tenant Linseed-access ClusterRole and ClusterRoleBinding
+// that authorize that ServiceAccount against Linseed. These are rendered by render.TenantAPIServerRBAC and are
+// owned by the Tenant, so they are garbage collected when the tenant namespace is torn down.
 func (r *ReconcileAPIServer) reconcileTenant(ctx context.Context, namespace string, reqLogger logr.Logger) (reconcile.Result, error) {
 	tenant, _, err := utils.GetTenant(ctx, true, r.client, namespace)
 	if errors.IsNotFound(err) {
@@ -672,7 +661,7 @@ func (r *ReconcileAPIServer) reconcileTenant(ctx context.Context, namespace stri
 	}
 
 	handler := utils.NewComponentHandler(log, r.client, r.scheme, tenant)
-	component := render.NewCreationPassthrough(render.APIServerServiceAccount(namespace))
+	component := render.TenantAPIServerRBAC(namespace)
 	if err := handler.CreateOrUpdateOrDelete(ctx, component, r.status); err != nil {
 		r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error creating / updating tenant API server RBAC", err, reqLogger)
 		return reconcile.Result{}, err

--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-logr/logr"
-
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -191,29 +189,14 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 	}
 
 	if opts.MultiTenant {
-		// In multi-tenant mode the apiserver controller has two responsibilities: the cluster-scoped
-		// reconcile (request with an empty namespace) installs the aggregated API server in calico-system,
-		// while a per-tenant reconcile (request scoped to a tenant namespace) creates the calico-apiserver
-		// ServiceAccount and its per-tenant Linseed-access RBAC in that tenant namespace so it can be
-		// authorized against Linseed.
-		//
-		// A Tenant change enqueues the tenant's own namespace so its per-tenant RBAC is created/refreshed.
-		// The per-tenant RBAC is self-contained (named per tenant), so no cluster-scoped re-reconcile is
-		// needed.
-		tenantHandler := handler.EnqueueRequestsFromMapFunc(func(_ context.Context, obj client.Object) []reconcile.Request {
-			return []reconcile.Request{
-				{NamespacedName: types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}},
-			}
-		})
-		if err = c.WatchObject(&operatorv1.Tenant{}, tenantHandler); err != nil {
+		// On a multi-tenant management cluster the aggregated API server remains a single cluster-scoped
+		// component in calico-system, but each tenant's calico-apiserver identity must be granted Linseed
+		// access via a ClusterRoleBinding with one subject per tenant namespace. That binding is rendered by
+		// the (cluster-scoped) reconcile over the current set of tenant namespaces, so a Tenant change just
+		// needs to trigger a reconcile; the binding is then re-rendered with the up-to-date namespace set,
+		// which also drops a deleted tenant's subject.
+		if err = c.WatchObject(&operatorv1.Tenant{}, &handler.EnqueueRequestForObject{}); err != nil {
 			return fmt.Errorf("apiserver-controller failed to watch Tenant resource: %w", err)
-		}
-
-		// Periodically re-reconcile every tenant namespace as a backstop so a tenant's per-tenant RBAC
-		// self-heals if it is deleted out-of-band. The existing periodic reconcile above only drives the
-		// cluster-scoped (empty-namespace) reconcile.
-		if err = utils.AddPeriodicReconcile(c, utils.PeriodicReconcileTime, utils.EnqueueAllTenants(mgr.GetClient())); err != nil {
-			return fmt.Errorf("apiserver-controller failed to create per-tenant periodic reconcile watch: %w", err)
 		}
 	}
 
@@ -254,27 +237,6 @@ type ReconcileAPIServer struct {
 func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	reqLogger.V(2).Info("Reconciling APIServer")
-
-	// In multi-tenant mode, a request scoped to a tenant namespace is handled by the per-tenant path, which
-	// provisions only that tenant's Linseed-access RBAC. The aggregated API server itself is a single
-	// cluster-scoped component in calico-system, reconciled by the cluster-scoped path below.
-	//
-	// We must only divert to the per-tenant path for genuine tenant namespaces. Many of this controller's
-	// watches (secrets and config maps in the operator namespace, the API server deployment in calico-system,
-	// etc.) enqueue requests carrying a non-empty, non-tenant namespace; those must fall through to the
-	// cluster-scoped reconcile, or the API server would stop reconciling on those events. A namespace is a
-	// tenant namespace iff it contains a Tenant, so we key off that rather than "namespace is non-empty".
-	if r.opts.MultiTenant && request.Namespace != "" {
-		tenant, _, err := utils.GetTenant(ctx, true, r.client, request.Namespace)
-		if err != nil && !errors.IsNotFound(err) {
-			r.status.SetDegraded(operatorv1.ResourceReadError, "An error occurred while querying Tenant", err, reqLogger)
-			return reconcile.Result{}, err
-		}
-		if tenant != nil {
-			return r.reconcileTenant(ctx, tenant, reqLogger)
-		}
-		// No Tenant in this namespace - fall through to the cluster-scoped reconcile.
-	}
 
 	// Check if a datastore migration is in progress. If so, the migration controller
 	// owns the APIService and we should not reconcile to avoid fighting over it.
@@ -526,6 +488,20 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 	// Create a component handler to manage the rendered component.
 	handler := utils.NewComponentHandler(log, r.client, r.scheme, instance)
 
+	// Determine the tenant namespaces whose calico-apiserver ServiceAccount should be granted Linseed access.
+	// For zero/single-tenant clusters this is empty (the calico-system API server is covered by its own
+	// ClusterRoleBinding); for multi-tenant management clusters it is every tenant namespace, so each tenant's
+	// calico-apiserver identity is authorized against Linseed.
+	nsHelper := utils.NewNamespaceHelper(r.opts.MultiTenant, render.APIServerNamespace, "")
+	var bindingNamespaces []string
+	if r.opts.MultiTenant {
+		bindingNamespaces, err = nsHelper.TenantNamespaces(r.client)
+		if err != nil {
+			r.status.SetDegraded(operatorv1.ResourceReadError, "Error reading tenant namespaces", err, reqLogger)
+			return reconcile.Result{}, err
+		}
+	}
+
 	// Render the desired objects from the CRD and create or update them.
 	reqLogger.V(3).Info("rendering components")
 
@@ -543,6 +519,7 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 		OpenShift:                    r.opts.DetectedProvider.IsOpenShift(),
 		TrustedBundle:                trustedBundle,
 		MultiTenant:                  r.opts.MultiTenant,
+		BindingNamespaces:            bindingNamespaces,
 		KeyValidatorConfig:           keyValidatorConfig,
 		KubernetesVersion:            r.opts.KubernetesVersion,
 		ClusterDomain:                r.opts.ClusterDomain,
@@ -653,22 +630,6 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 	if err = r.client.Status().Update(ctx, instance); err != nil {
 		return reconcile.Result{}, err
 	}
-	return reconcile.Result{}, nil
-}
-
-// reconcileTenant handles a reconcile request scoped to a single tenant namespace in multi-tenant mode. The
-// aggregated API server itself is a cluster-scoped calico-system component; what a tenant namespace needs is
-// the per-tenant Linseed-access ClusterRole and ClusterRoleBinding that authorize the tenant's calico-apiserver
-// identity against Linseed. These are rendered by render.TenantAPIServerRBAC. The Tenant is passed as the owner
-// so the handler attributes the resources to it (cluster-scoped resources do not receive an owner reference).
-func (r *ReconcileAPIServer) reconcileTenant(ctx context.Context, tenant *operatorv1.Tenant, reqLogger logr.Logger) (reconcile.Result, error) {
-	handler := utils.NewComponentHandler(log, r.client, r.scheme, tenant)
-	component := render.TenantAPIServerRBAC(tenant.Namespace)
-	if err := handler.CreateOrUpdateOrDelete(ctx, component, r.status); err != nil {
-		r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error creating / updating tenant API server RBAC", err, reqLogger)
-		return reconcile.Result{}, err
-	}
-
 	return reconcile.Result{}, nil
 }
 

--- a/pkg/controller/apiserver/apiserver_controller_test.go
+++ b/pkg/controller/apiserver/apiserver_controller_test.go
@@ -870,42 +870,14 @@ var _ = Describe("apiserver controller tests", func() {
 				Expect(kerror.IsNotFound(err)).Should(BeTrue())
 			})
 
-			It("Should not swallow non-tenant namespaced events in multi-tenant mode", func() {
-				r := ReconcileAPIServer{
-					client:              cli,
-					scheme:              scheme,
-					status:              mockStatus,
-					tierWatchReady:      ready,
-					migrationWatchReady: &utils.ReadyFlag{},
-					opts: options.ControllerOptions{
-						EnterpriseCRDExists: true,
-						DetectedProvider:    operatorv1.ProviderNone,
-						MultiTenant:         true,
-					},
-				}
-
-				// Many of this controller's watches (e.g. secrets in the operator namespace) enqueue requests
-				// carrying a non-empty, non-tenant namespace. These must fall through to the cluster-scoped
-				// reconcile rather than being diverted to (and dropped by) the per-tenant path.
-				_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{
-					Namespace: common.OperatorNamespace(),
-					Name:      "calico-apiserver-certs",
-				}})
-				Expect(err).ShouldNot(HaveOccurred())
-
-				// The cluster-scoped reconcile ran: the API server deployment exists.
-				deployment := appsv1.Deployment{
-					TypeMeta:   metav1.TypeMeta{Kind: "Deployment", APIVersion: "v1"},
-					ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver", Namespace: "calico-system"},
-				}
-				Expect(kerror.IsNotFound(test.GetResource(cli, &deployment))).Should(BeFalse())
-			})
-
-			It("Should provision per-tenant Linseed RBAC for a tenant-namespace request", func() {
-				const tenantNS = "tenant-a"
+			It("Should grant each tenant's calico-apiserver ServiceAccount Linseed access via one ClusterRoleBinding", func() {
 				Expect(cli.Create(ctx, &operatorv1.Tenant{
-					ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: tenantNS},
+					ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "tenant-a"},
 					Spec:       operatorv1.TenantSpec{ID: "tenant-a-id"},
+				})).NotTo(HaveOccurred())
+				Expect(cli.Create(ctx, &operatorv1.Tenant{
+					ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "tenant-b"},
+					Spec:       operatorv1.TenantSpec{ID: "tenant-b-id"},
 				})).NotTo(HaveOccurred())
 
 				r := ReconcileAPIServer{
@@ -921,25 +893,20 @@ var _ = Describe("apiserver controller tests", func() {
 					},
 				}
 
-				_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{
-					Namespace: tenantNS,
-					Name:      "default",
-				}})
+				_, err := r.Reconcile(ctx, reconcile.Request{})
 				Expect(err).ShouldNot(HaveOccurred())
 
-				// The per-tenant Linseed-access ClusterRole was created, named for the tenant namespace.
-				role := rbacv1.ClusterRole{
-					TypeMeta:   metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
-					ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-%s", render.APIServerLinseedAccessClusterRoleName, tenantNS)},
+				// A single Linseed-access ClusterRoleBinding with one calico-apiserver ServiceAccount subject
+				// per tenant namespace.
+				crb := rbacv1.ClusterRoleBinding{
+					TypeMeta:   metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+					ObjectMeta: metav1.ObjectMeta{Name: render.APIServerLinseedAccessClusterRoleName},
 				}
-				Expect(test.GetResource(cli, &role)).To(BeNil())
-
-				// The per-tenant path short-circuits: it must not install the cluster-scoped API server.
-				deployment := appsv1.Deployment{
-					TypeMeta:   metav1.TypeMeta{Kind: "Deployment", APIVersion: "v1"},
-					ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver", Namespace: "calico-system"},
-				}
-				Expect(kerror.IsNotFound(test.GetResource(cli, &deployment))).Should(BeTrue())
+				Expect(test.GetResource(cli, &crb)).To(BeNil())
+				Expect(crb.Subjects).To(ConsistOf(
+					rbacv1.Subject{Kind: "ServiceAccount", Name: render.APIServerServiceAccountName, Namespace: "tenant-a"},
+					rbacv1.Subject{Kind: "ServiceAccount", Name: render.APIServerServiceAccountName, Namespace: "tenant-b"},
+				))
 			})
 		})
 	})

--- a/pkg/controller/apiserver/apiserver_controller_test.go
+++ b/pkg/controller/apiserver/apiserver_controller_test.go
@@ -869,6 +869,78 @@ var _ = Describe("apiserver controller tests", func() {
 				err = test.GetResource(cli, &clusterConnectionInAppNs)
 				Expect(kerror.IsNotFound(err)).Should(BeTrue())
 			})
+
+			It("Should not swallow non-tenant namespaced events in multi-tenant mode", func() {
+				r := ReconcileAPIServer{
+					client:              cli,
+					scheme:              scheme,
+					status:              mockStatus,
+					tierWatchReady:      ready,
+					migrationWatchReady: &utils.ReadyFlag{},
+					opts: options.ControllerOptions{
+						EnterpriseCRDExists: true,
+						DetectedProvider:    operatorv1.ProviderNone,
+						MultiTenant:         true,
+					},
+				}
+
+				// Many of this controller's watches (e.g. secrets in the operator namespace) enqueue requests
+				// carrying a non-empty, non-tenant namespace. These must fall through to the cluster-scoped
+				// reconcile rather than being diverted to (and dropped by) the per-tenant path.
+				_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{
+					Namespace: common.OperatorNamespace(),
+					Name:      "calico-apiserver-certs",
+				}})
+				Expect(err).ShouldNot(HaveOccurred())
+
+				// The cluster-scoped reconcile ran: the API server deployment exists.
+				deployment := appsv1.Deployment{
+					TypeMeta:   metav1.TypeMeta{Kind: "Deployment", APIVersion: "v1"},
+					ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver", Namespace: "calico-system"},
+				}
+				Expect(kerror.IsNotFound(test.GetResource(cli, &deployment))).Should(BeFalse())
+			})
+
+			It("Should provision per-tenant Linseed RBAC for a tenant-namespace request", func() {
+				const tenantNS = "tenant-a"
+				Expect(cli.Create(ctx, &operatorv1.Tenant{
+					ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: tenantNS},
+					Spec:       operatorv1.TenantSpec{ID: "tenant-a-id"},
+				})).NotTo(HaveOccurred())
+
+				r := ReconcileAPIServer{
+					client:              cli,
+					scheme:              scheme,
+					status:              mockStatus,
+					tierWatchReady:      ready,
+					migrationWatchReady: &utils.ReadyFlag{},
+					opts: options.ControllerOptions{
+						EnterpriseCRDExists: true,
+						DetectedProvider:    operatorv1.ProviderNone,
+						MultiTenant:         true,
+					},
+				}
+
+				_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{
+					Namespace: tenantNS,
+					Name:      "default",
+				}})
+				Expect(err).ShouldNot(HaveOccurred())
+
+				// The per-tenant Linseed-access ClusterRole was created, named for the tenant namespace.
+				role := rbacv1.ClusterRole{
+					TypeMeta:   metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
+					ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-%s", render.APIServerLinseedAccessClusterRoleName, tenantNS)},
+				}
+				Expect(test.GetResource(cli, &role)).To(BeNil())
+
+				// The per-tenant path short-circuits: it must not install the cluster-scoped API server.
+				deployment := appsv1.Deployment{
+					TypeMeta:   metav1.TypeMeta{Kind: "Deployment", APIVersion: "v1"},
+					ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver", Namespace: "calico-system"},
+				}
+				Expect(kerror.IsNotFound(test.GetResource(cli, &deployment))).Should(BeTrue())
+			})
 		})
 	})
 

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -140,17 +140,9 @@ type APIServerConfiguration struct {
 	OpenShift                    bool
 	TrustedBundle                certificatemanagement.TrustedBundle
 	MultiTenant                  bool
-
-	// BindingNamespaces are the namespaces whose calico-apiserver service account should be bound to the
-	// calico-apiserver ClusterRole. For zero/single-tenant clusters this is calico-system. For multi-tenant
-	// management clusters this is the set of tenant namespaces, so that each tenant's calico-apiserver (which
-	// authenticates to Linseed as system:serviceaccount:<tenant-namespace>:calico-apiserver) is granted the
-	// linseed.tigera.io permissions carried by the ClusterRole.
-	BindingNamespaces []string
-
-	KeyValidatorConfig authentication.KeyValidatorConfig
-	KubernetesVersion  *common.VersionInfo
-	ClusterDomain      string
+	KeyValidatorConfig           authentication.KeyValidatorConfig
+	KubernetesVersion            *common.VersionInfo
+	ClusterDomain                string
 
 	// Whether or not we should run the aggregation API server for projectcalico.org/v3 APIs
 	// as part of this component.
@@ -227,22 +219,18 @@ func (c *apiServerComponent) Objects() ([]client.Object, []client.Object) {
 	secrets := secret.CopyToNamespace(APIServerNamespace, c.cfg.PullSecrets...)
 	namespacedObjects = append(namespacedObjects, secret.ToRuntimeObjects(secrets...)...)
 
-	if c.cfg.RequiresAggregationServer || c.cfg.Installation.Variant.IsEnterprise() || c.cfg.MultiTenant {
-		namespacedObjects = append(namespacedObjects, c.apiServerServiceAccount())
-	} else {
-		objsToDelete = append(objsToDelete, &corev1.ServiceAccount{TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: APIServerServiceAccountName, Namespace: APIServerNamespace}})
-	}
-
 	// The deployment and its supporting objects are needed when running the aggregation API server
 	// or when running Enterprise (which always needs the queryserver).
 	if c.cfg.RequiresAggregationServer || c.cfg.Installation.Variant.IsEnterprise() {
 		namespacedObjects = append(namespacedObjects,
+			c.apiServerServiceAccount(),
 			c.apiServerDeployment(),
 			c.apiServerService(),
 			c.apiServerPodDisruptionBudget(),
 		)
 	} else {
 		objsToDelete = append(objsToDelete,
+			&corev1.ServiceAccount{TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: APIServerServiceAccountName, Namespace: APIServerNamespace}},
 			&appsv1.Deployment{TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"}, ObjectMeta: metav1.ObjectMeta{Name: APIServerName, Namespace: APIServerNamespace}},
 			&corev1.Service{TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: APIServerServiceName, Namespace: APIServerNamespace}},
 			&policyv1.PodDisruptionBudget{TypeMeta: metav1.TypeMeta{Kind: "PodDisruptionBudget", APIVersion: "policy/v1"}, ObjectMeta: metav1.ObjectMeta{Name: APIServerName, Namespace: APIServerNamespace}},
@@ -282,25 +270,12 @@ func (c *apiServerComponent) Objects() ([]client.Object, []client.Object) {
 		c.tigeraAPIServerClusterRoleBinding(),
 	}
 
-	if c.cfg.MultiTenant {
-		// On multi-tenant management clusters, each tenant's calico-apiserver service account needs read
-		// access to Linseed. A dedicated least-privilege ClusterRole is bound to every tenant namespace via a
-		// single ClusterRoleBinding.
-		globalEnterpriseObjects = append(globalEnterpriseObjects,
-			c.tigeraLinseedAccessClusterRole(),
-			c.tigeraLinseedAccessClusterRoleBinding(),
-		)
-	} else {
+	if !c.cfg.MultiTenant {
 		// These resources are only installed in zero-tenant clusters. Multi-tenant clusters don't use the default
 		// RBAC resources.
 		globalEnterpriseObjects = append(globalEnterpriseObjects,
 			c.tigeraUserClusterRole(),
 			c.tigeraNetworkAdminClusterRole(),
-		)
-		// The Linseed-access RBAC is multi-tenant only; ensure it is cleaned up on zero/single-tenant clusters.
-		objsToDelete = append(objsToDelete,
-			c.tigeraLinseedAccessClusterRoleBinding(),
-			c.tigeraLinseedAccessClusterRole(),
 		)
 	}
 
@@ -497,9 +472,9 @@ func (c *apiServerComponent) apiServerServiceAccount() *corev1.ServiceAccount {
 
 // APIServerServiceAccount returns the calico-apiserver ServiceAccount for the given namespace. In
 // zero/single-tenant clusters this is calico-system. In multi-tenant management clusters the apiserver
-// controller also creates this ServiceAccount in every tenant namespace, so that each tenant's
-// calico-apiserver identity (system:serviceaccount:<tenant-namespace>:calico-apiserver) exists and can
-// be authorized against Linseed via the shared calico-apiserver ClusterRoleBinding.
+// controller also creates this ServiceAccount in every tenant namespace (see TenantAPIServerRBAC), so that
+// each tenant's calico-apiserver identity (system:serviceaccount:<tenant-namespace>:calico-apiserver) exists
+// and can be authorized against Linseed.
 func APIServerServiceAccount(namespace string) *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"},
@@ -508,6 +483,57 @@ func APIServerServiceAccount(namespace string) *corev1.ServiceAccount {
 			Namespace: namespace,
 		},
 	}
+}
+
+// TenantAPIServerRBAC renders the per-tenant calico-apiserver RBAC installed on a multi-tenant management
+// cluster, and is reconciled per tenant (see the apiserver controller's reconcileTenant). Each tenant's
+// aggregated-API-server identity (system:serviceaccount:<tenant-namespace>:calico-apiserver) must be
+// authorized against Linseed, which authorizes with a cluster-scoped SubjectAccessReview. That requires a
+// ClusterRoleBinding - a namespaced RoleBinding would not satisfy a cluster-scoped review - so the binding and
+// the least-privilege ClusterRole it references are named per tenant to avoid collisions between tenants. All
+// three objects are owned by the Tenant (via the reconcile handler) so they are garbage-collected when the
+// tenant is torn down.
+//
+// Calico Enterprise, multi-tenant only.
+func TenantAPIServerRBAC(namespace string) Component {
+	return NewCreationPassthrough(
+		APIServerServiceAccount(namespace),
+		tenantLinseedAccessClusterRole(namespace),
+		tenantLinseedAccessClusterRoleBinding(namespace),
+	)
+}
+
+// tenantLinseedAccessName returns the per-tenant name for a tenant's calico-apiserver Linseed-access
+// ClusterRole and ClusterRoleBinding. The tenant namespace is embedded so each tenant owns a distinct pair of
+// cluster-scoped objects that do not collide with other tenants'.
+func tenantLinseedAccessName(namespace string) string {
+	return fmt.Sprintf("%s-%s", APIServerLinseedAccessClusterRoleName, namespace)
+}
+
+// tenantLinseedAccessClusterRole is a minimal ClusterRole granting a tenant's calico-apiserver read access to
+// Linseed policy activity data (for queryserver enrichment). It is deliberately least-privilege - the full
+// backing-storage/queryserver rules live on the calico-apiserver ClusterRole, which is bound only to the
+// calico-system API server itself.
+func tenantLinseedAccessClusterRole(namespace string) *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: tenantLinseedAccessName(namespace)},
+		Rules: []rbacv1.PolicyRule{
+			{
+				// Read access to Linseed policy activity data for queryserver enrichment.
+				APIGroups: []string{"linseed.tigera.io"},
+				Resources: []string{"policyactivity"},
+				Verbs:     []string{"get"},
+			},
+		},
+	}
+}
+
+// tenantLinseedAccessClusterRoleBinding binds a tenant's Linseed-access ClusterRole to that tenant's
+// calico-apiserver ServiceAccount. Linseed authorizes with a cluster-scoped SubjectAccessReview, so this is a
+// ClusterRoleBinding (with a single tenant-namespaced subject) rather than a namespaced RoleBinding.
+func tenantLinseedAccessClusterRoleBinding(namespace string) *rbacv1.ClusterRoleBinding {
+	return rcomp.ClusterRoleBinding(tenantLinseedAccessName(namespace), tenantLinseedAccessName(namespace), APIServerServiceAccountName, []string{namespace})
 }
 
 func calicoSystemAPIServerPolicy(cfg *APIServerConfiguration) *v3.NetworkPolicy {
@@ -1549,39 +1575,24 @@ func (c *apiServerComponent) tigeraAPIServerClusterRole() *rbacv1.ClusterRole {
 //
 // Calico Enterprise only
 func (c *apiServerComponent) tigeraAPIServerClusterRoleBinding() *rbacv1.ClusterRoleBinding {
-	return rcomp.ClusterRoleBinding(APIServerName, APIServerName, APIServerServiceAccountName, []string{APIServerNamespace})
-}
-
-// tigeraLinseedAccessClusterRole creates a minimal ClusterRole that grants the calico-apiserver identity read
-// access to Linseed. On multi-tenant management clusters this is bound to each tenant's calico-apiserver
-// service account so that tenant's managed clusters can reach Linseed. It is deliberately least-privilege and
-// carries only linseed.tigera.io permissions - the full backing-storage/queryserver rules live on the
-// calico-apiserver ClusterRole, which is bound only to the calico-system API server itself.
-//
-// Calico Enterprise, multi-tenant only
-func (c *apiServerComponent) tigeraLinseedAccessClusterRole() *rbacv1.ClusterRole {
-	return &rbacv1.ClusterRole{
-		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: APIServerLinseedAccessClusterRoleName},
-		Rules: []rbacv1.PolicyRule{
+	return &rbacv1.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: APIServerName,
+		},
+		Subjects: []rbacv1.Subject{
 			{
-				// Read access to Linseed policy activity data for queryserver enrichment.
-				APIGroups: []string{"linseed.tigera.io"},
-				Resources: []string{"policyactivity"},
-				Verbs:     []string{"get"},
+				Kind:      "ServiceAccount",
+				Name:      APIServerServiceAccountName,
+				Namespace: APIServerNamespace,
 			},
 		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			Name:     APIServerName,
+			APIGroup: "rbac.authorization.k8s.io",
+		},
 	}
-}
-
-// tigeraLinseedAccessClusterRoleBinding creates the single ClusterRoleBinding for multi-tenancy that binds the
-// Linseed-access ClusterRole to the calico-apiserver service account in every tenant namespace. Linseed
-// authorizes with a cluster-scoped SubjectAccessReview, so a ClusterRoleBinding (with one subject per tenant)
-// is required rather than a per-namespace RoleBinding.
-//
-// Calico Enterprise, multi-tenant only
-func (c *apiServerComponent) tigeraLinseedAccessClusterRoleBinding() *rbacv1.ClusterRoleBinding {
-	return rcomp.ClusterRoleBinding(APIServerLinseedAccessClusterRoleName, APIServerLinseedAccessClusterRoleName, APIServerServiceAccountName, c.cfg.BindingNamespaces)
 }
 
 // tierGetterClusterRole creates a clusterrole that gives permissions to get tiers.

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -140,9 +140,17 @@ type APIServerConfiguration struct {
 	OpenShift                    bool
 	TrustedBundle                certificatemanagement.TrustedBundle
 	MultiTenant                  bool
-	KeyValidatorConfig           authentication.KeyValidatorConfig
-	KubernetesVersion            *common.VersionInfo
-	ClusterDomain                string
+
+	// BindingNamespaces are the tenant namespaces whose calico-apiserver ServiceAccount should be granted
+	// Linseed access on a multi-tenant management cluster. Each managed cluster's calico-apiserver
+	// authenticates to Linseed with a token whose identity is namespace-overridden to its tenant namespace
+	// (system:serviceaccount:<tenant-namespace>:calico-apiserver), so a ClusterRoleBinding with one subject
+	// per tenant namespace is required. Empty on zero/single-tenant clusters.
+	BindingNamespaces []string
+
+	KeyValidatorConfig authentication.KeyValidatorConfig
+	KubernetesVersion  *common.VersionInfo
+	ClusterDomain      string
 
 	// Whether or not we should run the aggregation API server for projectcalico.org/v3 APIs
 	// as part of this component.
@@ -270,12 +278,25 @@ func (c *apiServerComponent) Objects() ([]client.Object, []client.Object) {
 		c.tigeraAPIServerClusterRoleBinding(),
 	}
 
-	if !c.cfg.MultiTenant {
+	if c.cfg.MultiTenant {
+		// On a multi-tenant management cluster, each tenant's calico-apiserver identity needs read access to
+		// Linseed. A single least-privilege ClusterRole is bound to the calico-apiserver ServiceAccount in
+		// every tenant namespace via one ClusterRoleBinding (see linseedAccessClusterRoleBinding).
+		globalEnterpriseObjects = append(globalEnterpriseObjects,
+			c.linseedAccessClusterRole(),
+			c.linseedAccessClusterRoleBinding(),
+		)
+	} else {
 		// These resources are only installed in zero-tenant clusters. Multi-tenant clusters don't use the default
 		// RBAC resources.
 		globalEnterpriseObjects = append(globalEnterpriseObjects,
 			c.tigeraUserClusterRole(),
 			c.tigeraNetworkAdminClusterRole(),
+		)
+		// The Linseed-access RBAC is multi-tenant only; ensure it is cleaned up on zero/single-tenant clusters.
+		objsToDelete = append(objsToDelete,
+			c.linseedAccessClusterRoleBinding(),
+			c.linseedAccessClusterRole(),
 		)
 	}
 
@@ -476,42 +497,17 @@ func (c *apiServerComponent) apiServerServiceAccount() *corev1.ServiceAccount {
 	}
 }
 
-// TenantAPIServerRBAC renders the per-tenant calico-apiserver RBAC installed on a multi-tenant management
-// cluster, and is reconciled per tenant (see the apiserver controller's reconcileTenant). Each tenant's
-// aggregated-API-server identity (system:serviceaccount:<tenant-namespace>:calico-apiserver) must be
-// authorized against Linseed, which authorizes with a cluster-scoped SubjectAccessReview. That requires a
-// ClusterRoleBinding - a namespaced RoleBinding would not satisfy a cluster-scoped review - so the binding and
-// the least-privilege ClusterRole it references are named per tenant to avoid collisions between tenants.
-//
-// The tenant's calico-apiserver ServiceAccount is provisioned as part of tenant setup, so it is not rendered
-// here. Both objects returned are cluster-scoped and therefore cannot carry an owner reference to the
-// (namespaced) Tenant - the component handler skips owner references in that owner/owned combination - so they
-// are NOT garbage-collected automatically when the tenant is removed. They are named per tenant so they do not
-// collide, but tearing them down when a tenant is deleted is not yet handled here.
+// linseedAccessClusterRole is a minimal, least-privilege ClusterRole granting the calico-apiserver identity
+// read access to Linseed policy activity data (for queryserver enrichment). On a multi-tenant management
+// cluster it is bound to each tenant's calico-apiserver ServiceAccount so that tenant's managed clusters can
+// reach Linseed. The full backing-storage/queryserver rules live on the calico-apiserver ClusterRole, which is
+// bound only to the calico-system API server itself.
 //
 // Calico Enterprise, multi-tenant only.
-func TenantAPIServerRBAC(namespace string) Component {
-	return NewCreationPassthrough(
-		tenantLinseedAccessClusterRole(namespace),
-		tenantLinseedAccessClusterRoleBinding(namespace),
-	)
-}
-
-// tenantLinseedAccessName returns the per-tenant name for a tenant's calico-apiserver Linseed-access
-// ClusterRole and ClusterRoleBinding. The tenant namespace is embedded so each tenant owns a distinct pair of
-// cluster-scoped objects that do not collide with other tenants'.
-func tenantLinseedAccessName(namespace string) string {
-	return fmt.Sprintf("%s-%s", APIServerLinseedAccessClusterRoleName, namespace)
-}
-
-// tenantLinseedAccessClusterRole is a minimal ClusterRole granting a tenant's calico-apiserver read access to
-// Linseed policy activity data (for queryserver enrichment). It is deliberately least-privilege - the full
-// backing-storage/queryserver rules live on the calico-apiserver ClusterRole, which is bound only to the
-// calico-system API server itself.
-func tenantLinseedAccessClusterRole(namespace string) *rbacv1.ClusterRole {
+func (c *apiServerComponent) linseedAccessClusterRole() *rbacv1.ClusterRole {
 	return &rbacv1.ClusterRole{
 		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: tenantLinseedAccessName(namespace)},
+		ObjectMeta: metav1.ObjectMeta{Name: APIServerLinseedAccessClusterRoleName},
 		Rules: []rbacv1.PolicyRule{
 			{
 				// Read access to Linseed policy activity data for queryserver enrichment.
@@ -523,11 +519,14 @@ func tenantLinseedAccessClusterRole(namespace string) *rbacv1.ClusterRole {
 	}
 }
 
-// tenantLinseedAccessClusterRoleBinding binds a tenant's Linseed-access ClusterRole to that tenant's
-// calico-apiserver ServiceAccount. Linseed authorizes with a cluster-scoped SubjectAccessReview, so this is a
-// ClusterRoleBinding (with a single tenant-namespaced subject) rather than a namespaced RoleBinding.
-func tenantLinseedAccessClusterRoleBinding(namespace string) *rbacv1.ClusterRoleBinding {
-	return rcomp.ClusterRoleBinding(tenantLinseedAccessName(namespace), tenantLinseedAccessName(namespace), APIServerServiceAccountName, []string{namespace})
+// linseedAccessClusterRoleBinding binds the Linseed-access ClusterRole to the calico-apiserver ServiceAccount
+// in each tenant namespace. Linseed authorizes with a cluster-scoped SubjectAccessReview, so this is a single
+// ClusterRoleBinding with one ServiceAccount subject per tenant namespace - mirroring how compliance,
+// intrusion-detection, and the manager grant their managed-cluster components Linseed access.
+//
+// Calico Enterprise, multi-tenant only.
+func (c *apiServerComponent) linseedAccessClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+	return rcomp.ClusterRoleBinding(APIServerLinseedAccessClusterRoleName, APIServerLinseedAccessClusterRoleName, APIServerServiceAccountName, c.cfg.BindingNamespaces)
 }
 
 func calicoSystemAPIServerPolicy(cfg *APIServerConfiguration) *v3.NetworkPolicy {

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -467,20 +467,11 @@ func (c *apiServerComponent) authReaderRoleBinding() client.Object {
 //
 // Both Calico and Calico Enterprise, but in different namespaces.
 func (c *apiServerComponent) apiServerServiceAccount() *corev1.ServiceAccount {
-	return APIServerServiceAccount(APIServerNamespace)
-}
-
-// APIServerServiceAccount returns the calico-apiserver ServiceAccount for the given namespace. In
-// zero/single-tenant clusters this is calico-system. In multi-tenant management clusters the apiserver
-// controller also creates this ServiceAccount in every tenant namespace (see TenantAPIServerRBAC), so that
-// each tenant's calico-apiserver identity (system:serviceaccount:<tenant-namespace>:calico-apiserver) exists
-// and can be authorized against Linseed.
-func APIServerServiceAccount(namespace string) *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      APIServerServiceAccountName,
-			Namespace: namespace,
+			Namespace: APIServerNamespace,
 		},
 	}
 }
@@ -490,14 +481,17 @@ func APIServerServiceAccount(namespace string) *corev1.ServiceAccount {
 // aggregated-API-server identity (system:serviceaccount:<tenant-namespace>:calico-apiserver) must be
 // authorized against Linseed, which authorizes with a cluster-scoped SubjectAccessReview. That requires a
 // ClusterRoleBinding - a namespaced RoleBinding would not satisfy a cluster-scoped review - so the binding and
-// the least-privilege ClusterRole it references are named per tenant to avoid collisions between tenants. All
-// three objects are owned by the Tenant (via the reconcile handler) so they are garbage-collected when the
-// tenant is torn down.
+// the least-privilege ClusterRole it references are named per tenant to avoid collisions between tenants.
+//
+// The tenant's calico-apiserver ServiceAccount is provisioned as part of tenant setup, so it is not rendered
+// here. Both objects returned are cluster-scoped and therefore cannot carry an owner reference to the
+// (namespaced) Tenant - the component handler skips owner references in that owner/owned combination - so they
+// are NOT garbage-collected automatically when the tenant is removed. They are named per tenant so they do not
+// collide, but tearing them down when a tenant is deleted is not yet handled here.
 //
 // Calico Enterprise, multi-tenant only.
 func TenantAPIServerRBAC(namespace string) Component {
 	return NewCreationPassthrough(
-		APIServerServiceAccount(namespace),
 		tenantLinseedAccessClusterRole(namespace),
 		tenantLinseedAccessClusterRoleBinding(namespace),
 	)

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -79,6 +79,7 @@ const (
 	APIServerServiceAccountName  = "calico-apiserver"
 
 	APIServerSecretsRBACName                                      = "calico-extension-apiserver-secrets-access"
+	APIServerLinseedAccessClusterRoleName                         = "calico-apiserver-linseed-access"
 	MultiTenantManagedClustersAccessClusterRoleName               = "calico-managed-cluster-access"
 	ManagedClustersWatchClusterRoleName                           = "calico-managed-cluster-watch"
 	L7AdmissionControllerContainerName              ContainerName = "calico-l7-admission-controller"
@@ -139,9 +140,17 @@ type APIServerConfiguration struct {
 	OpenShift                    bool
 	TrustedBundle                certificatemanagement.TrustedBundle
 	MultiTenant                  bool
-	KeyValidatorConfig           authentication.KeyValidatorConfig
-	KubernetesVersion            *common.VersionInfo
-	ClusterDomain                string
+
+	// BindingNamespaces are the namespaces whose calico-apiserver service account should be bound to the
+	// calico-apiserver ClusterRole. For zero/single-tenant clusters this is calico-system. For multi-tenant
+	// management clusters this is the set of tenant namespaces, so that each tenant's calico-apiserver (which
+	// authenticates to Linseed as system:serviceaccount:<tenant-namespace>:calico-apiserver) is granted the
+	// linseed.tigera.io permissions carried by the ClusterRole.
+	BindingNamespaces []string
+
+	KeyValidatorConfig authentication.KeyValidatorConfig
+	KubernetesVersion  *common.VersionInfo
+	ClusterDomain      string
 
 	// Whether or not we should run the aggregation API server for projectcalico.org/v3 APIs
 	// as part of this component.
@@ -218,18 +227,22 @@ func (c *apiServerComponent) Objects() ([]client.Object, []client.Object) {
 	secrets := secret.CopyToNamespace(APIServerNamespace, c.cfg.PullSecrets...)
 	namespacedObjects = append(namespacedObjects, secret.ToRuntimeObjects(secrets...)...)
 
+	if c.cfg.RequiresAggregationServer || c.cfg.Installation.Variant.IsEnterprise() || c.cfg.MultiTenant {
+		namespacedObjects = append(namespacedObjects, c.apiServerServiceAccount())
+	} else {
+		objsToDelete = append(objsToDelete, &corev1.ServiceAccount{TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: APIServerServiceAccountName, Namespace: APIServerNamespace}})
+	}
+
 	// The deployment and its supporting objects are needed when running the aggregation API server
 	// or when running Enterprise (which always needs the queryserver).
 	if c.cfg.RequiresAggregationServer || c.cfg.Installation.Variant.IsEnterprise() {
 		namespacedObjects = append(namespacedObjects,
-			c.apiServerServiceAccount(),
 			c.apiServerDeployment(),
 			c.apiServerService(),
 			c.apiServerPodDisruptionBudget(),
 		)
 	} else {
 		objsToDelete = append(objsToDelete,
-			&corev1.ServiceAccount{TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: APIServerServiceAccountName, Namespace: APIServerNamespace}},
 			&appsv1.Deployment{TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"}, ObjectMeta: metav1.ObjectMeta{Name: APIServerName, Namespace: APIServerNamespace}},
 			&corev1.Service{TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: APIServerServiceName, Namespace: APIServerNamespace}},
 			&policyv1.PodDisruptionBudget{TypeMeta: metav1.TypeMeta{Kind: "PodDisruptionBudget", APIVersion: "policy/v1"}, ObjectMeta: metav1.ObjectMeta{Name: APIServerName, Namespace: APIServerNamespace}},
@@ -269,12 +282,25 @@ func (c *apiServerComponent) Objects() ([]client.Object, []client.Object) {
 		c.tigeraAPIServerClusterRoleBinding(),
 	}
 
-	if !c.cfg.MultiTenant {
+	if c.cfg.MultiTenant {
+		// On multi-tenant management clusters, each tenant's calico-apiserver service account needs read
+		// access to Linseed. A dedicated least-privilege ClusterRole is bound to every tenant namespace via a
+		// single ClusterRoleBinding.
+		globalEnterpriseObjects = append(globalEnterpriseObjects,
+			c.tigeraLinseedAccessClusterRole(),
+			c.tigeraLinseedAccessClusterRoleBinding(),
+		)
+	} else {
 		// These resources are only installed in zero-tenant clusters. Multi-tenant clusters don't use the default
 		// RBAC resources.
 		globalEnterpriseObjects = append(globalEnterpriseObjects,
 			c.tigeraUserClusterRole(),
 			c.tigeraNetworkAdminClusterRole(),
+		)
+		// The Linseed-access RBAC is multi-tenant only; ensure it is cleaned up on zero/single-tenant clusters.
+		objsToDelete = append(objsToDelete,
+			c.tigeraLinseedAccessClusterRoleBinding(),
+			c.tigeraLinseedAccessClusterRole(),
 		)
 	}
 
@@ -466,11 +492,20 @@ func (c *apiServerComponent) authReaderRoleBinding() client.Object {
 //
 // Both Calico and Calico Enterprise, but in different namespaces.
 func (c *apiServerComponent) apiServerServiceAccount() *corev1.ServiceAccount {
+	return APIServerServiceAccount(APIServerNamespace)
+}
+
+// APIServerServiceAccount returns the calico-apiserver ServiceAccount for the given namespace. In
+// zero/single-tenant clusters this is calico-system. In multi-tenant management clusters the apiserver
+// controller also creates this ServiceAccount in every tenant namespace, so that each tenant's
+// calico-apiserver identity (system:serviceaccount:<tenant-namespace>:calico-apiserver) exists and can
+// be authorized against Linseed via the shared calico-apiserver ClusterRoleBinding.
+func APIServerServiceAccount(namespace string) *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      APIServerServiceAccountName,
-			Namespace: APIServerNamespace,
+			Namespace: namespace,
 		},
 	}
 }
@@ -1508,28 +1543,45 @@ func (c *apiServerComponent) tigeraAPIServerClusterRole() *rbacv1.ClusterRole {
 }
 
 // tigeraAPIServerClusterRoleBinding creates a clusterrolebinding that applies tigeraAPIServerClusterRole to
-// the calico-apiserver service account.
+// the calico-apiserver service account. This is the aggregated API server's own identity, which always runs
+// in calico-system - including on multi-tenant management clusters, where the API server is a single
+// cluster-scoped component rather than a per-tenant one.
 //
 // Calico Enterprise only
 func (c *apiServerComponent) tigeraAPIServerClusterRoleBinding() *rbacv1.ClusterRoleBinding {
-	return &rbacv1.ClusterRoleBinding{
-		TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: APIServerName,
-		},
-		Subjects: []rbacv1.Subject{
+	return rcomp.ClusterRoleBinding(APIServerName, APIServerName, APIServerServiceAccountName, []string{APIServerNamespace})
+}
+
+// tigeraLinseedAccessClusterRole creates a minimal ClusterRole that grants the calico-apiserver identity read
+// access to Linseed. On multi-tenant management clusters this is bound to each tenant's calico-apiserver
+// service account so that tenant's managed clusters can reach Linseed. It is deliberately least-privilege and
+// carries only linseed.tigera.io permissions - the full backing-storage/queryserver rules live on the
+// calico-apiserver ClusterRole, which is bound only to the calico-system API server itself.
+//
+// Calico Enterprise, multi-tenant only
+func (c *apiServerComponent) tigeraLinseedAccessClusterRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: APIServerLinseedAccessClusterRoleName},
+		Rules: []rbacv1.PolicyRule{
 			{
-				Kind:      "ServiceAccount",
-				Name:      APIServerServiceAccountName,
-				Namespace: APIServerNamespace,
+				// Read access to Linseed policy activity data for queryserver enrichment.
+				APIGroups: []string{"linseed.tigera.io"},
+				Resources: []string{"policyactivity"},
+				Verbs:     []string{"get"},
 			},
 		},
-		RoleRef: rbacv1.RoleRef{
-			Kind:     "ClusterRole",
-			Name:     APIServerName,
-			APIGroup: "rbac.authorization.k8s.io",
-		},
 	}
+}
+
+// tigeraLinseedAccessClusterRoleBinding creates the single ClusterRoleBinding for multi-tenancy that binds the
+// Linseed-access ClusterRole to the calico-apiserver service account in every tenant namespace. Linseed
+// authorizes with a cluster-scoped SubjectAccessReview, so a ClusterRoleBinding (with one subject per tenant)
+// is required rather than a per-namespace RoleBinding.
+//
+// Calico Enterprise, multi-tenant only
+func (c *apiServerComponent) tigeraLinseedAccessClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+	return rcomp.ClusterRoleBinding(APIServerLinseedAccessClusterRoleName, APIServerLinseedAccessClusterRoleName, APIServerServiceAccountName, c.cfg.BindingNamespaces)
 }
 
 // tierGetterClusterRole creates a clusterrole that gives permissions to get tiers.

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -2603,10 +2603,9 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 			const tenantNS = "tenant-a"
 			resources, _ := render.TenantAPIServerRBAC(tenantNS).Objects()
 
-			// The calico-apiserver ServiceAccount is created in the tenant namespace so the identity exists.
-			sa := rtest.GetResource(resources,
-				render.APIServerServiceAccountName, tenantNS, "", "v1", "ServiceAccount").(*corev1.ServiceAccount)
-			Expect(sa.Namespace).To(Equal(tenantNS))
+			// The tenant's calico-apiserver ServiceAccount is provisioned by tenant setup, not here.
+			Expect(rtest.GetResource(resources,
+				render.APIServerServiceAccountName, tenantNS, "", "v1", "ServiceAccount")).To(BeNil())
 
 			// A dedicated, Linseed-only ClusterRole, named per tenant so tenants do not collide.
 			roleName := fmt.Sprintf("%s-%s", render.APIServerLinseedAccessClusterRoleName, tenantNS)

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -2593,37 +2593,32 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 				Name:      render.APIServerServiceAccountName,
 				Namespace: render.APIServerNamespace,
 			}))
-			// The Linseed-access RBAC is not part of the cluster-scoped API server component; it is
-			// rendered per tenant by render.TenantAPIServerRBAC.
-			Expect(rtest.GetResource(resources,
-				render.APIServerLinseedAccessClusterRoleName, "", rbacv1.GroupName, "v1", "ClusterRole")).To(BeNil())
 		})
 
-		It("should render per-tenant calico-apiserver Linseed RBAC scoped to a single tenant namespace", func() {
-			const tenantNS = "tenant-a"
-			resources, _ := render.TenantAPIServerRBAC(tenantNS).Objects()
+		It("should grant each tenant's calico-apiserver service account least-privilege Linseed access", func() {
+			cfg.BindingNamespaces = []string{"tenant-a", "tenant-b"}
+			component, err := render.APIServer(cfg)
+			Expect(err).NotTo(HaveOccurred())
 
-			// The tenant's calico-apiserver ServiceAccount is provisioned by tenant setup, not here.
-			Expect(rtest.GetResource(resources,
-				render.APIServerServiceAccountName, tenantNS, "", "v1", "ServiceAccount")).To(BeNil())
+			resources, _ := component.Objects()
 
-			// A dedicated, Linseed-only ClusterRole, named per tenant so tenants do not collide.
-			roleName := fmt.Sprintf("%s-%s", render.APIServerLinseedAccessClusterRoleName, tenantNS)
+			// A dedicated, Linseed-only ClusterRole.
 			role := rtest.GetResource(resources,
-				roleName, "", rbacv1.GroupName, "v1", "ClusterRole").(*rbacv1.ClusterRole)
+				render.APIServerLinseedAccessClusterRoleName, "", rbacv1.GroupName, "v1", "ClusterRole").(*rbacv1.ClusterRole)
 			Expect(role.Rules).To(ConsistOf(rbacv1.PolicyRule{
 				APIGroups: []string{"linseed.tigera.io"},
 				Resources: []string{"policyactivity"},
 				Verbs:     []string{"get"},
 			}))
 
-			// A per-tenant ClusterRoleBinding with a single tenant-namespaced subject. Linseed authorizes with a
-			// cluster-scoped SubjectAccessReview, so this must be a ClusterRoleBinding rather than a RoleBinding.
+			// A single ClusterRoleBinding with one calico-apiserver ServiceAccount subject per tenant namespace.
+			// Linseed authorizes with a cluster-scoped SubjectAccessReview, so this must be a ClusterRoleBinding.
 			crb := rtest.GetResource(resources,
-				roleName, "", rbacv1.GroupName, "v1", "ClusterRoleBinding").(*rbacv1.ClusterRoleBinding)
-			Expect(crb.RoleRef.Name).To(Equal(roleName))
+				render.APIServerLinseedAccessClusterRoleName, "", rbacv1.GroupName, "v1", "ClusterRoleBinding").(*rbacv1.ClusterRoleBinding)
+			Expect(crb.RoleRef.Name).To(Equal(render.APIServerLinseedAccessClusterRoleName))
 			Expect(crb.Subjects).To(ConsistOf(
-				rbacv1.Subject{Kind: "ServiceAccount", Name: render.APIServerServiceAccountName, Namespace: tenantNS},
+				rbacv1.Subject{Kind: "ServiceAccount", Name: render.APIServerServiceAccountName, Namespace: "tenant-a"},
+				rbacv1.Subject{Kind: "ServiceAccount", Name: render.APIServerServiceAccountName, Namespace: "tenant-b"},
 			))
 		})
 	})

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -2579,7 +2579,6 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 		})
 
 		It("should bind the calico-apiserver ClusterRole only to the calico-system service account", func() {
-			cfg.BindingNamespaces = []string{"tenant-a", "tenant-b"}
 			component, err := render.APIServer(cfg)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -2594,31 +2593,38 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 				Name:      render.APIServerServiceAccountName,
 				Namespace: render.APIServerNamespace,
 			}))
+			// The Linseed-access RBAC is not part of the cluster-scoped API server component; it is
+			// rendered per tenant by render.TenantAPIServerRBAC.
+			Expect(rtest.GetResource(resources,
+				render.APIServerLinseedAccessClusterRoleName, "", rbacv1.GroupName, "v1", "ClusterRole")).To(BeNil())
 		})
 
-		It("should grant each tenant's calico-apiserver service account least-privilege Linseed access", func() {
-			cfg.BindingNamespaces = []string{"tenant-a", "tenant-b"}
-			component, err := render.APIServer(cfg)
-			Expect(err).NotTo(HaveOccurred())
+		It("should render per-tenant calico-apiserver Linseed RBAC scoped to a single tenant namespace", func() {
+			const tenantNS = "tenant-a"
+			resources, _ := render.TenantAPIServerRBAC(tenantNS).Objects()
 
-			resources, _ := component.Objects()
+			// The calico-apiserver ServiceAccount is created in the tenant namespace so the identity exists.
+			sa := rtest.GetResource(resources,
+				render.APIServerServiceAccountName, tenantNS, "", "v1", "ServiceAccount").(*corev1.ServiceAccount)
+			Expect(sa.Namespace).To(Equal(tenantNS))
 
-			// A dedicated, Linseed-only ClusterRole.
+			// A dedicated, Linseed-only ClusterRole, named per tenant so tenants do not collide.
+			roleName := fmt.Sprintf("%s-%s", render.APIServerLinseedAccessClusterRoleName, tenantNS)
 			role := rtest.GetResource(resources,
-				render.APIServerLinseedAccessClusterRoleName, "", rbacv1.GroupName, "v1", "ClusterRole").(*rbacv1.ClusterRole)
+				roleName, "", rbacv1.GroupName, "v1", "ClusterRole").(*rbacv1.ClusterRole)
 			Expect(role.Rules).To(ConsistOf(rbacv1.PolicyRule{
 				APIGroups: []string{"linseed.tigera.io"},
 				Resources: []string{"policyactivity"},
 				Verbs:     []string{"get"},
 			}))
 
-			// A single ClusterRoleBinding with one subject per tenant namespace.
+			// A per-tenant ClusterRoleBinding with a single tenant-namespaced subject. Linseed authorizes with a
+			// cluster-scoped SubjectAccessReview, so this must be a ClusterRoleBinding rather than a RoleBinding.
 			crb := rtest.GetResource(resources,
-				render.APIServerLinseedAccessClusterRoleName, "", rbacv1.GroupName, "v1", "ClusterRoleBinding").(*rbacv1.ClusterRoleBinding)
-			Expect(crb.RoleRef.Name).To(Equal(render.APIServerLinseedAccessClusterRoleName))
+				roleName, "", rbacv1.GroupName, "v1", "ClusterRoleBinding").(*rbacv1.ClusterRoleBinding)
+			Expect(crb.RoleRef.Name).To(Equal(roleName))
 			Expect(crb.Subjects).To(ConsistOf(
-				rbacv1.Subject{Kind: "ServiceAccount", Name: render.APIServerServiceAccountName, Namespace: "tenant-a"},
-				rbacv1.Subject{Kind: "ServiceAccount", Name: render.APIServerServiceAccountName, Namespace: "tenant-b"},
+				rbacv1.Subject{Kind: "ServiceAccount", Name: render.APIServerServiceAccountName, Namespace: tenantNS},
 			))
 		})
 	})

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -2577,5 +2577,49 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 			}
 			Expect(managedClusterAccessRole.Rules).To(ContainElements(expectedManagedClusterAccessRules))
 		})
+
+		It("should bind the calico-apiserver ClusterRole only to the calico-system service account", func() {
+			cfg.BindingNamespaces = []string{"tenant-a", "tenant-b"}
+			component, err := render.APIServer(cfg)
+			Expect(err).NotTo(HaveOccurred())
+
+			resources, _ := component.Objects()
+			crb := rtest.GetResource(resources,
+				render.APIServerName, "", rbacv1.GroupName, "v1", "ClusterRoleBinding").(*rbacv1.ClusterRoleBinding)
+			Expect(crb.RoleRef.Name).To(Equal(render.APIServerName))
+			// The aggregated API server always runs in calico-system, even in multi-tenant mode - its
+			// full-privilege ClusterRole must not be bound to tenant service accounts.
+			Expect(crb.Subjects).To(ConsistOf(rbacv1.Subject{
+				Kind:      "ServiceAccount",
+				Name:      render.APIServerServiceAccountName,
+				Namespace: render.APIServerNamespace,
+			}))
+		})
+
+		It("should grant each tenant's calico-apiserver service account least-privilege Linseed access", func() {
+			cfg.BindingNamespaces = []string{"tenant-a", "tenant-b"}
+			component, err := render.APIServer(cfg)
+			Expect(err).NotTo(HaveOccurred())
+
+			resources, _ := component.Objects()
+
+			// A dedicated, Linseed-only ClusterRole.
+			role := rtest.GetResource(resources,
+				render.APIServerLinseedAccessClusterRoleName, "", rbacv1.GroupName, "v1", "ClusterRole").(*rbacv1.ClusterRole)
+			Expect(role.Rules).To(ConsistOf(rbacv1.PolicyRule{
+				APIGroups: []string{"linseed.tigera.io"},
+				Resources: []string{"policyactivity"},
+				Verbs:     []string{"get"},
+			}))
+
+			// A single ClusterRoleBinding with one subject per tenant namespace.
+			crb := rtest.GetResource(resources,
+				render.APIServerLinseedAccessClusterRoleName, "", rbacv1.GroupName, "v1", "ClusterRoleBinding").(*rbacv1.ClusterRoleBinding)
+			Expect(crb.RoleRef.Name).To(Equal(render.APIServerLinseedAccessClusterRoleName))
+			Expect(crb.Subjects).To(ConsistOf(
+				rbacv1.Subject{Kind: "ServiceAccount", Name: render.APIServerServiceAccountName, Namespace: "tenant-a"},
+				rbacv1.Subject{Kind: "ServiceAccount", Name: render.APIServerServiceAccountName, Namespace: "tenant-b"},
+			))
+		})
 	})
 })


### PR DESCRIPTION
## Description

**Type of change:** new feature (Calico Enterprise, multi-tenant only).

On a multi-tenant management cluster the aggregated API server stays a single, cluster-scoped component in `calico-system` — there is no per-tenant API server deployment. But each tenant's managed clusters run a `calico-apiserver` (queryserver) that reads Linseed `policyactivity`, authenticating with a Linseed-signed token whose identity is namespace-overridden to the tenant namespace (`system:serviceaccount:<tenant-namespace>:calico-apiserver`). Linseed authorizes every request with a **cluster-scoped `SubjectAccessReview`** against the management cluster (the token only authenticates), so the management cluster must grant that tenant-namespaced identity `linseed.tigera.io/policyactivity` access via a `ClusterRoleBinding`. This PR provisions that RBAC.

This mirrors how compliance, intrusion-detection, and the manager already grant their managed-cluster components Linseed access — all of which carry the same `TenantNamespaceOverride` in Linseed's token controller.

**What changed:**
- Added a dedicated least-privilege `calico-apiserver-linseed-access` ClusterRole (only `linseed.tigera.io/policyactivity: get`).
- Bound it via a **single** ClusterRoleBinding whose subjects are the `calico-apiserver` `ServiceAccount` in every tenant namespace (one `ServiceAccount` subject per tenant), rendered from the API server component over `BindingNamespaces` using the shared `rcomponents.ClusterRoleBinding` helper. Multi-tenant only; cleaned up on zero/single-tenant clusters.
- The apiserver controller computes `BindingNamespaces` by listing the current tenant namespaces during reconcile, and watches `Tenant` resources so the binding's subject list is re-rendered when tenants are added or removed. Because it is one shared object rendered over the current namespace set, it **self-heals** on tenant deletion (the deleted tenant's subject is simply dropped) — no per-tenant cluster-scoped objects to garbage-collect.
- Restored the full `calico-apiserver` ClusterRole to its ungated rule set and scoped its binding to the `calico-system` API server only. (An in-progress change had gated those enterprise rules behind multi-tenant, which stripped them from single-tenant Enterprise; this restores correct behavior.)

The API server reconcile is unchanged in shape: a single idempotent path that renders the full component (the tenant binding included) on every trigger. No per-tenant dispatch, and no `ServiceAccount` is created in tenant namespaces — the SA object is not required, since Linseed's SAR matches the synthesized username string whether or not the object exists.

**Affected components:** `pkg/controller/apiserver`, `pkg/render/apiserver.go`.

**Testing:**
- `go test ./pkg/render/...` and `go test ./pkg/controller/apiserver/...` pass.
- Render specs assert: the `calico-apiserver` ClusterRoleBinding binds only the `calico-system` ServiceAccount; the Linseed-access ClusterRole is least-privilege; and its single binding has one `calico-apiserver` ServiceAccount subject per tenant namespace.
- A controller spec asserts that, with multiple tenants present, one reconcile produces the `calico-apiserver-linseed-access` ClusterRoleBinding with a subject per tenant namespace.

## Release Note

```release-note
NONE
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`
