### PR TITLE
[v3.24] fix(waf): keep the WAF controller wired to tear down EnvoyExtensionPolicies on disable

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1381,7 +1381,15 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 	// spec.extensions.waf.state != Enabled, the WAF surface is not rendered.
 	// See design tigera/designs#25 (PMREQ-384) §Gating.
 	wafGatewayExtensionEnabled := false
+	// gatewayAPIPresent means the GatewayAPI CR exists (regardless of waf.state),
+	// so the operator manages the Gateway API + Envoy Gateway CRDs the WAF
+	// reconcilers watch. It keeps the applicationlayer controller wired (with
+	// EnvoyExtensionPolicy delete RBAC) even while WAF is disabled, so the
+	// controller can tear down the EEPs it generated instead of being removed in
+	// the same reconcile that disables WAF (EV-6751).
+	gatewayAPIPresent := false
 	if gatewayAPI, msg, err := gatewayapi.GetGatewayAPI(ctx, r.client); err == nil {
+		gatewayAPIPresent = true
 		wafGatewayExtensionEnabled = gatewayAPI.Spec.IsWAFGatewayExtensionEnabled()
 	} else if !apierrors.IsNotFound(err) {
 		// Mirrors the GatewayAPI controller's handling: a read error or a
@@ -1698,6 +1706,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		Namespace:                   common.CalicoNamespace,
 		BindingNamespaces:           []string{common.CalicoNamespace},
 		WAFGatewayExtensionEnabled:  wafGatewayExtensionEnabled,
+		GatewayAPIPresent:           gatewayAPIPresent,
 		WAFWebhookServerTLS:         wafWebhookTLS,
 		WASMPullSecret:              wasmPullSecret,
 		WASMCACert:                  wasmCACert,

--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -128,14 +128,25 @@ type KubeControllersConfiguration struct {
 	// If this is nil, then we should run in zero-tenant mode.
 	Tenant *operatorv1.Tenant
 
-	// WAFGatewayExtensionEnabled gates the WAF v3 (Gateway API add-on) surface
-	// on calico-kube-controllers: the applicationlayer controller enablement,
-	// the WAF / Gateway-API / EnvoyExtensionPolicy / event / secret-replication
-	// RBAC, the WASM_IMAGE / WASM_PULL_SECRET / WASM_CA_CERT env vars, and the
-	// gateway envoy-proxy wasm image resolution.  Sourced from
+	// WAFGatewayExtensionEnabled gates the ACTIVE WAF v3 (Gateway API add-on)
+	// surface on calico-kube-controllers: the WASM_IMAGE / WASM_PULL_SECRET /
+	// WASM_CA_CERT env vars, the in-process admission webhook, and the gateway
+	// envoy-proxy wasm image resolution. Sourced from
 	// `GatewayAPI.spec.extensions.waf.state == Enabled` (default off).
 	// See design `tigera/designs#25` (PMREQ-384).
 	WAFGatewayExtensionEnabled bool
+
+	// GatewayAPIPresent is true when the GatewayAPI CR exists (regardless of
+	// waf.state), so the operator manages the Gateway API + Envoy Gateway CRDs the
+	// WAF reconcilers watch. It gates the applicationlayer controller enablement,
+	// its WAF / Gateway-API / EnvoyExtensionPolicy / event / secret RBAC, and the
+	// WAF_GATEWAY_EXTENSION_ENABLED signal env — a superset of
+	// WAFGatewayExtensionEnabled. The WAF controller stays wired (and keeps its
+	// envoyextensionpolicies delete RBAC) while WAF is disabled precisely so it can
+	// tear down the EnvoyExtensionPolicies it generated, instead of being removed
+	// in the same reconcile that disables WAF and never getting the chance
+	// (EV-6751). It de-programs on WAF_GATEWAY_EXTENSION_ENABLED=false.
+	GatewayAPIPresent bool
 
 	// WAFWebhookServerTLS is the serving certificate for the in-process WAF
 	// SecLang validating admission webhook hosted by calico-kube-controllers.
@@ -197,7 +208,11 @@ func NewCalicoKubeControllers(cfg *KubeControllersConfiguration) *kubeController
 			},
 		)
 		enabledControllers = append(enabledControllers, "service", "federatedservices", "usage")
-		if cfg.WAFGatewayExtensionEnabled {
+		// Wire the applicationlayer WAF controller whenever Gateway API is present,
+		// not only when WAF is enabled, so it stays running (and can tear down its
+		// generated EnvoyExtensionPolicies) when WAF is disabled. It de-programs vs
+		// programs based on WAF_GATEWAY_EXTENSION_ENABLED (EV-6751).
+		if cfg.GatewayAPIPresent {
 			enabledControllers = append(enabledControllers, "applicationlayer")
 		}
 	}
@@ -565,9 +580,12 @@ func kubeControllersRoleEnterpriseCommonRules(cfg *KubeControllersConfiguration)
 		},
 	}
 
-	if cfg.WAFGatewayExtensionEnabled {
-		// WAF v3 (Gateway API add-on) RBAC. Gated by
-		// GatewayAPI.spec.extensions.waf.state == Enabled.
+	if cfg.GatewayAPIPresent {
+		// WAF v3 (Gateway API add-on) RBAC. Gated by GatewayAPIPresent, not
+		// waf.state==Enabled, so the applicationlayer controller keeps the RBAC it
+		// needs to watch targets and DELETE the EnvoyExtensionPolicies it generated
+		// while WAF is disabled (EV-6751). The rule set is identical enabled vs
+		// disabled, so toggling waf.state causes no ClusterRole churn.
 		rules = append(rules,
 			// Application-layer (gateway-addons) reconcilers reconcile WAF resources
 			// against Gateway API targetRefs and emit events on the policy objects.
@@ -747,11 +765,20 @@ func (c *kubeControllersComponent) controllersDeployment() *appsv1.Deployment {
 			env = append(env, corev1.EnvVar{Name: "MULTI_INTERFACE_MODE", Value: c.cfg.Installation.CalicoNetwork.MultiInterfaceMode.Value()})
 		}
 
-		// Application-layer (gateway-addons / WAF v3) env vars, gated by
+		// The WAF reconcilers are wired whenever Gateway API is present (see the
+		// applicationlayer entry in enabledControllers), so they can tear down the
+		// EnvoyExtensionPolicies they generated when WAF is disabled.
+		// WAF_GATEWAY_EXTENSION_ENABLED tells them whether to program (enabled) or
+		// de-program (disabled) — EV-6751. Absent ⇒ the reconciler defaults to
+		// enabled, so an older operator that predates this var is unaffected.
+		if c.cfg.GatewayAPIPresent {
+			env = append(env, corev1.EnvVar{Name: "WAF_GATEWAY_EXTENSION_ENABLED", Value: strconv.FormatBool(c.cfg.WAFGatewayExtensionEnabled)})
+		}
+
+		// Application-layer (gateway-addons / WAF v3) WASM env vars, gated by
 		// GatewayAPI.spec.extensions.waf.state == Enabled. When the gate is
 		// off (default), none of the WASM_* env vars are rendered and the
-		// kube-controllers binary skips the WAF reconcilers entirely (see the
-		// applicationlayer entry in enabledControllers).
+		// WAF reconcilers de-program rather than attach a filter.
 		if c.cfg.WAFGatewayExtensionEnabled {
 			// Application-layer (gateway-addons) reconcilers consume the Coraza WAF
 			// wasm OCI reference from this env var to program WAF policy attachments.

--- a/pkg/render/kubecontrollers/kube-controllers_test.go
+++ b/pkg/render/kubecontrollers/kube-controllers_test.go
@@ -254,6 +254,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		cfg.MetricsPort = 9094
 		// Opt in to the WAF Gateway API add-on so the WAF env vars + RBAC are rendered.
 		cfg.WAFGatewayExtensionEnabled = true
+		cfg.GatewayAPIPresent = true
 		cfg.WAFWebhookCABundle = []byte("fake-ca-bundle")
 		// core_controller provisions a dedicated WAF wasm pull secret (a renamed
 		// copy of the install pull secret) so the reconciler can replicate it into
@@ -450,6 +451,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		cfg.MetricsPort = 9094
 		// Opt in to the WAF Gateway API add-on so the WAF env vars + RBAC are rendered.
 		cfg.WAFGatewayExtensionEnabled = true
+		cfg.GatewayAPIPresent = true
 
 		component := kubecontrollers.NewElasticsearchKubeControllers(&cfg)
 		Expect(component.ResolveImages(nil)).To(BeNil())
@@ -521,6 +523,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		cfg.MetricsPort = 9094
 		// Opt in to the WAF Gateway API add-on so the WAF env vars + RBAC are rendered.
 		cfg.WAFGatewayExtensionEnabled = true
+		cfg.GatewayAPIPresent = true
 
 		component := kubecontrollers.NewCalicoKubeControllers(&cfg)
 		Expect(component.ResolveImages(nil)).To(BeNil())
@@ -651,6 +654,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 
 		instance.Variant = operatorv1.CalicoEnterprise
 		cfg.WAFGatewayExtensionEnabled = true
+		cfg.GatewayAPIPresent = true
 		cfg.WAFWebhookServerTLS = wafTLS
 
 		component := kubecontrollers.NewCalicoKubeControllers(&cfg)
@@ -684,6 +688,41 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		}))
 	})
 
+	It("should keep the WAF controller wired for teardown but render no active WAF surface when WAF is disabled (EV-6751)", func() {
+		instance.Variant = operatorv1.CalicoEnterprise
+		// GatewayAPI present but WAF turned off: the applicationlayer controller
+		// must stay wired (with its EnvoyExtensionPolicy delete RBAC) so it can
+		// tear down the EEPs it generated, and be told it is disabled via the env.
+		cfg.GatewayAPIPresent = true
+		cfg.WAFGatewayExtensionEnabled = false
+
+		component := kubecontrollers.NewCalicoKubeControllers(&cfg)
+		Expect(component.ResolveImages(nil)).To(BeNil())
+		resources, _ := component.Objects()
+
+		dp := rtest.GetResource(resources, kubecontrollers.KubeController, common.CalicoNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+		c := dp.Spec.Template.Spec.Containers[0]
+
+		// Controller stays wired.
+		Expect(c.Env).To(ContainElement(corev1.EnvVar{
+			Name: "ENABLED_CONTROLLERS", Value: "node,loadbalancer,service,federatedservices,usage,applicationlayer",
+		}))
+		// Told it is disabled → the reconciler de-programs rather than attaches.
+		Expect(c.Env).To(ContainElement(corev1.EnvVar{Name: "WAF_GATEWAY_EXTENSION_ENABLED", Value: "false"}))
+		// No active WAF surface: no WASM image env, no webhook cert dir.
+		for _, e := range c.Env {
+			Expect(e.Name).NotTo(Equal("WASM_IMAGE"))
+			Expect(e.Name).NotTo(Equal("WAF_WEBHOOK_CERT_DIR"))
+		}
+		// But it keeps the EnvoyExtensionPolicy delete RBAC to run the teardown.
+		clusterRole := rtest.GetResource(resources, "calico-kube-controllers", "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
+		Expect(clusterRole.Rules).To(ContainElement(rbacv1.PolicyRule{
+			APIGroups: []string{"gateway.envoyproxy.io"},
+			Resources: []string{"envoyextensionpolicies"},
+			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+		}))
+	})
+
 	It("should render all es-calico-kube-controllers resources for a default configuration using CalicoEnterprise and ClusterType is Management", func() {
 		expectedResources := []struct {
 			name    string
@@ -710,6 +749,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		cfg.MetricsPort = 9094
 		// Opt in to the WAF Gateway API add-on so the WAF env vars + RBAC are rendered.
 		cfg.WAFGatewayExtensionEnabled = true
+		cfg.GatewayAPIPresent = true
 
 		component := kubecontrollers.NewElasticsearchKubeControllers(&cfg)
 		Expect(component.ResolveImages(nil)).To(BeNil())


### PR DESCRIPTION
Cherry-pick of #4989.

## Description

The operator half of EV-6751. Disabling Gateway WAF (`GatewayAPI` `spec.extensions.waf.state: Disabled`) dropped the `applicationlayer` controller from kube-controllers `ENABLED_CONTROLLERS` and stripped its `envoyextensionpolicies …delete` RBAC in the same reconcile that tore down the rest of the WAF surface. So the controller never got the chance, or the permission, to delete the `EnvoyExtensionPolicy` objects it had generated. The gateway kept enforcing WAF after WAF was "off". That is the ordering race behind EV-6751: the operator removed the thing that was supposed to clean up, at the same moment it asked for cleanup.

Bug fix. Affects kube-controllers rendering (`applicationlayer` controller enablement + RBAC). Issue: EV-6751.

## What changed

Gate the `applicationlayer` controller enablement and its WAF / Gateway-API / `EnvoyExtensionPolicy` RBAC on a new `GatewayAPIPresent` (the `GatewayAPI` CR exists) rather than on `waf.state == Enabled`. `GatewayAPIPresent` is a superset of `WAFGatewayExtensionEnabled` — you can't enable WAF without the CR present, so in practice they move together on enable, but `GatewayAPIPresent` stays true through a disable.

Result: the WAF controller stays wired, with identical RBAC, whether WAF is enabled or disabled, so it can tear down its EEPs when disabled. A new `WAF_GATEWAY_EXTENSION_ENABLED` env on the kube-controllers Deployment tells the reconciler whether to program (enabled) or de-program (disabled).

The active WAF surface stays gated on `waf.state == Enabled`: `WASM_*` env vars, the admission webhook + its cert, wasm image resolution, and the webhook NetworkPolicy. Toggling `waf.state` causes no ClusterRole churn, since the WAF RBAC set is identical enabled vs disabled.

Because the controller only watches Gateway API / Envoy Gateway CRDs when they exist, gating on `GatewayAPIPresent` keeps it off on clusters that never installed Gateway API (where those CRDs are absent). The toggle-disable path this fixes keeps Gateway API installed, so the CRDs the controller watches are present.

## Pairs with

calico-private https://github.com/tigera/calico-private/pull/12568 — the reconciler change that reads `WAF_GATEWAY_EXTENSION_ENABLED` and tears down on disable. This operator PR is inert without it, and it is inert without this (the reconciler never sees the disable signal, and gets torn down before it can clean up). Land them together.

## Deferred (follow-up)

A belt-and-suspenders operator-side final GC — delete leftover EEPs by label (`app.kubernetes.io/name=calico-waf`) cluster-wide — for the hard-uninstall case where Gateway API itself is removed and no in-cluster controller can run. Not needed for the toggle-disable scenario this PR fixes; called out so it isn't lost.

## Test plan

- `go test ./pkg/render/kubecontrollers/` — green (44 specs). New spec: WAF disabled but Gateway API present renders the `applicationlayer` controller, `WAF_GATEWAY_EXTENSION_ENABLED=false`, and the `envoyextensionpolicies` delete RBAC, but no `WASM_IMAGE` / webhook cert.
- Existing WAF-enabled specs updated to set `GatewayAPIPresent` alongside `WAFGatewayExtensionEnabled` (the production invariant).
- `gofmt` + `go vet` clean; container pre-commit hook passed.
- Cluster verification (enable → disable → confirm EEP torn down + no enforcement) pending alongside the calico-private PR, on matched dev images.

## Release Note

```release-note
Fixed a bug where disabling Gateway WAF left the generated EnvoyExtensionPolicy in place so the gateway kept enforcing WAF. The WAF controller now stays running while disabled so it can tear down what it generated.
```

## For PR author

- [x] Tests for change. (new WAF-disabled render spec; existing specs updated)
- [x] If changing pkg/apis/, run `make gen-files` — N/A, no `pkg/apis/` changes.
- [x] If changing versions, run `make gen-versions` — N/A, no version changes.

## For PR reviewers

- [ ] Milestone set according to targeted release.
- [x] Appropriate labels:
  - `kind/bug` — bugfix.
  - `enterprise` — Calico Enterprise only.