### PR TITLE
Makefile: decompose GO_BUILD_VER for Renovate (release-v1.40)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,14 @@ endif
 REPO?=tigera/operator
 PACKAGE_NAME?=github.com/tigera/operator
 LOCAL_USER_ID?=$(shell id -u $$USER)
-GO_BUILD_VER?=1.25.11-llvm18.1.8-k8s1.33.12
+# The project Go version.
+GO_VERSION?=1.25.11
+# Version of Kubernetes to use for dependencies, tests, and kubectl.
+K8S_VERSION?=v1.33.12
+# The version of LLVM to use for the go-build image.
+LLVM_VERSION?=18.1.8
+# Calico toolchain versions and the calico/go-build image to use.
+GO_BUILD_VER?=$(GO_VERSION)-llvm$(LLVM_VERSION)-k8s$(K8S_VERSION:v%=%)
 CALICO_BUILD?=calico/go-build:$(GO_BUILD_VER)-$(BUILDARCH)
 SRC_FILES=$(shell find ./pkg -name '*.go')
 SRC_FILES+=$(shell find ./api -name '*.go')


### PR DESCRIPTION
## Description

Cherry-pick of the master `GO_BUILD_VER` decomposition to `release-v1.40`, adapted to this
branch's toolchain versions. Splits the monolithic go-build version into
individually-addressable `GO_VERSION` / `K8S_VERSION` / `LLVM_VERSION` parts and
rebuilds `GO_BUILD_VER` as a composite of them.

**Type of change:** internal build refactor (no product code changes).

**Why:** enables the Renovate bot (added on master) to track `GO_VERSION` (golang)
and `K8S_VERSION` (kubernetes/kubernetes) on this release branch, which is one of
Renovate's `baseBranchPatterns`. Without the decomposition the custom managers find
nothing to match here.

`GO_BUILD_VER` resolves to the **identical** value it had before
(`1.25.11-llvm18.1.8-k8s1.33.12`); `K8S_VERSION` carries a leading `v` stripped on interpolation via
`$(K8S_VERSION:v%=%)`. `LLVM_VERSION` is decomposed for clarity but not
Renovate-tracked. Any separate images (e.g. `CALICO_BUILD_LINT`) are left untouched.

**Testing:** verified via `make` that `GO_BUILD_VER` and `CALICO_BUILD` expand to the
same values as before; the pre-commit hook ran in the correctly-resolved
`calico/go-build:1.25.11-llvm18.1.8-k8s1.33.12-amd64` image.

## Release Note

```release-note
NONE
```

## For PR author

- [x] Tests for change. (N/A — build refactor; verified via make expansion)
- [x] If changing pkg/apis/, run `make gen-files` (N/A)
- [x] If changing versions, run `make gen-versions` (N/A — value unchanged)

## For PR reviewers

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels.
