### PR TITLE
[release-v1.42] Compare PVC storage quantities semantically in nodeSetName

### DIFF
--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -16,7 +16,6 @@ package render
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 
 	cmnv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/common/v1"
@@ -27,6 +26,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -806,7 +806,7 @@ func nodeSetName(pvcTemplate corev1.PersistentVolumeClaim, currentES *esv1.Elast
 		// We assume that the VolumeClaimTemplate is the same across all NodeSets (this is how we configure it).
 		currentPVCTemplate := currentES.Spec.NodeSets[0].VolumeClaimTemplates[0]
 		storageClassNamesMatch := *pvcTemplate.Spec.StorageClassName == *currentPVCTemplate.Spec.StorageClassName
-		resourceRequirementsMatch := reflect.DeepEqual(currentPVCTemplate.Spec.Resources, pvcTemplate.Spec.Resources)
+		resourceRequirementsMatch := apiequality.Semantic.DeepEqual(currentPVCTemplate.Spec.Resources, pvcTemplate.Spec.Resources)
 		if !storageClassNamesMatch || !resourceRequirementsMatch {
 			nameMustBeGenerated = true
 		}

--- a/pkg/render/logstorage_test.go
+++ b/pkg/render/logstorage_test.go
@@ -558,6 +558,66 @@ var _ = Describe("Elasticsearch rendering tests", func() {
 				newNodeName := rtest.GetResource(updatedResources, "tigera-secure", "tigera-elasticsearch", "elasticsearch.k8s.elastic.co", "v1", "Elasticsearch").(*esv1.Elasticsearch).Spec.NodeSets[0].Name
 				Expect(newNodeName).NotTo(Equal(oldNodeSetName))
 			})
+
+			// A non-canonical Quantity (e.g. "1024Gi") set in the resource requirements in the LogStorage CR
+			// is parsed by the operator and written into the Elasticsearch CR in its canonical form (e.g.
+			// "1Ti"). This is because when a Quantity is parsed, the requested string representation is
+			// ignored if it is non-canonical, leaving the default encoding logic of the Quantity to decide on
+			// the string representation. We must ensure that if the user specifies a non-canonical Quantity in
+			// the LogStorage, we do not view it as unequal to the canonical quantity we write to the
+			// Elasticsearch CR. Otherwise, we would wrongly conclude that the storage configuration changed
+			// and rename the NodeSet, which causes ECK to recreate the StatefulSet and its PVCs.
+			It("should retain the NodeSet name when the current storage quantity is equal but formatted differently", func() {
+				cfg.LogStorage = &operatorv1.LogStorage{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "tigera-secure",
+					},
+					Spec: operatorv1.LogStorageSpec{
+						Nodes: &operatorv1.Nodes{
+							Count: 1,
+							ResourceRequirements: &corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									"storage": resource.MustParse("1024Gi"),
+								},
+							},
+						},
+						StorageClassName: "tigera-elasticsearch",
+					},
+				}
+				cfg.Elasticsearch = &esv1.Elasticsearch{
+					Spec: esv1.ElasticsearchSpec{
+						NodeSets: []esv1.NodeSet{
+							{
+								Name: "t5kdhpw24vq7",
+								VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+									{
+										Spec: corev1.PersistentVolumeClaimSpec{
+											StorageClassName: ptr.ToPtr("tigera-elasticsearch"),
+											Resources: corev1.VolumeResourceRequirements{
+												Requests: corev1.ResourceList{
+													"storage": resource.MustParse("1Ti"),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+
+				component := render.LogStorage(cfg)
+				createResources, _ := component.Objects()
+				es := rtest.GetResource(createResources, "tigera-secure", "tigera-elasticsearch", "elasticsearch.k8s.elastic.co", "v1", "Elasticsearch").(*esv1.Elasticsearch)
+				Expect(es.Spec.NodeSets[0].Name).To(Equal("t5kdhpw24vq7"))
+
+				// A genuine storage change must still force a rename.
+				cfg.Elasticsearch.Spec.NodeSets[0].VolumeClaimTemplates[0].Spec.Resources.Requests["storage"] = resource.MustParse("2Ti")
+				component = render.LogStorage(cfg)
+				createResources, _ = component.Objects()
+				es = rtest.GetResource(createResources, "tigera-secure", "tigera-elasticsearch", "elasticsearch.k8s.elastic.co", "v1", "Elasticsearch").(*esv1.Elasticsearch)
+				Expect(es.Spec.NodeSets[0].Name).NotTo(Equal("t5kdhpw24vq7"))
+			})
 		})
 
 		It("should render DataNodeSelectors defined in the LogStorage CR", func() {


### PR DESCRIPTION
## Description

Cherry-pick of #5073 to `release-v1.42` (Calico Enterprise 3.23.x).

### Issue
A non-canonical storage Quantity in the LogStorage CR (e.g. `1024Gi`) is written into the Elasticsearch CR in its canonical form (`1Ti`). `nodeSetName()` compares the rendered PVC template against the live Elasticsearch CR with `reflect.DeepEqual`, which inspects the Quantity's unexported cached-string field. The two numerically-equal values therefore compare as different on every reconcile, so the operator generates a new random NodeSet name each pass. ECK treats a renamed NodeSet as new topology and recreates the StatefulSet and its PVCs — an unbounded reconcile loop that repeatedly provisions new volumes and prevents Elasticsearch from ever becoming operational.

The bug was introduced by #4378 (current-ES-aware NodeSet naming), which first shipped in operator v1.41 / CE 3.23.0, so it is present on this branch.

### Fix
Compare the PVC resource requirements with `apiequality.Semantic.DeepEqual`, which compares Quantities by numeric value (`Cmp`) and ignores their string representation. A genuine storage change still forces a rename.

### Cherry-pick note
The reproduction test on this branch uses `pkg/ptr.ToPtr(...)` instead of master's `k8s.io/utils/ptr.To(...)`, because `release-v1.42` imports the operator's internal `pkg/ptr` package in `logstorage_test.go`. The production change in `logstorage.go` is identical to #5073.

> [!NOTE]
> Backport of #5073 — merge only after #5073 lands on `master`.

## Release Note

```release-note
Fixed an issue where a non-canonical storage quantity in the LogStorage CR (e.g. 1024Gi) caused the Elasticsearch NodeSet to be renamed on every reconcile, repeatedly recreating the Elasticsearch StatefulSet and its PVCs.
```

## For PR reviewers

- [ ] Milestone set according to targeted release (CE 3.23.x).
- [ ] Labels: `kind/bug`, `enterprise`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
