### PR TITLE
gatewayapi: watch operator-namespace secrets for pull-secret rotation

### DIFF
--- a/pkg/controller/gatewayapi/gatewayapi_controller.go
+++ b/pkg/controller/gatewayapi/gatewayapi_controller.go
@@ -102,6 +102,14 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 		return fmt.Errorf("gatewayapi-controller failed to watch Installation resource: %w", err)
 	}
 
+	// Watch secrets in the operator namespace so pull-secret rotations reconcile the
+	// per-namespace copies we push into each Gateway namespace. Named "" to catch
+	// arbitrarily-named user-provided pull secrets.
+	if err = utils.AddSecretsWatch(c, "", common.OperatorNamespace()); err != nil {
+		log.V(5).Info("Failed to create secrets watch", "err", err)
+		return fmt.Errorf("gatewayapi-controller failed to watch secrets: %w", err)
+	}
+
 	// Perform periodic reconciliation. This acts as a backstop to catch reconcile issues,
 	// and also makes sure we spot when things change that might not trigger a reconciliation.
 	if err = utils.AddPeriodicReconcile(c, utils.PeriodicReconcileTime, &handler.EnqueueRequestForObject{}); err != nil {


### PR DESCRIPTION
## Description

Bug fix for the Ingress Gateway (Gateway API) controller.

The gatewayapi controller copies `tigera-pull-secret` from the `tigera-operator`
namespace into each Gateway namespace, but it did not watch the source secret. When a
customer rotated their pull secret, the per-namespace copies went stale until an
unrelated event triggered a gatewayapi reconcile — breaking image pulls for proxy pods
on reschedule or scale-up after a credential rotation.

This adds `utils.AddSecretsWatch(c, "", common.OperatorNamespace())` to the gatewayapi
controller's `Add` function, matching the pattern already used by the Installation
controller (`pkg/controller/installation/core_controller.go`). Rotations of the pull
secret (or any user-provided pull secret in the operator namespace) now immediately
enqueue a reconcile, which re-copies the updated data into every Gateway namespace.

- **Type:** bug fix
- **Affected components:** gatewayapi controller (Ingress Gateway / Gateway API)
- **Testing:** `make ut UT_DIR=./pkg/controller/gatewayapi` — 15/15 specs pass. Watch
  wiring is controller-runtime plumbing not exercised by the unit suite; the existing
  tests cover that the per-namespace copy is written on reconcile.

Fixes EV-6776

## Release Note

```release-note
NONE
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
