### PR TITLE
logcollector: run pos-migrator privileged on OpenShift

### DIFF
--- a/pkg/render/logcollector/daemonset.go
+++ b/pkg/render/logcollector/daemonset.go
@@ -109,11 +109,14 @@ func (c *fluentBitComponent) daemonset() *appsv1.DaemonSet {
 		}, migratorEnv...)
 	}
 	initContainers := []corev1.Container{{
-		Name:            "pos-migrator",
-		Image:           c.image,
-		Command:         []string{migratorCommand},
-		Env:             migratorEnv,
-		SecurityContext: c.securityContext(false),
+		Name:    "pos-migrator",
+		Image:   c.image,
+		Command: []string{migratorCommand},
+		Env:     migratorEnv,
+		// Writes to the same host path volume as the fluent-bit container, so
+		// it needs the same privileged access on OpenShift (SELinux otherwise
+		// denies mkdir on the host path).
+		SecurityContext: c.securityContext(c.cfg.Installation.KubernetesProvider.IsOpenShift()),
 		VolumeMounts: []corev1.VolumeMount{
 			{MountPath: c.path("/var/log/calico"), Name: "var-log-calico"},
 		},

--- a/pkg/render/logcollector/fluentbit_test.go
+++ b/pkg/render/logcollector/fluentbit_test.go
@@ -101,6 +101,17 @@ var _ = Describe("Tigera Secure Fluent Bit rendering tests", func() {
 			Verbs:         []string{"use"},
 			ResourceNames: []string{"privileged"},
 		}))
+
+		// Both the fluent-bit container and the pos-migrator init container
+		// write to the /var/log/calico host path volume, so both must be
+		// privileged on OpenShift.
+		ds := rtest.GetResource(resources, "calico-fluent-bit", "calico-system", "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
+		container := ds.Spec.Template.Spec.Containers[0]
+		Expect(*container.SecurityContext.Privileged).To(BeTrue())
+		initContainers := ds.Spec.Template.Spec.InitContainers
+		Expect(initContainers).NotTo(BeEmpty())
+		Expect(initContainers[0].Name).To(Equal("pos-migrator"))
+		Expect(*initContainers[0].SecurityContext.Privileged).To(BeTrue())
 	})
 
 	It("should render with a default configuration", func() {


### PR DESCRIPTION
## Description

Bug fix. On OpenShift, the fluent-bit pod crashloops before fluent-bit ever starts:

```
2026/07/16 22:45:30 mkdir /var/log/calico/calico-fluent-bit: mkdir /var/log/calico/calico-fluent-bit: permission denied
```

The `pos-migrator` init container writes to the same `/var/log/calico` host path volume as the fluent-bit container (it seeds the tail-offset DBs and pre-creates the tailed log directories), but its security context was hardcoded to non-privileged. On OpenShift, SELinux confines unprivileged containers and denies host path writes even as root. This PR gives the init container the same privileged-on-OpenShift security context as the main container. The pod is already admitted under the `privileged` SCC and the namespace is already labeled PSS-privileged, so no RBAC or namespace changes are needed.

Affects the logcollector (fluent-bit) rendering only; no behavior change outside OpenShift.

Testing: extended the OpenShift render unit test to assert both the fluent-bit container and the pos-migrator init container are privileged (`make ut UT_DIR=./pkg/render/logcollector` passes).

Fixes [EV-6838](https://tigera.atlassian.net/browse/EV-6838).

## Release Note

```release-note
NONE
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[EV-6838]: https://tigera.atlassian.net/browse/EV-6838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ