### PR TITLE
Add Renovate bot to automate dependency updates

### DIFF
--- a/.semaphore/renovate.yml
+++ b/.semaphore/renovate.yml
@@ -2,7 +2,7 @@ version: v1.0
 name: Renovate update dependencies
 agent:
   machine:
-    type: f1-standard-4
+    type: f1-standard-2
     os_image: ubuntu2204
 
 execution_time_limit:

--- a/.semaphore/renovate.yml
+++ b/.semaphore/renovate.yml
@@ -21,7 +21,7 @@ blocks:
   - name: Run Renovate
     task:
       secrets:
-        - name: marvin-renovate-token
+        - name: marvin-renovate-token-enterprise
       jobs:
         - name: Renovate
           env_vars:

--- a/.semaphore/renovate.yml
+++ b/.semaphore/renovate.yml
@@ -1,0 +1,37 @@
+version: v1.0
+name: Renovate update dependencies
+agent:
+  machine:
+    type: f1-standard-4
+    os_image: ubuntu2204
+
+execution_time_limit:
+  hours: 2
+
+global_job_config:
+  secrets:
+    - name: private-repo
+  prologue:
+    commands:
+      - chmod 0600 ~/.keys/*
+      - ssh-add ~/.keys/*
+      - checkout
+
+blocks:
+  - name: Run Renovate
+    task:
+      secrets:
+        - name: marvin-renovate-token
+      jobs:
+        - name: Renovate
+          env_vars:
+            - name: RENOVATE_REPOSITORIES
+              value: tigera/operator
+            - name: RENOVATE_GIT_AUTHOR
+              value: "marvin-tigera <marvin-tigera@users.noreply.github.com>"
+            - name: LOG_LEVEL
+              value: info
+          commands:
+            - nvm install 24 && nvm use 24
+            - npm install -g renovate@43
+            - renovate --platform=github --autodiscover=false

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,14 @@ endif
 REPO?=tigera/operator
 PACKAGE_NAME?=github.com/tigera/operator
 LOCAL_USER_ID?=$(shell id -u $$USER)
-GO_BUILD_VER?=1.26.4-llvm21.1.8-k8s1.36.2
+# The project Go version.
+GO_VERSION?=1.26.4
+# Version of Kubernetes to use for dependencies, tests, and kubectl.
+K8S_VERSION?=v1.36.2
+# The version of LLVM to use for the go-build image.
+LLVM_VERSION?=21.1.8
+# Calico toolchain versions and the calico/go-build image to use.
+GO_BUILD_VER?=$(GO_VERSION)-llvm$(LLVM_VERSION)-k8s$(K8S_VERSION:v%=%)
 CALICO_BASE_VER ?= ubi9-1781568165
 CALICO_BUILD?=calico/go-build:$(GO_BUILD_VER)-$(BUILDARCH)
 CALICO_BASE ?= calico/base:$(CALICO_BASE_VER)

--- a/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_felixconfigurations.yaml
@@ -1121,9 +1121,10 @@ spec:
                   type: integer
                 nftablesMode:
                   default: Auto
-                  description:
-                    "NFTablesMode configures nftables support in Felix. [Default:
-                    Auto]"
+                  description: |-
+                    NFTablesMode configures nftables support in Felix. In Auto mode, Felix uses the
+                    nftables dataplane if kube-proxy is detected to be running in nftables mode.
+                    [Default: Auto]
                   enum:
                     - Disabled
                     - Enabled

--- a/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_felixconfigurations.yaml
+++ b/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_felixconfigurations.yaml
@@ -1120,9 +1120,10 @@ spec:
                   type: integer
                 nftablesMode:
                   default: Auto
-                  description:
-                    "NFTablesMode configures nftables support in Felix. [Default:
-                    Auto]"
+                  description: |-
+                    NFTablesMode configures nftables support in Felix. In Auto mode, Felix uses the
+                    nftables dataplane if kube-proxy is detected to be running in nftables mode.
+                    [Default: Auto]
                   enum:
                     - Disabled
                     - Enabled

--- a/pkg/imports/crds/enterprise/01-crd-eck-bundle.yaml
+++ b/pkg/imports/crds/enterprise/01-crd-eck-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.0'
+    app.kubernetes.io/version: '3.4.1'
   name: agents.agent.k8s.elastic.co
 spec:
   group: agent.k8s.elastic.co
@@ -502,7 +502,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.0'
+    app.kubernetes.io/version: '3.4.1'
   name: apmservers.apm.k8s.elastic.co
 spec:
   group: apm.k8s.elastic.co
@@ -1024,7 +1024,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.0'
+    app.kubernetes.io/version: '3.4.1'
   name: autoopsagentpolicies.autoops.k8s.elastic.co
 spec:
   group: autoops.k8s.elastic.co
@@ -1184,7 +1184,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.0'
+    app.kubernetes.io/version: '3.4.1'
   name: beats.beat.k8s.elastic.co
 spec:
   group: beat.k8s.elastic.co
@@ -1423,7 +1423,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.0'
+    app.kubernetes.io/version: '3.4.1'
   name: elasticmapsservers.maps.k8s.elastic.co
 spec:
   group: maps.k8s.elastic.co
@@ -1680,7 +1680,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.0'
+    app.kubernetes.io/version: '3.4.1'
   name: elasticsearchautoscalers.autoscaling.k8s.elastic.co
 spec:
   group: autoscaling.k8s.elastic.co
@@ -1937,7 +1937,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.0'
+    app.kubernetes.io/version: '3.4.1'
   name: elasticsearches.elasticsearch.k8s.elastic.co
 spec:
   group: elasticsearch.k8s.elastic.co
@@ -3322,7 +3322,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.0'
+    app.kubernetes.io/version: '3.4.1'
   name: enterprisesearches.enterprisesearch.k8s.elastic.co
 spec:
   group: enterprisesearch.k8s.elastic.co
@@ -3800,7 +3800,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.0'
+    app.kubernetes.io/version: '3.4.1'
   name: kibanas.kibana.k8s.elastic.co
 spec:
   group: kibana.k8s.elastic.co
@@ -4368,7 +4368,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.0'
+    app.kubernetes.io/version: '3.4.1'
   name: logstashes.logstash.k8s.elastic.co
 spec:
   group: logstash.k8s.elastic.co
@@ -4911,7 +4911,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.0'
+    app.kubernetes.io/version: '3.4.1'
   name: packageregistries.packageregistry.k8s.elastic.co
 spec:
   group: packageregistry.k8s.elastic.co
@@ -5153,7 +5153,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.0'
+    app.kubernetes.io/version: '3.4.1'
   name: stackconfigpolicies.stackconfigpolicy.k8s.elastic.co
 spec:
   group: stackconfigpolicy.k8s.elastic.co

--- a/pkg/imports/crds/enterprise/applicationlayer.projectcalico.org/applicationlayer.projectcalico.org_wafpolicies.yaml
+++ b/pkg/imports/crds/enterprise/applicationlayer.projectcalico.org/applicationlayer.projectcalico.org_wafpolicies.yaml
@@ -94,7 +94,18 @@ spec:
                       type: string
                   type: object
                 plugins:
-                  description: Plugins references WAFPlugins in this namespace
+                  description: |-
+                    Plugins references WAFPlugins in this namespace. A cross-scope reference
+                    (kind: GlobalWAFPlugin) is rejected at admission by the CEL rule below and
+                    the validating webhook, because the reconciler resolves plugin scope from
+                    the parent policy and does not yet honor Kind. See EV-6753.
+
+                    Only this namespaced direction is guarded. The mirror case, a
+                    GlobalWAFPolicy referencing a namespaced WAFPlugin, is intentionally not
+                    guarded: PluginRef.Kind defaults to WAFPlugin (see above), so a symmetric
+                    rule would reject that default on nearly every GlobalWAFPolicy. The
+                    cross-scope-resolution follow-up owns the reverse guard, the Kind default,
+                    and an upgrade migration; see the WAF controllers README.
                   items:
                     description: |-
                       PluginRef references a plugin by kind + name. Kind makes the
@@ -128,6 +139,11 @@ spec:
                     type: object
                   maxItems: 64
                   type: array
+                  x-kubernetes-validations:
+                    - message:
+                        "cross-scope plugin references are not yet supported: a
+                        namespaced WAFPolicy cannot reference a GlobalWAFPlugin"
+                      rule: self.all(p, !has(p.kind) || p.kind != 'GlobalWAFPlugin')
                 targetRefs:
                   description:
                     TargetRefs specifies Gateway API references (Gateway,

--- a/renovate.json
+++ b/renovate.json
@@ -32,6 +32,21 @@
       "depNameTemplate": "calico/base",
       "datasourceTemplate": "docker",
       "versioningTemplate": "regex:^(?<compatibility>ubi\\d+)-(?<patch>\\d+)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^Makefile$/"],
+      "matchStrings": ["GO_VERSION\\s*\\??=\\s*(?<currentValue>\\d+\\.\\d+\\.\\d+)"],
+      "depNameTemplate": "golang",
+      "datasourceTemplate": "golang-version"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^Makefile$/"],
+      "matchStrings": ["K8S_VERSION\\s*\\??=\\s*v(?<currentValue>\\d+\\.\\d+\\.\\d+)"],
+      "depNameTemplate": "kubernetes/kubernetes",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
     }
   ],
   "packageRules": [

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "rebaseWhen": "behind-base-branch",
+  "dependencyDashboard": false,
+  "baseBranchPatterns": ["release-v1.40", "release-v1.42", "release-v1.43", "master"],
+  "prBodyTemplate": "{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}{{{controls}}}",
+  "separateMinorPatch": true,
+  "enabledManagers": ["gomod", "custom.regex"],
+  "prHourlyLimit": 20,
+  "prConcurrentLimit": 20,
+  "addLabels": ["docs-not-required", "release-note-not-required", "dependencies"],
+  "gomod": {
+    "managerFilePatterns": ["/^go\\.mod$/"]
+  },
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "postUpdateOptions": ["gomodTidy"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^go\\.mod$/"],
+      "matchStrings": ["\\ngo (?<currentValue>\\d+\\.\\d+\\.\\d+)"],
+      "depNameTemplate": "golang",
+      "datasourceTemplate": "golang-version"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^Makefile$/"],
+      "matchStrings": ["CALICO_BASE_VER\\s*\\??=\\s*(?<currentValue>ubi\\d+-\\d+)"],
+      "depNameTemplate": "calico/base",
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "regex:^(?<compatibility>ubi\\d+)-(?<patch>\\d+)$"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Disable all Go module updates",
+      "matchManagers": ["gomod"],
+      "enabled": false
+    },
+    {
+      "description": "Enable k8s.io dependencies",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["k8s.io/**"],
+      "enabled": true
+    },
+    {
+      "description": "Enable golang.org/x libraries",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["golang.org/x/**"],
+      "enabled": true
+    },
+    {
+      "description": "Block all minor, major, and digest updates",
+      "matchUpdateTypes": ["minor", "major", "digest"],
+      "enabled": false
+    },
+    {
+      "description": "Allow golang.org/x minor updates",
+      "matchPackageNames": ["golang.org/x/**"],
+      "matchUpdateTypes": ["minor"],
+      "enabled": true
+    },
+    {
+      "description": "Group all updates into one PR",
+      "matchPackageNames": ["*"],
+      "matchDepNames": ["*"],
+      "groupName": "dependency-updates"
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Enables a Renovate bot for `tigera/operator`, bringing it to parity with the core
dependency automation that already runs in `projectcalico/calico`. Until now the
operator's Go modules, Go toolchain, and `calico/base` image have been bumped by hand.

**Type of change:** new feature / CI tooling (no product code changes).

This mirrors calico's setup — a `renovate.json` config plus a `.semaphore/renovate.yml`
pipeline run on a Semaphore schedule — adapted to the operator's file layout. Like
calico's, it is deliberately **not** a blanket dependency bumper: it tracks a small,
safe, patch-focused set and groups everything into a single PR.

### What it tracks
- **Go modules (patch-focused):** `k8s.io/**` → patch; `golang.org/x/**` → patch + minor;
  **all other Go modules disabled**. `go mod tidy` runs after each update
  (`postUpdateOptions: ["gomodTidy"]`).
- **Go language version:** the `go x.y.z` directive in `go.mod` (`golang-version`
  datasource), patch-only.
- **`calico/base` image:** `CALICO_BASE_VER` in the **Makefile** (`docker` datasource,
  `ubiN-<serial>` regex versioning), tolerant of `?=`.
- **Go-build toolchain parts:** `GO_VERSION` → `golang` (`golang-version`) and
  `K8S_VERSION` → `kubernetes/kubernetes` (`github-releases`, `v`-prefix extract),
  both patch-only. See the `GO_BUILD_VER` decomposition below.

### `GO_BUILD_VER` decomposition (Makefile)
`GO_BUILD_VER` was a single opaque string. Mirroring calico, it is now composed from
individually-addressable parts so each can be tracked/bumped on its own:
```makefile
GO_VERSION?=1.26.4
K8S_VERSION?=v1.36.2
LLVM_VERSION?=21.1.8
GO_BUILD_VER?=$(GO_VERSION)-llvm$(LLVM_VERSION)-k8s$(K8S_VERSION:v%=%)
```
This resolves to the identical value (`1.26.4-llvm21.1.8-k8s1.36.2`); `K8S_VERSION`
carries a leading `v` stripped on interpolation via `$(K8S_VERSION:v%=%)`. `LLVM_VERSION`
is decomposed for clarity but **not** Renovate-tracked (no datasource), same as calico.

Note: Renovate only edits the version text; the resulting `calico/go-build:<tag>` is a
downstream image built by `projectcalico/toolchain`. If a matching tag isn't published
yet, CI simply fails and the PR stays unmerged — master is never broken (same model as
calico).

### Global behaviour (mirrored from calico)
- All updates grouped into one PR (`groupName: dependency-updates`).
- Minor / major / digest blocked globally (with the `golang.org/x` minor exception above).
- `baseBranchPatterns`: `release-v1.40`, `release-v1.42`, `release-v1.43`, `master`.
- `vulnerabilityAlerts` enabled, `rebaseWhen: behind-base-branch`, PR limits 20/20.

### Semaphore job
`.semaphore/renovate.yml`: ubuntu2204 VM, `nvm install 24`, `renovate@43`,
`renovate --platform=github --autodiscover=false`, `RENOVATE_REPOSITORIES=tigera/operator`,
`RENOVATE_GIT_AUTHOR=marvin-tigera`. Reuses the org secrets `marvin-renovate-token-enterprise`
(GitHub PAT) and `private-repo` (SSH key for private `tigera/*` module fetches, `ssh-add`
in the prologue). The cron **schedule** is configured as a Semaphore scheduled Task in
project settings — it is not committed here, same as calico.

### Bundled: imported-CRD regeneration
This branch also includes a `make gen-versions` regeneration of the bundled
calico/enterprise CRDs (eck bundle `3.4.0 → 3.4.1`, plus `felixconfigurations` v1/v3 and
`wafpolicies` content). This clears a **pre-existing, Renovate-unrelated** `dirty-check`
failure caused by upstream `master` drift (the CRDs are pinned at `version: master`).
Included here to keep this PR's CI green; re-run `make gen-versions` before merge if
upstream drifts again.

### Differences from the calico base config (intentionally dropped / adapted)
- **`skip-bot-cherry-pick` label — dropped.** No such label exists in `tigera/operator`.
  Kept labels the operator actually has: `docs-not-required`, `release-note-not-required`,
  `dependencies`.
- **`merge-when-ready` / `delete-branch` labels — dropped for now.** These drive
  auto-merge and branch cleanup. Omitted for the initial runs so we can build confidence
  with PRs that stop at "opened"; they can be added back later.
- **`npm` manager — dropped.** The operator has no `package.json`.
- **`metadata.mk` managers — adapted.** The operator has no `metadata.mk`; calico's
  `GO_VERSION`/`K8S_VERSION`/`CALICO_BASE_VER` regex managers (which point at
  `metadata.mk`) are re-pointed at the operator's `Makefile`, and tolerate `?=`.
- **`make gen-deps-files` `postUpgradeTasks` + `RENOVATE_ALLOWED_COMMANDS` — dropped.**
  The operator has no `deps.txt` generation step; it relies on `gomodTidy` instead.
- **`baseBranchPatterns` — adapted** to the operator's active release branches
  (`release-v1.40/-v1.42/-v1.43` + `master`) instead of calico's `release-v3.31/-v3.32`.
  Note: `release-v1.40`'s Makefile uses a different base-image scheme (no `CALICO_BASE_VER`),
  so `calico/base` is not tracked on that branch — Go modules and the go directive still are.

### Testing
Validated locally against the real repos before/while iterating on this PR:
- `renovate-config-validator` — config passes schema validation.
- Full `renovate --dry-run` against `tigera/operator` — extraction succeeds on all base
  branches; `golang` (go directive) and `calico/base` (with `?=`) both extract; scoping is
  correct; updates group into `renovate/<branch>-dependency-updates`; `vulnerabilityAlerts`
  correctly opens security PRs that bypass the block rules.
- `renovate --dry-run` against the decomposed Makefile (fork branch) — the new `GO_VERSION`
  → `golang` and `K8S_VERSION` → `kubernetes/kubernetes` managers both extract and are
  patch-only.
- `make gen-versions` re-run is idempotent (clean tree) after the CRD regeneration commit.

## Release Note

```release-note
NONE
```

## For PR author

- [x] Tests for change. (N/A — CI tooling; validated via renovate-config-validator + dry-run)
- [x] If changing pkg/apis/, run `make gen-files` (N/A)
- [x] If changing versions, run `make gen-versions` (done — see CRD regeneration commit)

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
