### PR TITLE
istio: Add cleanup for stale istio resources to waypoint controller

### DIFF
--- a/pkg/controller/istio/istio_controller.go
+++ b/pkg/controller/istio/istio_controller.go
@@ -91,13 +91,19 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 		return fmt.Errorf("istio-controller failed to create periodic reconcile watch: %w", err)
 	}
 
-	// The waypoint pull-secrets controller replicates the Installation pull
-	// secret into namespaces that contain istio-waypoint Gateways, so waypoint
-	// pods can pull the Istio proxy image from a private registry (the
-	// imagePullSecrets reference injected via istiod's global config is
-	// namespace-scoped and the secret must exist in the user namespace).
+	// The waypoint controller reconciles the per-Gateway state the Istio
+	// feature needs beyond istiod's own rendering. It replicates the
+	// Installation pull secret into namespaces that contain istio-waypoint
+	// Gateways, so waypoint pods can pull the Istio proxy image from a private
+	// registry (the imagePullSecrets reference injected via istiod's global
+	// config is namespace-scoped and the secret must exist in the user
+	// namespace). It also deletes the per-class resource sets that istiod
+	// strands when a Gateway's spec.gatewayClassName changes: istiod only
+	// applies the set for the current class and never deletes the previous
+	// class's set, and owner-reference GC only fires when the Gateway itself
+	// is deleted.
 	if err := waypoint.Add(mgr, opts); err != nil {
-		return fmt.Errorf("failed to add waypoint pull secrets controller: %w", err)
+		return fmt.Errorf("failed to add waypoint controller: %w", err)
 	}
 
 	return nil

--- a/pkg/controller/istio/waypoint/waypoint_cleanup.go
+++ b/pkg/controller/istio/waypoint/waypoint_cleanup.go
@@ -75,9 +75,8 @@ func (r *ReconcileWaypoint) staleGatewaySets(ctx context.Context, reqLogger logr
 		return nil, fmt.Errorf("failed to list Gateways: %w", err)
 	}
 	gateways := map[types.NamespacedName]*gapi.Gateway{}
-	for i := range gatewayList.Items {
-		gw := &gatewayList.Items[i]
-		gateways[types.NamespacedName{Namespace: gw.Namespace, Name: gw.Name}] = gw
+	for _, gw := range gatewayList.Items {
+		gateways[types.NamespacedName{Namespace: gw.Namespace, Name: gw.Name}] = &gw
 	}
 
 	// The kinds istiod renders for every managed Gateway. It can also render a

--- a/pkg/controller/istio/waypoint/waypoint_cleanup.go
+++ b/pkg/controller/istio/waypoint/waypoint_cleanup.go
@@ -1,0 +1,193 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package waypoint
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	gapi "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+const (
+	// GatewayClassNameLabel is stamped by istiod's gateway deployment controller
+	// on every resource it renders for a Gateway, recording the GatewayClass the
+	// resource was rendered for.
+	GatewayClassNameLabel = "gateway.networking.k8s.io/gateway-class-name"
+
+	gatewayAPIGroup = "gateway.networking.k8s.io"
+
+	// istioGatewayControllerPrefix identifies GatewayClasses handled by istiod's
+	// gateway deployment controller (e.g. istio.io/gateway-controller,
+	// istio.io/mesh-controller).
+	istioGatewayControllerPrefix = "istio.io/"
+)
+
+// builtinIstioGatewayClasses are the GatewayClass names istiod handles even
+// when no GatewayClass object exists for them. istiod's ClassController
+// creates (and re-creates) the GatewayClass objects for these, so this list
+// only decides staleness in the window where such an object is absent.
+var builtinIstioGatewayClasses = map[string]bool{
+	"istio":           true,
+	"istio-waypoint":  true,
+	"istio-remote":    true,
+	"istio-east-west": true,
+}
+
+// staleGatewaySets returns the istiod-managed gateway resources that were
+// rendered for a GatewayClass their owning Gateway no longer uses.
+//
+// Istiod's gateway deployment controller renders a per-class resource set
+// (Deployment, Service, ServiceAccount, ...) for each Gateway, named
+// differently per class: the istio-waypoint class uses the Gateway's name
+// as-is, other classes append the class name. It only ever applies the set for
+// the Gateway's *current* class and never deletes the set rendered for a
+// previous class, and Kubernetes garbage collection only fires when the
+// Gateway itself is deleted. So changing a Gateway's spec.gatewayClassName
+// strands the previous class's set — for waypoints, a running Deployment whose
+// l7-collector sidecar stays connected to Felix.
+func (r *ReconcileWaypoint) staleGatewaySets(ctx context.Context, reqLogger logr.Logger) ([]client.Object, error) {
+	gatewayList := &gapi.GatewayList{}
+	if err := r.List(ctx, gatewayList); err != nil {
+		return nil, fmt.Errorf("failed to list Gateways: %w", err)
+	}
+	gateways := map[types.NamespacedName]*gapi.Gateway{}
+	for i := range gatewayList.Items {
+		gw := &gatewayList.Items[i]
+		gateways[types.NamespacedName{Namespace: gw.Namespace, Name: gw.Name}] = gw
+	}
+
+	// The kinds istiod renders for every managed Gateway. It can also render a
+	// HorizontalPodAutoscaler and PodDisruptionBudget when the Gateway opts in;
+	// the HPA is not swept here because the operator has no delete permission
+	// on HPAs, and a stale HPA is inert (its scale target no longer exists) and
+	// is still garbage-collected with the Gateway.
+	lists := []client.ObjectList{
+		&appsv1.DeploymentList{},
+		&corev1.ServiceList{},
+		&corev1.ServiceAccountList{},
+		&policyv1.PodDisruptionBudgetList{},
+	}
+
+	var stale []client.Object
+	classManaged := map[string]bool{}
+	for _, list := range lists {
+		if err := r.List(ctx, list, client.HasLabels{GatewayClassNameLabel}); err != nil {
+			return nil, fmt.Errorf("failed to list gateway-managed resources: %w", err)
+		}
+		items, err := meta.ExtractList(list)
+		if err != nil {
+			return nil, fmt.Errorf("failed to extract gateway-managed resources: %w", err)
+		}
+		for _, item := range items {
+			obj, ok := item.(client.Object)
+			if !ok {
+				continue
+			}
+			isStale, err := r.staleGatewayResource(ctx, obj, gateways, classManaged)
+			if err != nil {
+				return nil, err
+			}
+			if isStale {
+				stale = append(stale, obj)
+			}
+		}
+	}
+
+	// These deletions are in user namespaces, so leave an Info-level trail.
+	for _, obj := range stale {
+		gvk, _ := apiutil.GVKForObject(obj, r.scheme)
+		reqLogger.Info("Deleting gateway resource rendered for a class its Gateway no longer uses",
+			"kind", gvk.Kind, "namespace", obj.GetNamespace(), "name", obj.GetName(),
+			"renderedForClass", obj.GetLabels()[GatewayClassNameLabel])
+	}
+
+	return stale, nil
+}
+
+// staleGatewayResource reports whether obj was rendered by istiod for a
+// GatewayClass that its owning Gateway no longer uses. Resources whose owning
+// Gateway no longer exists (or was recreated with a new UID) are not
+// considered stale: Kubernetes garbage collection removes those via the owner
+// reference. Resources rendered for a class that is not istiod-managed are
+// never touched — another gateway implementation could stamp the same labels.
+//
+// A racy read can transiently mark the active set stale (e.g. the class was
+// flipped back but the cache still holds the old Gateway). Deleting it anyway
+// is safe: istiod watches the resources it manages and re-applies the set for
+// the Gateway's current class.
+func (r *ReconcileWaypoint) staleGatewayResource(ctx context.Context, obj client.Object, gateways map[types.NamespacedName]*gapi.Gateway, classManaged map[string]bool) (bool, error) {
+	class := obj.GetLabels()[GatewayClassNameLabel]
+	if class == "" {
+		return false, nil
+	}
+	owner := gatewayOwnerRef(obj)
+	if owner == nil {
+		return false, nil
+	}
+	gw, ok := gateways[types.NamespacedName{Namespace: obj.GetNamespace(), Name: owner.Name}]
+	if !ok || gw.UID != owner.UID {
+		return false, nil
+	}
+	if string(gw.Spec.GatewayClassName) == class {
+		return false, nil
+	}
+	return r.isIstioManagedClass(ctx, class, classManaged)
+}
+
+// isIstioManagedClass reports whether className is handled by istiod's gateway
+// deployment controller, mirroring istiod's own lookup: an existing
+// GatewayClass object decides by controllerName; otherwise the builtin class
+// names apply. Results are memoized in classManaged for the reconcile.
+func (r *ReconcileWaypoint) isIstioManagedClass(ctx context.Context, className string, classManaged map[string]bool) (bool, error) {
+	if managed, ok := classManaged[className]; ok {
+		return managed, nil
+	}
+	var managed bool
+	gc := &gapi.GatewayClass{}
+	err := r.Get(ctx, types.NamespacedName{Name: className}, gc)
+	switch {
+	case err == nil:
+		managed = strings.HasPrefix(string(gc.Spec.ControllerName), istioGatewayControllerPrefix)
+	case errors.IsNotFound(err):
+		managed = builtinIstioGatewayClasses[className]
+	default:
+		return false, err
+	}
+	classManaged[className] = managed
+	return managed, nil
+}
+
+// gatewayOwnerRef returns obj's owner reference to a Gateway API Gateway, or
+// nil if there is none.
+func gatewayOwnerRef(obj client.Object) *metav1.OwnerReference {
+	for _, ref := range obj.GetOwnerReferences() {
+		if ref.Kind == "Gateway" && strings.HasPrefix(ref.APIVersion, gatewayAPIGroup+"/") {
+			return &ref
+		}
+	}
+	return nil
+}

--- a/pkg/controller/istio/waypoint/waypoint_cleanup_test.go
+++ b/pkg/controller/istio/waypoint/waypoint_cleanup_test.go
@@ -1,0 +1,359 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package waypoint
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gapi "sigs.k8s.io/gateway-api/apis/v1"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/apis"
+	"github.com/tigera/operator/pkg/controller/utils"
+	ctrlrfake "github.com/tigera/operator/pkg/ctrlruntime/client/fake"
+)
+
+var _ = Describe("Waypoint controller stale gateway set tests", func() {
+	const (
+		istioClassName = "istio"
+		userNamespace  = "user-ns"
+		gatewayName    = "waypoint"
+		gatewayUID     = types.UID("11111111-2222-3333-4444-555555555555")
+	)
+
+	var (
+		cli     client.Client
+		scheme  *runtime.Scheme
+		ctx     context.Context
+		r       *ReconcileWaypoint
+		istioCR *operatorv1.Istio
+	)
+
+	BeforeEach(func() {
+		scheme = runtime.NewScheme()
+		Expect(apis.AddToScheme(scheme, false)).ShouldNot(HaveOccurred())
+
+		ctx = context.Background()
+		cli = ctrlrfake.DefaultFakeClientBuilder(scheme).Build()
+
+		gatewayWatchReady := &utils.ReadyFlag{}
+		gatewayWatchReady.MarkAsReady()
+
+		r = &ReconcileWaypoint{
+			Client:            cli,
+			scheme:            scheme,
+			gatewayWatchReady: gatewayWatchReady,
+		}
+
+		istioCR = &operatorv1.Istio{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "default",
+			},
+		}
+	})
+
+	createIstioCR := func() {
+		Expect(cli.Create(ctx, istioCR)).NotTo(HaveOccurred())
+	}
+
+	createGateway := func(name, namespace, class string, uid types.UID) {
+		gw := &gapi.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				UID:       uid,
+			},
+			Spec: gapi.GatewaySpec{
+				GatewayClassName: gapi.ObjectName(class),
+				Listeners: []gapi.Listener{
+					{
+						Name:     "mesh",
+						Port:     15008,
+						Protocol: gapi.ProtocolType("HBONE"),
+					},
+				},
+			},
+		}
+		Expect(cli.Create(ctx, gw)).NotTo(HaveOccurred())
+	}
+
+	// gatewaySetMeta mirrors the metadata istiod stamps on the resources it
+	// renders for a Gateway: the istio-waypoint class uses the Gateway's name
+	// as-is, other classes append the class name.
+	gatewaySetMeta := func(gwName, namespace, class string, uid types.UID) metav1.ObjectMeta {
+		name := gwName
+		if class != IstioWaypointClassName {
+			name = gwName + "-" + class
+		}
+		return metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"gateway.networking.k8s.io/gateway-name": gwName,
+				GatewayClassNameLabel:                    class,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "gateway.networking.k8s.io/v1beta1",
+					Kind:       "Gateway",
+					Name:       gwName,
+					UID:        uid,
+				},
+			},
+		}
+	}
+
+	createGatewaySet := func(gwName, namespace, class string, uid types.UID) {
+		Expect(cli.Create(ctx, &appsv1.Deployment{ObjectMeta: gatewaySetMeta(gwName, namespace, class, uid)})).NotTo(HaveOccurred())
+		Expect(cli.Create(ctx, &corev1.Service{ObjectMeta: gatewaySetMeta(gwName, namespace, class, uid)})).NotTo(HaveOccurred())
+		Expect(cli.Create(ctx, &corev1.ServiceAccount{ObjectMeta: gatewaySetMeta(gwName, namespace, class, uid)})).NotTo(HaveOccurred())
+		Expect(cli.Create(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: gatewaySetMeta(gwName, namespace, class, uid)})).NotTo(HaveOccurred())
+	}
+
+	doReconcile := func() {
+		_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "default"}})
+		Expect(err).ShouldNot(HaveOccurred())
+	}
+
+	// remainingSetNames returns the names of the resources of each kind still
+	// present in the user namespace.
+	remainingSetNames := func() map[string][]string {
+		remaining := map[string][]string{}
+
+		deployments := &appsv1.DeploymentList{}
+		Expect(cli.List(ctx, deployments, client.InNamespace(userNamespace))).NotTo(HaveOccurred())
+		for _, d := range deployments.Items {
+			remaining["Deployment"] = append(remaining["Deployment"], d.Name)
+		}
+
+		services := &corev1.ServiceList{}
+		Expect(cli.List(ctx, services, client.InNamespace(userNamespace))).NotTo(HaveOccurred())
+		for _, s := range services.Items {
+			remaining["Service"] = append(remaining["Service"], s.Name)
+		}
+
+		serviceAccounts := &corev1.ServiceAccountList{}
+		Expect(cli.List(ctx, serviceAccounts, client.InNamespace(userNamespace))).NotTo(HaveOccurred())
+		for _, s := range serviceAccounts.Items {
+			remaining["ServiceAccount"] = append(remaining["ServiceAccount"], s.Name)
+		}
+
+		pdbs := &policyv1.PodDisruptionBudgetList{}
+		Expect(cli.List(ctx, pdbs, client.InNamespace(userNamespace))).NotTo(HaveOccurred())
+		for _, p := range pdbs.Items {
+			remaining["PodDisruptionBudget"] = append(remaining["PodDisruptionBudget"], p.Name)
+		}
+
+		return remaining
+	}
+
+	Context("when a Gateway's class has changed", func() {
+		It("should delete the stale istio-waypoint set and keep the current set", func() {
+			createIstioCR()
+			// The Gateway was flipped from istio-waypoint to istio: the stale
+			// set carries the istio-waypoint class label, the current set the
+			// istio class label.
+			createGateway(gatewayName, userNamespace, istioClassName, gatewayUID)
+			createGatewaySet(gatewayName, userNamespace, IstioWaypointClassName, gatewayUID)
+			createGatewaySet(gatewayName, userNamespace, istioClassName, gatewayUID)
+
+			doReconcile()
+
+			remaining := remainingSetNames()
+			for _, kind := range []string{"Deployment", "Service", "ServiceAccount", "PodDisruptionBudget"} {
+				Expect(remaining[kind]).To(ConsistOf("waypoint-istio"), "stale %s should be deleted", kind)
+			}
+		})
+
+		It("should delete the stale istio set when flipping back to istio-waypoint", func() {
+			createIstioCR()
+			createGateway(gatewayName, userNamespace, IstioWaypointClassName, gatewayUID)
+			createGatewaySet(gatewayName, userNamespace, IstioWaypointClassName, gatewayUID)
+			createGatewaySet(gatewayName, userNamespace, istioClassName, gatewayUID)
+
+			doReconcile()
+
+			remaining := remainingSetNames()
+			for _, kind := range []string{"Deployment", "Service", "ServiceAccount", "PodDisruptionBudget"} {
+				Expect(remaining[kind]).To(ConsistOf("waypoint"), "stale %s should be deleted", kind)
+			}
+		})
+	})
+
+	Context("when a Gateway's class matches its resources", func() {
+		It("should not delete anything", func() {
+			createIstioCR()
+			createGateway(gatewayName, userNamespace, IstioWaypointClassName, gatewayUID)
+			createGatewaySet(gatewayName, userNamespace, IstioWaypointClassName, gatewayUID)
+
+			doReconcile()
+
+			remaining := remainingSetNames()
+			for _, kind := range []string{"Deployment", "Service", "ServiceAccount", "PodDisruptionBudget"} {
+				Expect(remaining[kind]).To(ConsistOf("waypoint"), "%s should be kept", kind)
+			}
+		})
+	})
+
+	Context("when the owning Gateway no longer exists", func() {
+		It("should leave the resources to Kubernetes garbage collection", func() {
+			createIstioCR()
+			createGatewaySet(gatewayName, userNamespace, IstioWaypointClassName, gatewayUID)
+
+			doReconcile()
+
+			remaining := remainingSetNames()
+			for _, kind := range []string{"Deployment", "Service", "ServiceAccount", "PodDisruptionBudget"} {
+				Expect(remaining[kind]).To(ConsistOf("waypoint"), "%s should be left to GC", kind)
+			}
+		})
+	})
+
+	Context("when the owner reference UID does not match the Gateway", func() {
+		It("should leave the resources to Kubernetes garbage collection", func() {
+			createIstioCR()
+			createGateway(gatewayName, userNamespace, istioClassName, gatewayUID)
+			createGatewaySet(gatewayName, userNamespace, IstioWaypointClassName, types.UID("99999999-9999-9999-9999-999999999999"))
+
+			doReconcile()
+
+			remaining := remainingSetNames()
+			for _, kind := range []string{"Deployment", "Service", "ServiceAccount", "PodDisruptionBudget"} {
+				Expect(remaining[kind]).To(ConsistOf("waypoint"), "%s should be left to GC", kind)
+			}
+		})
+	})
+
+	Context("when the stale class is not istiod-managed", func() {
+		It("should not delete resources of another gateway implementation", func() {
+			createIstioCR()
+			gc := &gapi.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{Name: "other-class"},
+				Spec: gapi.GatewayClassSpec{
+					ControllerName: "example.com/gateway-controller",
+				},
+			}
+			Expect(cli.Create(ctx, gc)).NotTo(HaveOccurred())
+
+			createGateway(gatewayName, userNamespace, istioClassName, gatewayUID)
+			createGatewaySet(gatewayName, userNamespace, "other-class", gatewayUID)
+
+			doReconcile()
+
+			Expect(remainingSetNames()["Deployment"]).To(ConsistOf("waypoint-other-class"))
+		})
+	})
+
+	Context("when the stale class is a non-builtin istiod-managed class", func() {
+		It("should delete the stale set", func() {
+			createIstioCR()
+			gc := &gapi.GatewayClass{
+				ObjectMeta: metav1.ObjectMeta{Name: "custom-waypoint"},
+				Spec: gapi.GatewayClassSpec{
+					ControllerName: "istio.io/mesh-controller",
+				},
+			}
+			Expect(cli.Create(ctx, gc)).NotTo(HaveOccurred())
+
+			createGateway(gatewayName, userNamespace, IstioWaypointClassName, gatewayUID)
+			createGatewaySet(gatewayName, userNamespace, "custom-waypoint", gatewayUID)
+			createGatewaySet(gatewayName, userNamespace, IstioWaypointClassName, gatewayUID)
+
+			doReconcile()
+
+			Expect(remainingSetNames()["Deployment"]).To(ConsistOf("waypoint"))
+		})
+	})
+
+	Context("when resources are not labeled with a gateway class", func() {
+		It("should not delete them", func() {
+			createIstioCR()
+			createGateway(gatewayName, userNamespace, istioClassName, gatewayUID)
+
+			// A user Deployment that happens to have an owner reference to the
+			// Gateway but was not rendered by istiod (no class label).
+			d := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "user-deployment",
+					Namespace: userNamespace,
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "gateway.networking.k8s.io/v1beta1",
+							Kind:       "Gateway",
+							Name:       gatewayName,
+							UID:        gatewayUID,
+						},
+					},
+				},
+			}
+			Expect(cli.Create(ctx, d)).NotTo(HaveOccurred())
+
+			doReconcile()
+
+			Expect(remainingSetNames()["Deployment"]).To(ConsistOf("user-deployment"))
+		})
+	})
+
+	Context("when the Istio CR does not exist", func() {
+		It("should not delete anything", func() {
+			createGateway(gatewayName, userNamespace, istioClassName, gatewayUID)
+			createGatewaySet(gatewayName, userNamespace, IstioWaypointClassName, gatewayUID)
+
+			doReconcile()
+
+			Expect(remainingSetNames()["Deployment"]).To(ConsistOf("waypoint"))
+		})
+	})
+
+	Context("when the Istio CR is being deleted", func() {
+		It("should not delete anything", func() {
+			istioCR.Finalizers = []string{"tigera.io/test-finalizer"}
+			createIstioCR()
+			Expect(cli.Delete(ctx, istioCR)).NotTo(HaveOccurred())
+
+			createGateway(gatewayName, userNamespace, istioClassName, gatewayUID)
+			createGatewaySet(gatewayName, userNamespace, IstioWaypointClassName, gatewayUID)
+
+			doReconcile()
+
+			Expect(remainingSetNames()["Deployment"]).To(ConsistOf("waypoint"))
+		})
+	})
+
+	Context("when the Gateway watch is not yet ready", func() {
+		It("should not delete anything", func() {
+			r.gatewayWatchReady = &utils.ReadyFlag{}
+
+			createIstioCR()
+			createGateway(gatewayName, userNamespace, istioClassName, gatewayUID)
+			createGatewaySet(gatewayName, userNamespace, IstioWaypointClassName, gatewayUID)
+
+			doReconcile()
+
+			Expect(remainingSetNames()["Deployment"]).To(ConsistOf("waypoint"))
+		})
+	})
+})

--- a/pkg/controller/istio/waypoint/waypoint_controller.go
+++ b/pkg/controller/istio/waypoint/waypoint_controller.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -57,7 +58,11 @@ const (
 
 var log = logf.Log.WithName("controller_istio_waypoint")
 
-// Add creates the waypoint pull secrets controller and adds it to the Manager.
+// Add creates the waypoint controller and adds it to the Manager. The
+// controller reconciles the per-Gateway state the Istio feature needs beyond
+// istiod's own rendering: it copies Installation pull secrets into namespaces
+// that contain istio-waypoint Gateways, and deletes the resource sets istiod
+// strands when a Gateway's spec.gatewayClassName changes.
 func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 	if !opts.EnterpriseCRDExists {
 		return nil
@@ -65,15 +70,15 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 
 	gatewayWatchReady := &utils.ReadyFlag{}
 
-	r := &ReconcileWaypointSecrets{
+	r := &ReconcileWaypoint{
 		Client:            mgr.GetClient(),
 		scheme:            mgr.GetScheme(),
 		gatewayWatchReady: gatewayWatchReady,
 	}
 
-	c, err := ctrlruntime.NewController("istio-waypoint-secrets-controller", mgr, controller.Options{Reconciler: r})
+	c, err := ctrlruntime.NewController("istio-waypoint-controller", mgr, controller.Options{Reconciler: r})
 	if err != nil {
-		return fmt.Errorf("failed to create istio-waypoint-secrets-controller: %w", err)
+		return fmt.Errorf("failed to create istio-waypoint-controller: %w", err)
 	}
 
 	// Defer the Gateway watch — the Gateway API CRD may not be installed yet.
@@ -83,14 +88,28 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 		TypeMeta: metav1.TypeMeta{Kind: "Gateway", APIVersion: "gateway.networking.k8s.io/v1"},
 	}
 	go utils.WaitToAddResourceWatch(c, opts.K8sClientset, log, gatewayWatchReady, []client.Object{gatewayObj}, predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool {
-			gw, ok := e.Object.(*gapi.Gateway)
-			return ok && string(gw.Spec.GatewayClassName) == IstioWaypointClassName
-		},
+		// Any create can matter: a waypoint-class Gateway needs pull secrets,
+		// and when the informer syncs at operator startup every Gateway is
+		// replayed as a create — the sweep uses those to catch class flips
+		// that happened while the operator was down.
+		CreateFunc: func(e event.CreateEvent) bool { return true },
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			gw, ok := e.ObjectNew.(*gapi.Gateway)
-			return ok && string(gw.Spec.GatewayClassName) == IstioWaypointClassName
+			old, okOld := e.ObjectOld.(*gapi.Gateway)
+			curr, okNew := e.ObjectNew.(*gapi.Gateway)
+			if !okOld || !okNew {
+				return false
+			}
+			// A class change strands the resource set istiod rendered for the
+			// previous class, and moves pull secrets in or out of scope.
+			if old.Spec.GatewayClassName != curr.Spec.GatewayClassName {
+				return true
+			}
+			// Other updates only matter for waypoint Gateways, which drive
+			// pull-secret placement.
+			return string(curr.Spec.GatewayClassName) == IstioWaypointClassName
 		},
+		// Deletes only affect pull secrets: the resource sets istiod rendered
+		// are removed by Kubernetes garbage collection via owner references.
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			gw, ok := e.Object.(*gapi.Gateway)
 			return ok && string(gw.Spec.GatewayClassName) == IstioWaypointClassName
@@ -101,74 +120,103 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 		},
 	})
 
-	// Watch Istio CR for pull secret config changes.
+	// Watch the Istio CR for pull secret config changes and feature enablement.
 	err = c.WatchObject(&operatorv1.Istio{}, &handler.EnqueueRequestForObject{})
 	if err != nil {
-		return fmt.Errorf("istio-waypoint-secrets-controller failed to watch Istio resource: %w", err)
+		return fmt.Errorf("istio-waypoint-controller failed to watch Istio resource: %w", err)
 	}
 
 	// Watch Installation for pull secret changes.
 	if err = utils.AddInstallationWatch(c); err != nil {
-		return fmt.Errorf("istio-waypoint-secrets-controller failed to watch Installation resource: %w", err)
+		return fmt.Errorf("istio-waypoint-controller failed to watch Installation resource: %w", err)
 	}
 
 	// Periodic reconcile as a backstop.
 	if err = utils.AddPeriodicReconcile(c, utils.PeriodicReconcileTime, &handler.EnqueueRequestForObject{}); err != nil {
-		return fmt.Errorf("istio-waypoint-secrets-controller failed to create periodic reconcile watch: %w", err)
+		return fmt.Errorf("istio-waypoint-controller failed to create periodic reconcile watch: %w", err)
 	}
 
 	return nil
 }
 
-// ReconcileWaypointSecrets copies pull secrets to namespaces that contain
-// istio-waypoint Gateways so that waypoint pods can pull images from private registries.
-type ReconcileWaypointSecrets struct {
+// ReconcileWaypoint reconciles the per-Gateway state the Istio feature needs
+// beyond istiod's own rendering: it copies pull secrets to namespaces that
+// contain istio-waypoint Gateways so waypoint pods can pull images from
+// private registries, and deletes istiod-managed gateway resources that were
+// rendered for a GatewayClass their owning Gateway no longer uses.
+type ReconcileWaypoint struct {
 	client.Client
 	scheme *runtime.Scheme
 
 	gatewayWatchReady *utils.ReadyFlag
 }
 
-func (r *ReconcileWaypointSecrets) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+func (r *ReconcileWaypoint) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
-	reqLogger.V(1).Info("Reconciling waypoint pull secrets")
+	reqLogger.V(1).Info("Reconciling waypoint gateway resources")
 
-	// Determine which secrets need to exist (toCreate) based on current state,
-	// and which existing secrets are stale (toDelete).
-	var toCreate []client.Object
-	var toDelete []client.Object
-
-	// Get the Istio CR - if not found or being deleted, all existing secrets are stale.
+	// Get the Istio CR - if not found or being deleted, the feature is
+	// inactive: copied pull secrets are stale, and istiod's gateway resources
+	// belong to a mesh the operator does not manage and must not be touched.
 	instance := &operatorv1.Istio{}
 	err := r.Get(ctx, utils.DefaultInstanceKey, instance)
-	istioActive := err == nil && instance.DeletionTimestamp.IsZero()
 	if err != nil && !errors.IsNotFound(err) {
 		return reconcile.Result{}, err
 	}
+	istioActive := err == nil && instance.DeletionTimestamp.IsZero()
+	gatewaysVisible := istioActive && r.gatewayWatchReady.IsReady()
 
+	toCreate, toDelete, err := r.pullSecretChanges(ctx, gatewaysVisible, reqLogger)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if gatewaysVisible {
+		stale, err := r.staleGatewaySets(ctx, reqLogger)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		toDelete = append(toDelete, stale...)
+	}
+
+	// Use a single passthrough component to handle both creation and deletion.
+	hdlr := utils.NewComponentHandler(log, r, r.scheme, nil)
+	component := render.NewPassthrough(toCreate, toDelete)
+	if err := hdlr.CreateOrUpdateOrDelete(ctx, component, nil); err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to reconcile waypoint gateway resources: %w", err)
+	}
+
+	return reconcile.Result{}, nil
+}
+
+// pullSecretChanges determines which copied pull secrets need to exist
+// (toCreate) based on the namespaces that contain istio-waypoint Gateways, and
+// which existing copies are stale (toDelete). When active is false no copies
+// are desired, so every existing copy is returned as stale.
+func (r *ReconcileWaypoint) pullSecretChanges(ctx context.Context, active bool, reqLogger logr.Logger) (toCreate, toDelete []client.Object, err error) {
 	// Build the desired set of secrets if Istio is active and the Gateway watch is established.
-	targetNamespaces := map[string]bool{}
-	if istioActive && r.gatewayWatchReady.IsReady() {
+	if active {
 		_, installationSpec, err := utils.GetInstallationSpec(ctx, r)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				reqLogger.V(1).Info("Installation not found")
-				return reconcile.Result{}, nil
+				return nil, nil, nil
 			}
-			return reconcile.Result{}, err
+			return nil, nil, err
 		}
 
 		pullSecrets, err := utils.GetInstallationPullSecrets(installationSpec, r)
 		if err != nil {
-			return reconcile.Result{}, err
+			return nil, nil, err
 		}
 
 		// List all Gateway resources and filter for istio-waypoint class.
 		gatewayList := &gapi.GatewayList{}
 		if err := r.List(ctx, gatewayList); err != nil {
-			return reconcile.Result{}, fmt.Errorf("failed to list Gateways: %w", err)
+			return nil, nil, fmt.Errorf("failed to list Gateways: %w", err)
 		}
 
+		targetNamespaces := map[string]bool{}
 		for i := range gatewayList.Items {
 			gw := &gatewayList.Items[i]
 			if string(gw.Spec.GatewayClassName) == IstioWaypointClassName &&
@@ -200,7 +248,7 @@ func (r *ReconcileWaypointSecrets) Reconcile(ctx context.Context, request reconc
 	// List all existing secrets managed by this controller and mark stale ones for deletion.
 	existingSecrets := &corev1.SecretList{}
 	if err := r.List(ctx, existingSecrets, client.MatchingLabels{WaypointPullSecretLabel: "true"}); err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to list waypoint pull secrets: %w", err)
+		return nil, nil, fmt.Errorf("failed to list waypoint pull secrets: %w", err)
 	}
 	for i := range existingSecrets.Items {
 		s := &existingSecrets.Items[i]
@@ -210,12 +258,5 @@ func (r *ReconcileWaypointSecrets) Reconcile(ctx context.Context, request reconc
 		}
 	}
 
-	// Use a single passthrough component to handle both creation and deletion.
-	hdlr := utils.NewComponentHandler(log, r, r.scheme, nil)
-	component := render.NewPassthrough(toCreate, toDelete)
-	if err := hdlr.CreateOrUpdateOrDelete(ctx, component, nil); err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to reconcile waypoint pull secrets: %w", err)
-	}
-
-	return reconcile.Result{}, nil
+	return toCreate, toDelete, nil
 }

--- a/pkg/controller/istio/waypoint/waypoint_controller_test.go
+++ b/pkg/controller/istio/waypoint/waypoint_controller_test.go
@@ -36,12 +36,12 @@ import (
 	ctrlrfake "github.com/tigera/operator/pkg/ctrlruntime/client/fake"
 )
 
-var _ = Describe("Waypoint pull secrets controller tests", func() {
+var _ = Describe("Waypoint controller pull secret tests", func() {
 	var (
 		cli          client.Client
 		scheme       *runtime.Scheme
 		ctx          context.Context
-		r            *ReconcileWaypointSecrets
+		r            *ReconcileWaypoint
 		installation *operatorv1.Installation
 		istioCR      *operatorv1.Istio
 	)
@@ -61,7 +61,7 @@ var _ = Describe("Waypoint pull secrets controller tests", func() {
 		gatewayWatchReady := &utils.ReadyFlag{}
 		gatewayWatchReady.MarkAsReady()
 
-		r = &ReconcileWaypointSecrets{
+		r = &ReconcileWaypoint{
 			Client:            cli,
 			scheme:            scheme,
 			gatewayWatchReady: gatewayWatchReady,


### PR DESCRIPTION
If a Gateway class name is changed, it will result in an abandoned resource. Add clean up for these stale istio references.

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
TBD
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
