### PR TITLE
fix(waf): sync WAFPolicy CRD with cross-scope plugin CEL rule

### DIFF
--- a/pkg/imports/crds/enterprise/applicationlayer.projectcalico.org/applicationlayer.projectcalico.org_wafpolicies.yaml
+++ b/pkg/imports/crds/enterprise/applicationlayer.projectcalico.org/applicationlayer.projectcalico.org_wafpolicies.yaml
@@ -95,10 +95,17 @@ spec:
                   type: object
                 plugins:
                   description: |-
-                    Plugins references WAFPlugins in this namespace. Cross-scope references
-                    (kind: GlobalWAFPlugin) are not yet resolved by the reconciler, so the
-                    CEL rule rejects them at admission as a backstop to the validating
-                    webhook — see EV-6753 and the PluginRef doc above.
+                    Plugins references WAFPlugins in this namespace. A cross-scope reference
+                    (kind: GlobalWAFPlugin) is rejected at admission by the CEL rule below and
+                    the validating webhook, because the reconciler resolves plugin scope from
+                    the parent policy and does not yet honor Kind. See EV-6753.
+
+                    Only this namespaced direction is guarded. The mirror case, a
+                    GlobalWAFPolicy referencing a namespaced WAFPlugin, is intentionally not
+                    guarded: PluginRef.Kind defaults to WAFPlugin (see above), so a symmetric
+                    rule would reject that default on nearly every GlobalWAFPolicy. The
+                    cross-scope-resolution follow-up owns the reverse guard, the Kind default,
+                    and an upgrade migration; see the WAF controllers README.
                   items:
                     description: |-
                       PluginRef references a plugin by kind + name. Kind makes the

--- a/pkg/imports/crds/enterprise/applicationlayer.projectcalico.org/applicationlayer.projectcalico.org_wafpolicies.yaml
+++ b/pkg/imports/crds/enterprise/applicationlayer.projectcalico.org/applicationlayer.projectcalico.org_wafpolicies.yaml
@@ -94,7 +94,11 @@ spec:
                       type: string
                   type: object
                 plugins:
-                  description: Plugins references WAFPlugins in this namespace
+                  description: |-
+                    Plugins references WAFPlugins in this namespace. Cross-scope references
+                    (kind: GlobalWAFPlugin) are not yet resolved by the reconciler, so the
+                    CEL rule rejects them at admission as a backstop to the validating
+                    webhook — see EV-6753 and the PluginRef doc above.
                   items:
                     description: |-
                       PluginRef references a plugin by kind + name. Kind makes the
@@ -128,6 +132,11 @@ spec:
                     type: object
                   maxItems: 64
                   type: array
+                  x-kubernetes-validations:
+                    - message:
+                        "cross-scope plugin references are not yet supported: a
+                        namespaced WAFPolicy cannot reference a GlobalWAFPlugin"
+                      rule: self.all(p, !has(p.kind) || p.kind != 'GlobalWAFPlugin')
                 targetRefs:
                   description:
                     TargetRefs specifies Gateway API references (Gateway,


### PR DESCRIPTION
## Description

Bundled-CRD sync for a bug fix in calico-private. A namespaced `WAFPolicy` could name a cluster-scoped `GlobalWAFPlugin` in `spec.plugins[].kind`. Admission accepted it, but the reconciler always resolves a plugin ref as a namespace-scoped `WAFPlugin` and ignores `kind`, so the ref never resolved and failed later with a confusing `PluginNotFound`.

The calico-private PR adds a CRD CEL rule (`x-kubernetes-validations`) on `WAFPolicy.spec.plugins` that rejects the cross-scope ref at admission. kube-apiserver enforces it no matter what, so it backstops the `/validate-waf` webhook when the webhook isn't there (cert not provisioned yet, gateway license off, or an older operator that hasn't wired the webhook config).

This PR is the operator side. It syncs the bundled enterprise WAFPolicy CRD (`pkg/imports/crds/enterprise/applicationlayer.projectcalico.org/applicationlayer.projectcalico.org_wafpolicies.yaml`) so the operator ships the rule. The diff is exactly the CEL block plus the field description, and it matches what a full `make fetch-crds` re-sync from calico-private master will produce once the paired PR lands.

- Type: bug fix (generated-CRD sync)
- Affects: enterprise WAFPolicy CRD only. No controller or render changes.
- Paired with https://github.com/tigera/calico-private/pull/12606
- Jira: EV-6753

## Release Note

```release-note
Fixed a namespaced WAFPolicy that referenced a GlobalWAFPlugin being silently accepted and then failing with PluginNotFound. Such cross-scope plugin references are now rejected at admission with a clear message.
```

## For PR author

- [x] Tests for change. The webhook and CEL behavior are tested in the paired calico-private PR; this PR is a generated-CRD sync, so no operator-side test applies.
- [x] If changing pkg/apis/, run `make gen-files`. N/A, no `api/v1` change; the bundled CRD under `pkg/imports/crds` is synced from calico-private, not produced by `gen-files`.
- [x] If changing versions, run `make gen-versions`. N/A.
