### PR TITLE
logstorage: stop deleting the tigera-linseed RoleBinding it no longer owns

### DIFF
--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -1372,10 +1372,6 @@ func (m *managedClusterLogStorage) deprecatedObjects() []client.Object {
 			TypeMeta:   metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
 			ObjectMeta: metav1.ObjectMeta{Name: "tigera-linseed-configmap"},
 		},
-		&rbacv1.RoleBinding{
-			TypeMeta:   metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
-			ObjectMeta: metav1.ObjectMeta{Name: "tigera-linseed", Namespace: "calico-system"},
-		},
 
 		// Remove legacy ExternalName service pointing to Guardian for linseed
 		&corev1.Service{

--- a/pkg/render/logstorage_test.go
+++ b/pkg/render/logstorage_test.go
@@ -625,7 +625,6 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 					&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "tigera-linseed-namespaces"}},
 					&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "tigera-linseed"}},
 					&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "tigera-linseed-configmap"}},
-					&rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "tigera-linseed", Namespace: "calico-system"}},
 					&corev1.Service{TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "tigera-linseed", Namespace: "tigera-elasticsearch"}},
 					&corev1.Service{TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure-es-gateway-http", Namespace: "tigera-elasticsearch"}},
 					&corev1.Namespace{TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "tigera-elasticsearch"}},


### PR DESCRIPTION
## Description

Bug fix for managed Enterprise clusters (EV-6837).

The managed-cluster logstorage cleanup still lists the `tigera-linseed` RoleBinding in `calico-system` in `deprecatedObjects()`, but that object is live again: the apiserver controller renders it for the MCM queryserver wiring (#4786) and the logcollector controller renders it since fluent-bit moved into `calico-system` (#4910), both so guardian's identity can manage Linseed token secrets there. The delete fought their create on every reconcile, so the RoleBinding flapped and guardian intermittently lost permission to provision Linseed tokens for calico-system components.

The entry was correct when it was added: the guardian RBAC consolidation (#3969, #4021) obsoleted logstorage's namespace-scoped bindings, and the cleanup removed the stragglers on upgrade. It just was never pruned when new controllers started rendering the same object again.

Found by a static audit of objects rendered by more than one controller (follow-up to #5055's `tigera-ca-bundle` fix — same root pattern: the component handler replaces object state wholesale, so two controllers with different desired state fight). The render test now pins the RoleBinding's absence from the delete list.

## Release Note

```release-note
None
```

No release note: both renders of this RoleBinding (#4786 and the fluent-bit migration #4910) are unreleased, so the create/delete fight never shipped.

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this PR fixes a bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)
