### PR TITLE
Only register the audit webhook on Enterprise

### DIFF
--- a/pkg/render/webhooks/render.go
+++ b/pkg/render/webhooks/render.go
@@ -412,41 +412,45 @@ func (c *component) Objects() ([]client.Object, []client.Object) {
 				TimeoutSeconds:          ptr.To(int32(5)),
 				FailurePolicy:           ptr.To(admissionregistrationv1.Ignore),
 			},
-			{
-				// This webhook is for audit logging. The webhook controller will get events for all relevant Calico API types
-				// and product audit logs for them.
-				Name: "audit-logging.api.projectcalico.org",
-				Rules: []admissionregistrationv1.RuleWithOperations{
-					{
-						Operations: []admissionregistrationv1.OperationType{
-							admissionregistrationv1.Create,
-							admissionregistrationv1.Update,
-							admissionregistrationv1.Delete,
-							admissionregistrationv1.Connect,
-						},
-						Rule: admissionregistrationv1.Rule{
-							APIGroups:   []string{"projectcalico.org"},
-							APIVersions: []string{"v3"},
-							Resources:   []string{"*"},
-							Scope:       ptr.To(admissionregistrationv1.AllScopes),
-						},
-					},
-				},
-				ClientConfig: admissionregistrationv1.WebhookClientConfig{
-					Service: &admissionregistrationv1.ServiceReference{
-						Namespace: common.CalicoNamespace,
-						Name:      WebhooksName,
-						Path:      ptr.To("/audit"),
-					},
-					CABundle: c.cfg.KeyPair.GetCertificatePEM(),
-				},
-				AdmissionReviewVersions: []string{"v1"},
-				SideEffects:             ptr.To(admissionregistrationv1.SideEffectClassNone),
-				TimeoutSeconds:          ptr.To(int32(5)),
-				FailurePolicy:           ptr.To(admissionregistrationv1.Ignore),
-				MatchPolicy:             ptr.To(admissionregistrationv1.Exact),
-			},
 		},
+	}
+
+	if c.cfg.Installation.Variant.IsEnterprise() {
+		// The /audit handler only exists in Enterprise. Registering this webhook on Calico OSS
+		// points the API server at an endpoint that isn't served, filling its log with failed
+		// webhook calls, so only add it for Enterprise.
+		vwc.Webhooks = append(vwc.Webhooks, admissionregistrationv1.ValidatingWebhook{
+			Name: "audit-logging.api.projectcalico.org",
+			Rules: []admissionregistrationv1.RuleWithOperations{
+				{
+					Operations: []admissionregistrationv1.OperationType{
+						admissionregistrationv1.Create,
+						admissionregistrationv1.Update,
+						admissionregistrationv1.Delete,
+						admissionregistrationv1.Connect,
+					},
+					Rule: admissionregistrationv1.Rule{
+						APIGroups:   []string{"projectcalico.org"},
+						APIVersions: []string{"v3"},
+						Resources:   []string{"*"},
+						Scope:       ptr.To(admissionregistrationv1.AllScopes),
+					},
+				},
+			},
+			ClientConfig: admissionregistrationv1.WebhookClientConfig{
+				Service: &admissionregistrationv1.ServiceReference{
+					Namespace: common.CalicoNamespace,
+					Name:      WebhooksName,
+					Path:      ptr.To("/audit"),
+				},
+				CABundle: c.cfg.KeyPair.GetCertificatePEM(),
+			},
+			AdmissionReviewVersions: []string{"v1"},
+			SideEffects:             ptr.To(admissionregistrationv1.SideEffectClassNone),
+			TimeoutSeconds:          ptr.To(int32(5)),
+			FailurePolicy:           ptr.To(admissionregistrationv1.Ignore),
+			MatchPolicy:             ptr.To(admissionregistrationv1.Exact),
+		})
 	}
 
 	// Create a MutatingWebhookConfiguration for Enterprise-only mutating webhooks.

--- a/pkg/render/webhooks/render_test.go
+++ b/pkg/render/webhooks/render_test.go
@@ -122,6 +122,15 @@ var _ = Describe("Webhooks rendering tests", func() {
 			Resources: []string{"managedclusters"},
 			Verbs:     []string{"list", "watch", "update"},
 		}))
+
+		// The audit-logging webhook targets the Enterprise-only /audit endpoint, so it must not
+		// be registered on Calico OSS.
+		vwc, err := rtest.GetResourceOfType[*admissionregistrationv1.ValidatingWebhookConfiguration](resources, "api.projectcalico.org", "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(vwc.Webhooks).To(ConsistOf(
+			HaveField("Name", "tiered-rbac.api.projectcalico.org"),
+			HaveField("Name", "cluster-info.api.projectcalico.org"),
+		))
 	})
 
 	It("should render all resources for Enterprise with the correct image", func() {
@@ -157,6 +166,11 @@ var _ = Describe("Webhooks rendering tests", func() {
 			admissionregistrationv1.Delete,
 		))
 		Expect(mwc.Webhooks[0].Rules[0].Rule.Resources).To(Equal([]string{"uisettings"}))
+
+		// The audit-logging webhook is Enterprise-only.
+		vwc, err := rtest.GetResourceOfType[*admissionregistrationv1.ValidatingWebhookConfiguration](resources, "api.projectcalico.org", "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(vwc.Webhooks).To(ContainElement(HaveField("Name", "audit-logging.api.projectcalico.org")))
 
 		// Verify the ClusterRole includes the enterprise-only rules.
 		cr := rtest.GetResource(resources, webhooks.WebhooksName, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)


### PR DESCRIPTION
## Description

On Calico OSS the operator registers an `audit-logging` validating webhook that points at `/audit`, but that endpoint only exists in Calico Enterprise. The result is a steady stream of "failed calling webhook" / 404 errors in the Kubernetes API server log, as reported in projectcalico/calico#13244. This gates the audit webhook on the Enterprise variant, so it's only registered where the handler actually exists. The `tiered-rbac` and `cluster-info` webhooks (which do exist in OSS) are unchanged.

Bug fix, affects the calico-webhooks component. Covered by unit tests in `pkg/render/webhooks` for both the OSS and Enterprise variants.

Related: projectcalico/calico#13244

## Release Note

```release-note
Fixes repeated failed-webhook errors in the Kubernetes API server log on Calico (non-Enterprise) clusters, caused by registering an audit admission webhook whose endpoint only exists in Calico Enterprise.
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`
