### PR TITLE
Makefile: fix k8s version drift on release-v1.40 (match go.mod)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ LOCAL_USER_ID?=$(shell id -u $$USER)
 # The project Go version.
 GO_VERSION?=1.25.11
 # Version of Kubernetes to use for dependencies, tests, and kubectl.
-K8S_VERSION?=v1.33.12
+K8S_VERSION?=v1.35.6
 # The version of LLVM to use for the go-build image.
 LLVM_VERSION?=18.1.8
 # Calico toolchain versions and the calico/go-build image to use.


### PR DESCRIPTION
## Description

Fixes a Kubernetes version drift on `release-v1.40` between the build toolchain and
the compiled-against libraries:

- **go.mod** pins `k8s.io/*` at `v0.35.3` → Kubernetes **1.35**
- **Makefile** `GO_BUILD_VER` used `k8s1.33.12` → Kubernetes **1.33**

This aligns the Makefile to go.mod's minor by setting `K8S_VERSION=v1.35.6`, so the
`calico/go-build` image (which bakes in kubectl / k8s test binaries) matches the
`k8s.io` libraries the operator is built against.

**Type of change:** build/toolchain fix (no product code changes).

Note on the patch: go.mod's exact patch is `1.35.3`, but no `calico/go-build` image is
published for `1.25.11-llvm18.1.8-k8s1.35.3`. The image **does** exist for `k8s1.35.6`,
so this uses `v1.35.6` — matching the meaningful 1.35 minor while ensuring CI has an
image to run in. `GO_BUILD_VER` becomes `1.25.11-llvm18.1.8-k8s1.35.6`. The separate
`CALICO_BUILD_LINT` image is intentionally left untouched (it is pinned to a different
version on purpose).

**Testing:** verified via `make` that `GO_BUILD_VER`/`CALICO_BUILD` expand to the new
value and `CALICO_BUILD_LINT` is unchanged; confirmed the go-build image tag exists and
pulled it; pre-commit hook ran in it.

## Release Note

```release-note
NONE
```

## For PR author

- [x] Tests for change. (N/A — build fix; verified via make expansion + image pull)
- [x] If changing pkg/apis/, run `make gen-files` (N/A)
- [x] If changing versions, run `make gen-versions` (N/A)

## For PR reviewers

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels.
