### PR TITLE
Makefile: fix k8s version drift on release-v1.42 (match go.mod)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ LOCAL_USER_ID?=$(shell id -u $$USER)
 # The project Go version.
 GO_VERSION?=1.26.4
 # Version of Kubernetes to use for dependencies, tests, and kubectl.
-K8S_VERSION?=v1.35.6
+K8S_VERSION?=v1.36.1
 # The version of LLVM to use for the go-build image.
 LLVM_VERSION?=21.1.8
 # Calico toolchain versions and the calico/go-build image to use.


### PR DESCRIPTION
## Description

Fixes a Kubernetes version drift on `release-v1.42` between the build toolchain and
the compiled-against libraries:

- **go.mod** pins `k8s.io/*` at `v0.36.1` → Kubernetes **1.36.1**
- **Makefile** `GO_BUILD_VER` used `k8s1.35.6` → Kubernetes **1.35.6**

This aligns the Makefile to go.mod by setting `K8S_VERSION=v1.36.1`, so the
`calico/go-build` image (which bakes in kubectl / k8s test binaries) matches the
`k8s.io` libraries the operator is built against.

**Type of change:** build/toolchain fix (no product code changes).

`GO_BUILD_VER` becomes `1.26.4-llvm21.1.8-k8s1.36.1`. The `calico/go-build` image for
that tag is published (verified), so CI has an image to run in.

**Testing:** verified via `make` that `GO_BUILD_VER`/`CALICO_BUILD` expand to the new
value; confirmed the go-build image tag exists and pulled it; pre-commit hook ran in it.

## Release Note

```release-note
NONE
```

## For PR author

- [x] Tests for change. (N/A — build fix; verified via make expansion + image pull)
- [x] If changing pkg/apis/, run `make gen-files` (N/A)
- [x] If changing versions, run `make gen-versions` (N/A)

## For PR reviewers

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels.
