### PR TITLE
Disable client caching for Pods

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -323,6 +323,11 @@ If a value other than 'all' is specified, the first CRD with a prefix of the spe
 			Cache: &client.CacheOptions{
 				DisableFor: []client.Object{
 					&v3.LicenseKey{},
+					// Pods are only listed by label/namespace selector from a handful of
+					// controllers. Caching them starts a shared informer that holds every pod
+					// in the cluster in memory (~36 MiB per 1000 pods), so read them uncached
+					// from the apiserver instead.
+					&corev1.Pod{},
 				},
 			},
 		},


### PR DESCRIPTION
The operator's controller-runtime client caches every object type it reads, so the first cached pod read starts a shared informer that lists and watches every pod in the cluster and holds them all in memory. Nothing needs a full in-memory pod cache - the handful of controllers that read pods (status diagnosis, dex/guardian proxy resolution, finalizer cleanup, CSR validation) all query by label and namespace, and a couple do single Gets by name, and all run conditionally in specific situations and aren't part of steady-state. 

This adds Pod to the client's `DisableFor` list so those reads go straight to the apiserver. The label/namespace selectors that were previously applied client-side over the cached store now become server-side filters, so responses are smaller too.

Measured with a throwaway envtest harness (synthetic pods, heap after 2x GC):

| pods | cached | uncached | saved |
| --- | --- | --- | --- |
| 1,000 | 39.9 MiB | 3.7 MiB | 36.2 MiB |
| 5,000 | 184.2 MiB | 3.8 MiB | 180.4 MiB |
| 10,000 | 364.0 MiB | 3.7 MiB | 360.2 MiB |

The uncached footprint stays flat regardless of cluster size.

Depends on #4987, which removes the pod `spec.nodeName` field index. That index starts the shared pod informer on its own, so this change only fully takes effect once #4987 lands - merge this after #4987. This PR doesn't include #4987's commits; I'll rebase once it merges.

```release-note
Reduces Tigera operator memory usage in large clusters by no longer caching all Pods in memory.
```
