### PR TITLE
Makefile: decompose GO_BUILD_VER for Renovate (release-v1.42)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,14 @@ endif
 REPO?=tigera/operator
 PACKAGE_NAME?=github.com/tigera/operator
 LOCAL_USER_ID?=$(shell id -u $$USER)
-GO_BUILD_VER?=1.26.4-llvm21.1.8-k8s1.35.6
+# The project Go version.
+GO_VERSION?=1.26.4
+# Version of Kubernetes to use for dependencies, tests, and kubectl.
+K8S_VERSION?=v1.35.6
+# The version of LLVM to use for the go-build image.
+LLVM_VERSION?=21.1.8
+# Calico toolchain versions and the calico/go-build image to use.
+GO_BUILD_VER?=$(GO_VERSION)-llvm$(LLVM_VERSION)-k8s$(K8S_VERSION:v%=%)
 CALICO_BASE_VER ?= ubi9-1771532994
 CALICO_BUILD?=calico/go-build:$(GO_BUILD_VER)-$(BUILDARCH)
 CALICO_BASE ?= calico/base:$(CALICO_BASE_VER)


### PR DESCRIPTION
## Description

Cherry-pick of the master `GO_BUILD_VER` decomposition to `release-v1.42`, adapted to this
branch's toolchain versions. Splits the monolithic go-build version into
individually-addressable `GO_VERSION` / `K8S_VERSION` / `LLVM_VERSION` parts and
rebuilds `GO_BUILD_VER` as a composite of them.

**Type of change:** internal build refactor (no product code changes).

**Why:** enables the Renovate bot (added on master) to track `GO_VERSION` (golang)
and `K8S_VERSION` (kubernetes/kubernetes) on this release branch, which is one of
Renovate's `baseBranchPatterns`. Without the decomposition the custom managers find
nothing to match here.

`GO_BUILD_VER` resolves to the **identical** value it had before
(`1.26.4-llvm21.1.8-k8s1.35.6`); `K8S_VERSION` carries a leading `v` stripped on interpolation via
`$(K8S_VERSION:v%=%)`. `LLVM_VERSION` is decomposed for clarity but not
Renovate-tracked. Any separate images (e.g. `CALICO_BUILD_LINT`) are left untouched.

**Testing:** verified via `make` that `GO_BUILD_VER` and `CALICO_BUILD` expand to the
same values as before; the pre-commit hook ran in the correctly-resolved
`calico/go-build:1.26.4-llvm21.1.8-k8s1.35.6-amd64` image.

## Release Note

```release-note
NONE
```

## For PR author

- [x] Tests for change. (N/A — build refactor; verified via make expansion)
- [x] If changing pkg/apis/, run `make gen-files` (N/A)
- [x] If changing versions, run `make gen-versions` (N/A — value unchanged)

## For PR reviewers

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels.
