### PR TITLE
[TSLA-11619] Make GetKeyCertPEM select key/cert pair deterministically (cherry-pick #5008, 1.42)

### DIFF
--- a/pkg/tls/certificatemanagement/keypair.go
+++ b/pkg/tls/certificatemanagement/keypair.go
@@ -275,15 +275,22 @@ func GetKeyCertPEM(secret *corev1.Secret) ([]byte, []byte) {
 		legacySecretCertName5 = "management-cluster.crt"
 	)
 	data := secret.Data
-	for keyField, certField := range map[string]string{
-		corev1.TLSPrivateKeyKey: corev1.TLSCertKey,
-		legacySecretKeyName:     legacySecretCertName,
-		legacySecretKeyName2:    legacySecretCertName2,
-		legacySecretKeyName3:    legacySecretCertName3,
-		legacySecretKeyName4:    legacySecretCertName4,
-		legacySecretKeyName5:    legacySecretCertName5,
+	// Check the recognised key/cert field-name pairs in a fixed priority order, standard
+	// tls.crt/tls.key first, then the legacy names. Iterating a map here would be a bug: Go
+	// randomizes map iteration order, so a secret that contains more than one recognised pair
+	// (e.g. the standard tls.crt/tls.key alongside a legacy cert/key that is intentionally kept
+	// during a certificate-rotation overlap) would return a non-deterministic cert. That flips
+	// the KeyPair's hash annotation between reconciles, which in turn triggers spurious rolling
+	// restarts of consumers such as Voltron/tigera-manager (dropping managed-cluster tunnels).
+	for _, pair := range []struct{ keyField, certField string }{
+		{corev1.TLSPrivateKeyKey, corev1.TLSCertKey},
+		{legacySecretKeyName, legacySecretCertName},
+		{legacySecretKeyName2, legacySecretCertName2},
+		{legacySecretKeyName3, legacySecretCertName3},
+		{legacySecretKeyName4, legacySecretCertName4},
+		{legacySecretKeyName5, legacySecretCertName5},
 	} {
-		key, cert := data[keyField], data[certField]
+		key, cert := data[pair.keyField], data[pair.certField]
 		if len(cert) > 0 {
 			return key, cert
 		}

--- a/pkg/tls/certificatemanagement/keypair_test.go
+++ b/pkg/tls/certificatemanagement/keypair_test.go
@@ -28,6 +28,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 )
 
@@ -200,6 +202,54 @@ var _ = Describe("TLS secret metadata", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(secret.Labels["certificates.operator.tigera.io/signer"]).To(Equal("unknown"))
+		})
+	})
+
+	Describe("GetKeyCertPEM()", func() {
+		It("should read the standard tls.crt/tls.key pair", func() {
+			secret := &corev1.Secret{Data: map[string][]byte{
+				"tls.key": []byte("standard-key"),
+				"tls.crt": []byte("standard-cert"),
+			}}
+			key, cert := certificatemanagement.GetKeyCertPEM(secret)
+			Expect(string(key)).To(Equal("standard-key"))
+			Expect(string(cert)).To(Equal("standard-cert"))
+		})
+
+		It("should fall back to legacy cert/key names when the standard pair is absent", func() {
+			secret := &corev1.Secret{Data: map[string][]byte{
+				"key":  []byte("legacy-key"),
+				"cert": []byte("legacy-cert"),
+			}}
+			key, cert := certificatemanagement.GetKeyCertPEM(secret)
+			Expect(string(key)).To(Equal("legacy-key"))
+			Expect(string(cert)).To(Equal("legacy-cert"))
+		})
+
+		// Regression test: a secret may legitimately hold both the standard tls.crt/tls.key pair
+		// and a legacy cert/key pair at the same time (e.g. an expired legacy cert kept during a
+		// rotation overlap). Selection must be deterministic and always prefer the standard pair;
+		// otherwise the KeyPair hash annotation flaps and rolls consumers like tigera-manager.
+		It("should deterministically prefer tls.crt/tls.key when both standard and legacy pairs exist", func() {
+			secret := &corev1.Secret{Data: map[string][]byte{
+				"tls.key": []byte("standard-key"),
+				"tls.crt": []byte("standard-cert"),
+				"key":     []byte("legacy-key"),
+				"cert":    []byte("legacy-cert"),
+			}}
+			// Run many times to defeat Go's randomized map iteration order.
+			for i := 0; i < 100; i++ {
+				key, cert := certificatemanagement.GetKeyCertPEM(secret)
+				Expect(string(key)).To(Equal("standard-key"))
+				Expect(string(cert)).To(Equal("standard-cert"))
+			}
+		})
+
+		It("should return nil when no recognised pair is present", func() {
+			secret := &corev1.Secret{Data: map[string][]byte{"unrelated": []byte("x")}}
+			key, cert := certificatemanagement.GetKeyCertPEM(secret)
+			Expect(key).To(BeNil())
+			Expect(cert).To(BeNil())
 		})
 	})
 })


### PR DESCRIPTION
## Description

Cherry-pick of #5008 to `release-v1.42`.

Bug fix. `GetKeyCertPEM` ranged over a Go map of key/cert field-name pairs, so when a secret held more than one recognized pair (e.g. standard `tls.crt`/`tls.key` alongside a legacy `cert`/`key` kept during a cert-rotation overlap), the returned cert was non-deterministic due to randomized map iteration. For the Voltron tunnel secret this flipped the KeyPair hash annotation between reconciles, changing the `tigera-manager` pod template hash and triggering spurious Voltron rolling restarts that dropped managed-cluster tunnels.

The fix selects the key/cert pair in a fixed priority order (standard `tls.crt`/`tls.key` first, then legacy names) and adds a regression test asserting deterministic selection when both pairs are present.

Affects `pkg/tls/certificatemanagement`. Clean cherry-pick from master (`b28e353d`); `pkg/tls/certificatemanagement` package tests pass.

## Release Note

```release-note
NONE
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
