### PR TITLE
feat(rbac): grant WAF UI personas read access to Gateway API resources

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1843,6 +1843,18 @@ func (c *apiServerComponent) tigeraUserClusterRole() *rbacv1.ClusterRole {
 			Resources: []string{"applicationlayers", "packetcaptureapis", "compliances", "intrusiondetections"},
 			Verbs:     []string{"get"},
 		},
+		// Allow the user to read the gatewayapis CR to detect if Gateway API is enabled/disabled.
+		{
+			APIGroups: []string{"operator.tigera.io"},
+			Resources: []string{"gatewayapis"},
+			Verbs:     []string{"get"},
+		},
+		// Allow the user to read Gateways and HTTPRoutes to offer as WAF policy attach targets.
+		{
+			APIGroups: []string{"gateway.networking.k8s.io"},
+			Resources: []string{"gateways", "httproutes"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
 		// Allow the user to view WAF policies, plugins, and validation policies.
 		{
 			APIGroups: []string{"applicationlayer.projectcalico.org"},
@@ -2058,6 +2070,19 @@ func (c *apiServerComponent) tigeraNetworkAdminClusterRole() *rbacv1.ClusterRole
 			APIGroups: []string{"operator.tigera.io"},
 			Resources: []string{"applicationlayers", "packetcaptureapis", "compliances", "intrusiondetections"},
 			Verbs:     []string{"get", "update", "patch", "create", "delete"},
+		},
+		// Allow the user to read the gatewayapis CR to detect if Gateway API is enabled/disabled.
+		// Read-only: enabling Gateway API from the WAF UI is intentionally deferred.
+		{
+			APIGroups: []string{"operator.tigera.io"},
+			Resources: []string{"gatewayapis"},
+			Verbs:     []string{"get"},
+		},
+		// Allow the user to read Gateways and HTTPRoutes to offer as WAF policy attach targets.
+		{
+			APIGroups: []string{"gateway.networking.k8s.io"},
+			Resources: []string{"gateways", "httproutes"},
+			Verbs:     []string{"get", "list", "watch"},
 		},
 		// Allow the user to manage WAF policies, plugins, and validation policies.
 		{

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -1724,6 +1724,16 @@ var (
 			Verbs:     []string{"get"},
 		},
 		{
+			APIGroups: []string{"operator.tigera.io"},
+			Resources: []string{"gatewayapis"},
+			Verbs:     []string{"get"},
+		},
+		{
+			APIGroups: []string{"gateway.networking.k8s.io"},
+			Resources: []string{"gateways", "httproutes"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+		{
 			APIGroups: []string{"applicationlayer.projectcalico.org"},
 			Resources: []string{
 				"globalwafpolicies",
@@ -1894,6 +1904,16 @@ var (
 			APIGroups: []string{"operator.tigera.io"},
 			Resources: []string{"applicationlayers", "packetcaptureapis", "compliances", "intrusiondetections"},
 			Verbs:     []string{"get", "update", "patch", "create", "delete"},
+		},
+		{
+			APIGroups: []string{"operator.tigera.io"},
+			Resources: []string{"gatewayapis"},
+			Verbs:     []string{"get"},
+		},
+		{
+			APIGroups: []string{"gateway.networking.k8s.io"},
+			Resources: []string{"gateways", "httproutes"},
+			Verbs:     []string{"get", "list", "watch"},
 		},
 		{
 			APIGroups: []string{"applicationlayer.projectcalico.org"},


### PR DESCRIPTION
## Description

New feature (RBAC). On master, neither shipped user persona has any Gateway API RBAC. The WAF management UI reads as the impersonated end user, so it can't see Gateway API resources yet. That breaks two things: the UI can't tell whether Gateway API is turned on (it needs to `get` the operator `gatewayapis` CR), and it can't list gateways or httproutes to offer them as WAF policy attach targets. Both calls come back 403.

This grants read access to both personas so those calls work:

- `tigera-ui-user` and `tigera-network-admin` get `get` on `operator.tigera.io` `gatewayapis`.
- Both get `get`, `list`, `watch` on `gateway.networking.k8s.io` `gateways` and `httproutes`.

A couple of notes on scope:

- `gatewayapis` is read-only for both roles. Turning Gateway API on from the UI is deferred, so network-admin gets its own get-only rule instead of folding it into its existing full-CRUD applicationlayers rule.
- The Gateway API resources are read-only too. WAF never creates or edits gateways or routes.
- The `gatewayapis` get mirrors the "read applicationlayers to detect if WAF is enabled" rule these roles already carry.

This is pure render RBAC. No API type change, no CRD change.

Affected component: apiserver (`pkg/render/apiserver.go`).

### Testing

- Updated the expected `PolicyRules` for both roles in `pkg/render/apiserver_test.go`.
- `make ut UT_DIR=./pkg/render` passes (561 specs).
- `make format-check` is clean. CI covers `static-checks` and the `gen-files` dirty check.

Fixes https://tigera.atlassian.net/browse/EV-6814

## Release Note

```release-note
WAF management UI users can now read Gateway API resources to attach policies and detect Gateway API enablement.
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
