### PR TITLE
Default BPFOverlayHostSourceIP to HostAddress on fresh eBPF installs

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -2173,6 +2173,16 @@ func (r *ReconcileInstallation) setDefaultsOnFelixConfiguration(ctx context.Cont
 				return false, err
 			}
 			updated = true
+
+			// A fresh eBPF install opts into sourcing host-networked overlay traffic from the
+			// node's own address instead of an IP assigned to the tunnel device. Felix defaults
+			// this to TunnelAddress, which existing/upgraded clusters keep so their host-networked
+			// flows are not disrupted; brand new clusters have no such flows to preserve. Only set
+			// it when unset so a user-provided value is never overridden.
+			if fc.Spec.BPFOverlayHostSourceIP == nil {
+				hostSourceIP := v3.BPFOverlayHostSourceIPHostAddress
+				fc.Spec.BPFOverlayHostSourceIP = &hostSourceIP
+			}
 		}
 	} else {
 		bpfEnabledOnDaemonsetWithEnvVar, err := bpfEnabledOnDaemonsetWithEnvVar(ds)

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -1675,6 +1675,52 @@ var _ = Describe("Testing core-controller installation", func() {
 			Expect(fc.Annotations[render.BPFOperatorAnnotation]).To(Equal("true"))
 			Expect(fc.Spec.BPFEnabled).NotTo(BeNil())
 			Expect(*fc.Spec.BPFEnabled).To(BeTrue())
+
+			// A fresh eBPF install should opt into sourcing host-networked overlay traffic
+			// from the node's address rather than a tunnel device IP.
+			Expect(fc.Spec.BPFOverlayHostSourceIP).NotTo(BeNil())
+			Expect(*fc.Spec.BPFOverlayHostSourceIP).To(Equal(v3.BPFOverlayHostSourceIPHostAddress))
+		})
+
+		It("should not set BPFOverlayHostSourceIP on FelixConfiguration when calico-node already exists (upgrade)", func() {
+			createNodeDaemonSet()
+
+			network := operator.LinuxDataplaneBPF
+			cr.Spec.CalicoNetwork = &operator.CalicoNetworkSpec{LinuxDataplane: &network}
+			Expect(c.Create(ctx, cr)).NotTo(HaveOccurred())
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			fc := &v3.FelixConfiguration{}
+			err = c.Get(ctx, types.NamespacedName{Name: "default"}, fc)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// An existing cluster keeps Felix's TunnelAddress default (field left unset) so
+			// its host-networked overlay flows are not disrupted.
+			Expect(fc.Spec.BPFOverlayHostSourceIP).To(BeNil())
+		})
+
+		It("should not override a user-set BPFOverlayHostSourceIP on a fresh install", func() {
+			tunnelAddress := v3.BPFOverlayHostSourceIPTunnelAddress
+			existingFC := &v3.FelixConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: "default"},
+				Spec:       v3.FelixConfigurationSpec{BPFOverlayHostSourceIP: &tunnelAddress},
+			}
+			Expect(c.Create(ctx, existingFC)).NotTo(HaveOccurred())
+
+			network := operator.LinuxDataplaneBPF
+			cr.Spec.CalicoNetwork = &operator.CalicoNetworkSpec{LinuxDataplane: &network}
+			Expect(c.Create(ctx, cr)).NotTo(HaveOccurred())
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			fc := &v3.FelixConfiguration{}
+			err = c.Get(ctx, types.NamespacedName{Name: "default"}, fc)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// The operator must not stomp a value the user already set.
+			Expect(fc.Spec.BPFOverlayHostSourceIP).NotTo(BeNil())
+			Expect(*fc.Spec.BPFOverlayHostSourceIP).To(Equal(v3.BPFOverlayHostSourceIPTunnelAddress))
 		})
 
 		It("should set BPFEnabled to false on FelixConfiguration if BPF is disabled on installation", func() {


### PR DESCRIPTION
## Description

**Type:** enhancement.

On a **fresh eBPF install**, the operator now defaults `FelixConfiguration`'s
`bpfOverlayHostSourceIP` to `HostAddress`, opting the cluster out of assigning an IP to the
IPIP/VXLAN overlay tunnel device and sourcing host-networked (node-originated) overlay traffic
from the node's own address instead.

Felix defaults this setting to `TunnelAddress`. **Existing and upgraded clusters keep that
default** — the operator only writes the field on a fresh install, detected by the absence of
the `calico-node` DaemonSet in `setDefaultsOnFelixConfiguration`. A cluster switched from
iptables to eBPF still has its DaemonSet, so it is treated as existing and its established
host-networked overlay flows are not disrupted. Fresh clusters have no such flows to preserve,
so they adopt the leaner `HostAddress` mode. The write is guarded on the field being unset, so
a user-provided value is never overridden (users can always set it on the `FelixConfiguration`
CRD directly).

This is the operator companion to the Felix change
projectcalico/calico#11919, which added the `bpfOverlayHostSourceIP`
enum (`TunnelAddress` | `HostAddress`). It applies to both Calico OSS and Calico Enterprise.

**Affected components:** `pkg/controller/installation` (core controller FelixConfiguration
defaulting).

> [!IMPORTANT]
> **Draft — blocked on a dependency bump.** The code references
> `v3.BPFOverlayHostSourceIPHostAddress`, which is not yet in the published
> `github.com/tigera/api` module (the field merged to calico OSS master but must still ride the
> OSS→EE merge into calico-private, then a `tigera/api` sync). Once `tigera/api` carries the
> field, the remaining step is `go get github.com/tigera/api@<sha>` + `make mod-tidy`, after
> which this compiles and CI is green. The bundled OSS `FelixConfiguration` CRD already carries
> the enum; the Enterprise bundled CRD will follow the same version sync.

### Testing

**Unit tests** (`pkg/controller/installation`), all passing:
- fresh eBPF install → `bpfOverlayHostSourceIP=HostAddress`
- `calico-node` DaemonSet already present (upgrade) → field left unset
- user-set value on a fresh install → not overridden

**End-to-end on a live 2-node kind BPF+VXLAN cluster** (operator run against the cluster; Calico
built from calico master `1696258efb`, which carries the Felix change, published to
`thruby/node` + `thruby/calico`):

- *Fresh eBPF install:* operator wrote `bpfOverlayHostSourceIP: HostAddress`; felix parsed and
  honored it; `vxlan.calico` had **no IPv4** on both nodes (a tunnel address was still allocated
  in IPAM but felix did not put it on the device); cross-node overlay pod-to-pod connectivity
  worked both directions (0% loss).
- *Existing iptables → eBPF flip:* iptables install first gave `vxlan.calico` the tunnel IPs
  (`192.168.139.64/32`, `192.168.233.128/32`); after flipping the Installation to BPF the
  operator wrote **nothing** (`bpfOverlayHostSourceIP` stayed empty), felix used its
  `TunnelAddress` default, and the tunnel IPs were **preserved unchanged** — no disruption.

## Release Note

```release-note
Fresh eBPF installs now default FelixConfiguration bpfOverlayHostSourceIP to HostAddress (no overlay tunnel device IP); upgraded clusters keep the TunnelAddress default.
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/enhancement` if this is a a new feature.
