### PR TITLE
[v1.43] Add SeccompProfile to Waypoint proxies

### DIFF
--- a/pkg/render/istio/config.go
+++ b/pkg/render/istio/config.go
@@ -14,7 +14,11 @@
 
 package istio
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	corev1 "k8s.io/api/core/v1"
+)
 
 type GlobalConfig struct {
 	IstioNamespace         string           `json:"istioNamespace,omitempty"`
@@ -33,6 +37,10 @@ type ProxyInitConfig struct {
 	Image string `json:"image,omitempty"`
 }
 
+type GatewaysConfig struct {
+	SeccompProfile *corev1.SeccompProfile `json:"seccompProfile,omitempty"`
+}
+
 type AmbientConfig struct {
 	Enabled                    bool `json:"enabled,omitempty"`
 	ReconcileIptablesOnStartup bool `json:"reconcileIptablesOnStartup,omitempty"`
@@ -43,10 +51,11 @@ type BaseOpts struct {
 }
 
 type IstiodOpts struct {
-	Image                   string        `json:"image,omitempty"`
-	Global                  *GlobalConfig `json:"global,omitempty"`
-	Profile                 string        `json:"profile,omitempty"`
-	TrustedZtunnelNamespace string        `json:"trustedZtunnelNamespace,omitempty"`
+	Image                   string          `json:"image,omitempty"`
+	Global                  *GlobalConfig   `json:"global,omitempty"`
+	Gateways                *GatewaysConfig `json:"gateways,omitempty"`
+	Profile                 string          `json:"profile,omitempty"`
+	TrustedZtunnelNamespace string          `json:"trustedZtunnelNamespace,omitempty"`
 }
 
 type IstioCNIOpts struct {

--- a/pkg/render/istio/istio.go
+++ b/pkg/render/istio/istio.go
@@ -106,6 +106,11 @@ func Istio(cfg *Configuration) (*IstioComponentCRDs, *IstioComponent, error) {
 					Image: istioFakeImageProxyv2,
 				},
 			},
+			Gateways: &GatewaysConfig{
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
 			Profile:                 "ambient",
 			TrustedZtunnelNamespace: IstioNamespace,
 		},

--- a/pkg/render/istio/istio_test.go
+++ b/pkg/render/istio/istio_test.go
@@ -15,6 +15,7 @@
 package istio_test
 
 import (
+	"encoding/json"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -407,6 +408,25 @@ var _ = Describe("Istio Component Rendering", func() {
 			for _, v := range valuesConfigMap.Data {
 				Expect(v).NotTo(ContainSubstring("my-pull-secret"), "Expected no secret names in imagePullSecrets when none configured")
 			}
+		})
+
+		It("should set gateways.seccompProfile so waypoints run in PSA-restricted namespaces", func() {
+			_, component, err := istio.Istio(cfg)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			objsToCreate, _ := component.Objects()
+
+			injectorConfigMap, err := rtest.GetResourceOfType[*corev1.ConfigMap](objsToCreate, istio.IstioSidecarInjectorConfigMapName, istio.IstioNamespace)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			var values struct {
+				Gateways struct {
+					SeccompProfile corev1.SeccompProfile `json:"seccompProfile"`
+				} `json:"gateways"`
+			}
+			Expect(json.Unmarshal([]byte(injectorConfigMap.Data["values"]), &values)).To(Succeed())
+			Expect(values.Gateways.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault),
+				"waypoint istio-proxy containers only get a seccompProfile when gateways.seccompProfile is set in the istiod values")
 		})
 	})
 


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v1.43**: tigera/operator#5033

Allow Waypoint proxies to run in PSA restricted mode.

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
TBD
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.

