### PR TITLE
renovate: track go directive in api/go.mod (+ enterprise CRD sync)

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/tigera/operator/api
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/envoyproxy/gateway v1.7.2

--- a/pkg/imports/crds/enterprise/v1.crd.projectcalico.org/crd.projectcalico.org_kubecontrollersconfigurations.yaml
+++ b/pkg/imports/crds/enterprise/v1.crd.projectcalico.org/crd.projectcalico.org_kubecontrollersconfigurations.yaml
@@ -136,6 +136,13 @@ spec:
                                 AutoHostEndpoints
                               items:
                                 properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description:
+                                      Annotations adds the specified annotations
+                                      to the generated AutoHostEndpoint.
+                                    type: object
                                   generateName:
                                     description:
                                       GenerateName is appended to the end
@@ -400,6 +407,13 @@ spec:
                                     AutoHostEndpoints
                                   items:
                                     properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description:
+                                          Annotations adds the specified
+                                          annotations to the generated AutoHostEndpoint.
+                                        type: object
                                       generateName:
                                         description:
                                           GenerateName is appended to the

--- a/pkg/imports/crds/enterprise/v3.projectcalico.org/projectcalico.org_kubecontrollersconfigurations.yaml
+++ b/pkg/imports/crds/enterprise/v3.projectcalico.org/projectcalico.org_kubecontrollersconfigurations.yaml
@@ -139,6 +139,13 @@ spec:
                                 AutoHostEndpoints
                               items:
                                 properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description:
+                                      Annotations adds the specified annotations
+                                      to the generated AutoHostEndpoint.
+                                    type: object
                                   generateName:
                                     description:
                                       GenerateName is appended to the end
@@ -403,6 +410,13 @@ spec:
                                     AutoHostEndpoints
                                   items:
                                     properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description:
+                                          Annotations adds the specified
+                                          annotations to the generated AutoHostEndpoint.
+                                        type: object
                                       generateName:
                                         description:
                                           GenerateName is appended to the

--- a/renovate.json
+++ b/renovate.json
@@ -20,7 +20,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "managerFilePatterns": ["/^go\\.mod$/"],
+      "managerFilePatterns": ["/^go\\.mod$/", "/^api\\/go\\.mod$/"],
       "matchStrings": ["\\ngo (?<currentValue>\\d+\\.\\d+\\.\\d+)"],
       "depNameTemplate": "golang",
       "datasourceTemplate": "golang-version"


### PR DESCRIPTION
## Description

Two related changes:

1. **Renovate: track the `go` directive in `api/go.mod`.** Adds `api/go.mod` to the
   `golang-version` custom manager so the Go **language version** in the api submodule
   is bumped in sync with root.

   The `gomod` *dependency* manager is intentionally left root-only. `api/go.mod`'s
   shared deps (`k8s.io/*`, `golang.org/x/*`) are **already** kept in sync by Renovate:
   `gomodTidy` follows the local `replace github.com/tigera/operator/api => ./api` and
   tidies the api module too (see e.g. #5021 / #5022, which updated `api/go.mod` deps
   with no api entry in the gomod manager). What `go mod tidy` does **not** touch is the
   `go X.Y.Z` directive line — which this custom-manager change covers. This mirrors
   calico, whose `golang-version` manager lists root + `api/go.mod` while its `gomod`
   manager stays root-only.

   This PR also **bumps `api/go.mod`'s current `go` directive** `1.26.4` → `1.26.5` to
   close the existing one-patch gap with root (k8s deps already match on master). `go build
   ./...` in `api/` passes.

2. **Sync imported enterprise CRDs.** `make update-enterprise-crds` regenerated the
   bundled `kubecontrollersconfigurations` CRDs (v1 + v3) to pick up an upstream additive
   change (an `annotations` field on `AutoHostEndpoint`). Clears `dirty-check`.

**Type of change:** CI tooling + generated-file sync (no product code changes).

**Testing:** `renovate-config-validator` passes; `api/go.mod`'s `go 1.26.x` directive
matches the manager regex; CRD regeneration re-run is idempotent on the freshly-synced
master.

## Release Note

```release-note
NONE
```

## For PR author

- [x] Tests for change. (N/A — tooling + generated files; validated via renovate-config-validator)
- [x] If changing pkg/apis/, run `make gen-files` (N/A)
- [x] If changing versions, run `make gen-versions` (CRDs regenerated via make update-enterprise-crds)

## For PR reviewers

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels.
