### PR TITLE
Strip managedFields from cached objects

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -64,6 +64,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/tools/clientcmd"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -331,6 +332,10 @@ If a value other than 'all' is specified, the first CRD with a prefix of the spe
 				},
 			},
 		},
+
+		// Cached objects are only read by the operator's own controllers, which
+		// never consult managedFields; stripping them substantially shrinks the cache.
+		Cache: cache.Options{DefaultTransform: cache.TransformStripManagedFields()},
 
 		// Explicitly set the MapperProvider to the NewDynamicRESTMapper, as we had previously had issues with the default
 		// not being this mapper (which has since been rectified). It was a tough issue to figure out when the default


### PR DESCRIPTION
## Description

Performance enhancement (memory) — no functional change.

Sets `DefaultTransform: cache.TransformStripManagedFields()` on the manager's informer cache in `cmd/main.go`, dropping `metadata.managedFields` from every object at informer ingest time.

The operator's controllers never consult managedFields: there are no readers of `ManagedFields` anywhere in the codebase, and the operator does no server-side apply (no `FieldManager`/`ApplyPatchType` usage), which is the only write pattern that consumes field-ownership data at runtime. The change is read-side only — an `Update` that carries empty managedFields leaves the server-side tracking untouched, so nothing changes in etcd or `kubectl` output; only the operator's in-memory copies shrink.

This is the documented intended use of the API: the controller-runtime godoc for [`TransformStripManagedFields`](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/cache#TransformStripManagedFields) notes that "setting this as `DefaultTransform` on the cache can lead to a significant reduction in memory usage", and [`Options.DefaultTransform`](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/cache#Options) calls it out as the typical use case.

**Measured impact** — envtest micro-benchmark (kube-apiserver 1.34.1, controller-runtime v0.24.1; same method as #5082): a cluster-wide informer cache over N namespaces × (2 Secrets + 1 ConfigMap + 1 Service, 2 KiB payloads, two field managers per object), heap read after 2× GC, runs identical except for `DefaultTransform`:

| namespaces | cached objects | with managedFields | stripped | saved |
|---|---|---|---|---|
| 1,000 | 4,000 | 22.9 MiB | 20.0 MiB | 2.9 MiB (13%) |
| 5,000 | 20,000 | 87.5 MiB | 73.8 MiB | 13.7 MiB (16%) |
| 10,000 | 40,000 | 169.5 MiB | 139.7 MiB | 29.8 MiB (18%) |

Savings are a stable ~750 B HeapInuse (~505 B live heap) per cached object and scale linearly with cache size. Serialized, managedFields accounted for 19.5% of Secret bytes, 14.3% of ConfigMap, and 52.2% of Service in this workload. The numbers are conservative: benchmark objects carry two field managers, while objects touched by `kubectl apply` plus controllers typically carry more.

Testing:
- `make ut` — all 82 suites pass with the transform active.
- Envtest benchmark above (throwaway harness, kept out of the tree per the #5082 convention).

Affected components: the shared manager cache — i.e. every controller's cached reads (Calico and Enterprise).

Related: #5082 (informer cache memory work whose measurement method this replicates).

## Release Note

```release-note
Reduced operator memory usage by stripping managedFields from cached objects.
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
