### PR TITLE
Apply calico-node before Typha during upgrades to prevent cluster-wide NotReady

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1503,7 +1503,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		NonClusterHost:         nonclusterhost,
 		FelixHealthPort:        *felixConfiguration.Spec.HealthPort,
 	}
-	components = append(components, render.Typha(&typhaCfg))
+	typhaComponent := render.Typha(&typhaCfg)
 
 	// See the section 'Use of Finalizers for graceful termination' at the top of this file for terminating details.
 	canRemoveCNI := false
@@ -1613,6 +1613,8 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		}
 	}
 
+	components = append(components, typhaComponent)
+
 	// Build a configuration for rendering calico/node.
 	nodeCfg := render.NodeConfiguration{
 		GoldmaneRunning:               goldmaneRunning,
@@ -1671,7 +1673,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		warnOnce.Reset()
 	}
 
-	components = append(components, render.Node(&nodeCfg))
+	nodeComponent := render.Node(&nodeCfg)
 
 	csiCfg := render.CSIConfiguration{
 		Installation: &instance.Spec,
@@ -1771,6 +1773,42 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		r.status.SetDegraded(operatorv1.ResourceValidationError, "Error validating ImageSet", err, reqLogger)
 		return reconcile.Result{}, err
 	}
+
+	// Apply calico-node before the remaining components so that its rollout
+	// status can be checked before Typha is applied. Per the Calico version
+	// skew policy, Felix may be at most one minor version ahead of Typha, but
+	// not behind it. Updating Typha while older calico-node pods are still
+	// running would leave those pods unable to sync, marking them NotReady
+	// and allowing the DaemonSet controller to exceed the configured surge
+	// limits when replacing them.
+	if err = imageset.ResolveImages(imageSet, nodeComponent); err != nil {
+		r.status.SetDegraded(operatorv1.ResourceValidationError, "Error resolving ImageSet for calico-node", err, reqLogger)
+		return reconcile.Result{}, err
+	}
+	if err := handler.CreateOrUpdateOrDelete(ctx, nodeComponent, nil); err != nil {
+		r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error creating / updating calico-node", err, reqLogger)
+		return reconcile.Result{}, err
+	}
+
+	// Check whether the calico-node rollout is complete; Typha is only
+	// applied once it is. Read the DaemonSet directly from the API server
+	// rather than the informer cache: immediately after the update above,
+	// the cache may still hold the pre-update object whose status reports
+	// fully rolled out, which would open the gate before the rollout has
+	// started.
+	nodeRolledOut := true
+	nodeDS, err := r.clientset.AppsV1().DaemonSets(common.CalicoNamespace).Get(ctx, common.NodeDaemonSetName, metav1.GetOptions{})
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			r.status.SetDegraded(operatorv1.ResourceReadError, "Unable to read calico-node DaemonSet", err, reqLogger)
+			return reconcile.Result{}, err
+		}
+	} else {
+		nodeRolledOut = nodeDS.Status.ObservedGeneration >= nodeDS.Generation &&
+			nodeDS.Status.UpdatedNumberScheduled == nodeDS.Status.DesiredNumberScheduled &&
+			nodeDS.Status.NumberReady == nodeDS.Status.DesiredNumberScheduled
+	}
+	typhaCfg.NodeRolledOut = nodeRolledOut
 
 	if err = imageset.ResolveImages(imageSet, components...); err != nil {
 		r.status.SetDegraded(operatorv1.ResourceValidationError, "Error resolving ImageSet for components", err, reqLogger)

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -25,6 +25,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/stringsutil"
 	"github.com/sirupsen/logrus"
@@ -1492,6 +1493,73 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		}
 	}
 
+	imageSet, err := imageset.GetImageSet(ctx, r.client, instance.Spec.Variant)
+	if err != nil {
+		r.status.SetDegraded(operatorv1.ResourceReadError, "Error getting ImageSet", err, reqLogger)
+		return reconcile.Result{}, err
+	}
+
+	if imageSet == nil {
+		// There is no imageSet for the configured variant, but check to see if there are any
+		// ImageSets with a different variant so we can give the user some kind of indication
+		// to why an existing ImageSet is being ignored.
+		nvis, err := imageset.DoesNonVariantImageSetExist(ctx, r.client, instance.Spec.Variant)
+		if err != nil {
+			r.status.SetDegraded(operatorv1.ResourceReadError, "Error checking for non-variant ImageSet", err, reqLogger)
+			return reconcile.Result{}, err
+		} else {
+			if nvis {
+				reqLogger.Info("An ImageSet exists for a different variant")
+			}
+		}
+	}
+
+	if err = imageset.ValidateImageSet(imageSet); err != nil {
+		r.status.SetDegraded(operatorv1.ResourceValidationError, "Error validating ImageSet", err, reqLogger)
+		return reconcile.Result{}, err
+	}
+
+	// Determine whether the Typha Deployment update must be deferred until the
+	// calico-node DaemonSet finishes rolling out. Per the Calico version skew
+	// policy, Felix may be newer than Typha, but not older: updating Typha
+	// while older calico-node pods are still running leaves those pods unable
+	// to sync, marking them NotReady, at which point the DaemonSet controller
+	// no longer honors the configured surge limits and replaces pods
+	// cluster-wide.
+	deferTyphaUpdate := false
+	desiredNodeImage, err := render.NodeImage(&instance.Spec, imageSet)
+	if err != nil {
+		r.status.SetDegraded(operatorv1.ResourceValidationError, "Error resolving calico-node image", err, reqLogger)
+		return reconcile.Result{}, err
+	}
+	nodeDS := &appsv1.DaemonSet{}
+	if err := r.client.Get(ctx, types.NamespacedName{Name: common.NodeDaemonSetName, Namespace: common.CalicoNamespace}, nodeDS); err != nil {
+		if !apierrors.IsNotFound(err) {
+			r.status.SetDegraded(operatorv1.ResourceReadError, "Unable to read calico-node DaemonSet", err, reqLogger)
+			return reconcile.Result{}, err
+		}
+		// DaemonSet doesn't exist (fresh install) - nothing to defer for.
+	} else {
+		deferTyphaUpdate = deferTyphaDeploymentUpdate(nodeDS, desiredNodeImage)
+	}
+	if deferTyphaUpdate {
+		// Only defer when a Typha Deployment already exists; if it is missing
+		// it must be created regardless, since calico-node depends on it.
+		typhaDeployment := &appsv1.Deployment{}
+		if err := r.client.Get(ctx, types.NamespacedName{Name: common.TyphaDeploymentName, Namespace: common.CalicoNamespace}, typhaDeployment); err != nil {
+			if !apierrors.IsNotFound(err) {
+				r.status.SetDegraded(operatorv1.ResourceReadError, "Unable to read Typha Deployment", err, reqLogger)
+				return reconcile.Result{}, err
+			}
+			deferTyphaUpdate = false
+		}
+	}
+	if deferTyphaUpdate {
+		reqLogger.Info("Deferring Typha Deployment update until the calico-node DaemonSet rollout completes",
+			"updatedNumberScheduled", nodeDS.Status.UpdatedNumberScheduled,
+			"desiredNumberScheduled", nodeDS.Status.DesiredNumberScheduled)
+	}
+
 	// Build a configuration for rendering calico/typha.
 	typhaCfg := render.TyphaConfiguration{
 		K8sServiceEp:           k8sapi.Endpoint,
@@ -1502,8 +1570,9 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		ClusterDomain:          r.clusterDomain,
 		NonClusterHost:         nonclusterhost,
 		FelixHealthPort:        *felixConfiguration.Spec.HealthPort,
+		DeferDeploymentUpdate:  deferTyphaUpdate,
 	}
-	typhaComponent := render.Typha(&typhaCfg)
+	components = append(components, render.Typha(&typhaCfg))
 
 	// See the section 'Use of Finalizers for graceful termination' at the top of this file for terminating details.
 	canRemoveCNI := false
@@ -1613,8 +1682,6 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		}
 	}
 
-	components = append(components, typhaComponent)
-
 	// Build a configuration for rendering calico/node.
 	nodeCfg := render.NodeConfiguration{
 		GoldmaneRunning:               goldmaneRunning,
@@ -1673,7 +1740,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		warnOnce.Reset()
 	}
 
-	nodeComponent := render.Node(&nodeCfg)
+	components = append(components, render.Node(&nodeCfg))
 
 	csiCfg := render.CSIConfiguration{
 		Installation: &instance.Spec,
@@ -1747,68 +1814,6 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 			kubecontrollers.NewCalicoKubeControllersPolicy(&kubeControllersCfg, calicoSystemDefaultDenyForCalicoSystem()),
 		)
 	}
-
-	imageSet, err := imageset.GetImageSet(ctx, r.client, instance.Spec.Variant)
-	if err != nil {
-		r.status.SetDegraded(operatorv1.ResourceReadError, "Error getting ImageSet", err, reqLogger)
-		return reconcile.Result{}, err
-	}
-
-	if imageSet == nil {
-		// There is no imageSet for the configured variant, but check to see if there are any
-		// ImageSets with a different variant so we can give the user some kind of indication
-		// to why an existing ImageSet is being ignored.
-		nvis, err := imageset.DoesNonVariantImageSetExist(ctx, r.client, instance.Spec.Variant)
-		if err != nil {
-			r.status.SetDegraded(operatorv1.ResourceReadError, "Error checking for non-variant ImageSet", err, reqLogger)
-			return reconcile.Result{}, err
-		} else {
-			if nvis {
-				reqLogger.Info("An ImageSet exists for a different variant")
-			}
-		}
-	}
-
-	if err = imageset.ValidateImageSet(imageSet); err != nil {
-		r.status.SetDegraded(operatorv1.ResourceValidationError, "Error validating ImageSet", err, reqLogger)
-		return reconcile.Result{}, err
-	}
-
-	// Apply calico-node before the remaining components so that its rollout
-	// status can be checked before Typha is applied. Per the Calico version
-	// skew policy, Felix may be at most one minor version ahead of Typha, but
-	// not behind it. Updating Typha while older calico-node pods are still
-	// running would leave those pods unable to sync, marking them NotReady
-	// and allowing the DaemonSet controller to exceed the configured surge
-	// limits when replacing them.
-	if err = imageset.ResolveImages(imageSet, nodeComponent); err != nil {
-		r.status.SetDegraded(operatorv1.ResourceValidationError, "Error resolving ImageSet for calico-node", err, reqLogger)
-		return reconcile.Result{}, err
-	}
-	if err := handler.CreateOrUpdateOrDelete(ctx, nodeComponent, nil); err != nil {
-		r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error creating / updating calico-node", err, reqLogger)
-		return reconcile.Result{}, err
-	}
-
-	// Check whether the calico-node rollout is complete; Typha is only
-	// applied once it is. Read the DaemonSet directly from the API server
-	// rather than the informer cache: immediately after the update above,
-	// the cache may still hold the pre-update object whose status reports
-	// fully rolled out, which would open the gate before the rollout has
-	// started.
-	nodeRolledOut := true
-	nodeDS, err := r.clientset.AppsV1().DaemonSets(common.CalicoNamespace).Get(ctx, common.NodeDaemonSetName, metav1.GetOptions{})
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			r.status.SetDegraded(operatorv1.ResourceReadError, "Unable to read calico-node DaemonSet", err, reqLogger)
-			return reconcile.Result{}, err
-		}
-	} else {
-		nodeRolledOut = nodeDS.Status.ObservedGeneration >= nodeDS.Generation &&
-			nodeDS.Status.UpdatedNumberScheduled == nodeDS.Status.DesiredNumberScheduled &&
-			nodeDS.Status.NumberReady == nodeDS.Status.DesiredNumberScheduled
-	}
-	typhaCfg.NodeRolledOut = nodeRolledOut
 
 	if err = imageset.ResolveImages(imageSet, components...); err != nil {
 		r.status.SetDegraded(operatorv1.ResourceValidationError, "Error resolving ImageSet for components", err, reqLogger)
@@ -1940,7 +1945,50 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 	}
 
 	reqLogger.V(1).Info("Finished reconciling Installation")
+	if deferTyphaUpdate {
+		// Nothing reliably triggers a reconcile when the calico-node rollout
+		// completes: the DaemonSet watch filters out status-only updates. So
+		// requeue to re-evaluate the deferred Typha Deployment update.
+		return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
+	}
 	return reconcile.Result{}, nil
+}
+
+// deferTyphaDeploymentUpdate returns true when the Typha Deployment update
+// must wait for the calico-node DaemonSet. While calico-node is moving to a
+// different image, updating Typha would leave the not-yet-updated Felix
+// instances unable to sync: per the Calico version skew policy, Felix may be
+// newer than Typha, but not older.
+//
+// The DaemonSet is read from the informer cache before any updates are
+// applied this reconcile, so the state here cannot be confused by our own
+// in-flight write. The image comparison covers the reconcile that introduces
+// a new image (the cached status still describes the previous rollout at that
+// point); the status condition covers subsequent reconciles while the rollout
+// progresses.
+func deferTyphaDeploymentUpdate(nodeDS *appsv1.DaemonSet, desiredNodeImage string) bool {
+	var deployedImage string
+	for i := range nodeDS.Spec.Template.Spec.Containers {
+		if nodeDS.Spec.Template.Spec.Containers[i].Name == "calico-node" {
+			deployedImage = nodeDS.Spec.Template.Spec.Containers[i].Image
+			break
+		}
+	}
+	if deployedImage == "" {
+		return false
+	}
+
+	// A calico-node image change is about to be applied this reconcile.
+	if deployedImage != desiredNodeImage {
+		return true
+	}
+
+	// The DaemonSet spec already has the desired image; defer while its
+	// rollout is still in progress so that no older Felix remains when Typha
+	// updates. Pod readiness is deliberately not part of this condition: a
+	// permanently unready node must not block Typha updates indefinitely.
+	return nodeDS.Status.ObservedGeneration < nodeDS.Generation ||
+		nodeDS.Status.UpdatedNumberScheduled != nodeDS.Status.DesiredNumberScheduled
 }
 
 func readMTUFile() (int, error) {

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -25,7 +25,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/stringsutil"
 	"github.com/sirupsen/logrus"
@@ -1949,7 +1948,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		// Nothing reliably triggers a reconcile when the calico-node rollout
 		// completes: the DaemonSet watch filters out status-only updates. So
 		// requeue to re-evaluate the deferred Typha Deployment update.
-		return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
+		return reconcile.Result{RequeueAfter: utils.StandardRetry}, nil
 	}
 	return reconcile.Result{}, nil
 }

--- a/pkg/controller/installation/typha_defer_test.go
+++ b/pkg/controller/installation/typha_defer_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package installation
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func nodeDaemonSet(image string, generation, observedGeneration, updated, desired int64) *appsv1.DaemonSet {
+	ds := &appsv1.DaemonSet{}
+	ds.Generation = generation
+	ds.Spec.Template.Spec.Containers = []corev1.Container{{Name: "calico-node", Image: image}}
+	ds.Status.ObservedGeneration = observedGeneration
+	ds.Status.UpdatedNumberScheduled = int32(updated)
+	ds.Status.DesiredNumberScheduled = int32(desired)
+	return ds
+}
+
+var _ = Describe("deferTyphaDeploymentUpdate", func() {
+	const (
+		oldImage = "docker.io/calico/node:v3.31.3"
+		newImage = "docker.io/calico/node:v3.32.1"
+	)
+
+	It("does not defer in steady state (image matches, rollout complete)", func() {
+		ds := nodeDaemonSet(newImage, 5, 5, 30, 30)
+		Expect(deferTyphaDeploymentUpdate(ds, newImage)).To(BeFalse())
+	})
+
+	It("defers when a node image change is about to be applied", func() {
+		// The cached DaemonSet still has the old image with a completed
+		// rollout; this reconcile is about to apply the new image.
+		ds := nodeDaemonSet(oldImage, 5, 5, 30, 30)
+		Expect(deferTyphaDeploymentUpdate(ds, newImage)).To(BeTrue())
+	})
+
+	It("defers while the rollout has not been observed by the DaemonSet controller", func() {
+		ds := nodeDaemonSet(newImage, 6, 5, 30, 30)
+		Expect(deferTyphaDeploymentUpdate(ds, newImage)).To(BeTrue())
+	})
+
+	It("defers while pods are still being updated", func() {
+		ds := nodeDaemonSet(newImage, 6, 6, 12, 30)
+		Expect(deferTyphaDeploymentUpdate(ds, newImage)).To(BeTrue())
+	})
+
+	It("does not defer once all pods are updated, regardless of readiness", func() {
+		// Readiness is intentionally not part of the condition: what matters
+		// is that no old-version Felix remains, and a permanently unready
+		// node must not block Typha updates.
+		ds := nodeDaemonSet(newImage, 6, 6, 30, 30)
+		ds.Status.NumberReady = 3
+		Expect(deferTyphaDeploymentUpdate(ds, newImage)).To(BeFalse())
+	})
+
+	It("does not defer when the DaemonSet has no calico-node container", func() {
+		ds := nodeDaemonSet(newImage, 5, 5, 30, 30)
+		ds.Spec.Template.Spec.Containers = []corev1.Container{{Name: "other", Image: oldImage}}
+		Expect(deferTyphaDeploymentUpdate(ds, newImage)).To(BeFalse())
+	})
+})

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -172,6 +172,15 @@ type nodeComponent struct {
 	nodeImage       string
 }
 
+// NodeImage returns the image used by the calico-node container for the given
+// installation, resolving through the ImageSet when one is present.
+func NodeImage(installation *operatorv1.InstallationSpec, is *operatorv1.ImageSet) (string, error) {
+	if installation.Variant.IsEnterprise() {
+		return components.GetReference(components.ComponentTigeraNode, installation.Registry, installation.ImagePath, installation.ImagePrefix, is)
+	}
+	return components.GetReference(components.ComponentCalicoNode, installation.Registry, installation.ImagePath, installation.ImagePrefix, is)
+}
+
 func (c *nodeComponent) ResolveImages(is *operatorv1.ImageSet) error {
 	reg := c.cfg.Installation.Registry
 	path := c.cfg.Installation.ImagePath
@@ -192,12 +201,7 @@ func (c *nodeComponent) ResolveImages(is *operatorv1.ImageSet) error {
 			c.cniPluginsImage = appendIfErr(components.GetReference(components.ComponentCalicoCNIPlugins, reg, path, prefix, is))
 		}
 	}
-	switch {
-	case c.cfg.Installation.Variant.IsEnterprise():
-		c.nodeImage = appendIfErr(components.GetReference(components.ComponentTigeraNode, reg, path, prefix, is))
-	default:
-		c.nodeImage = appendIfErr(components.GetReference(components.ComponentCalicoNode, reg, path, prefix, is))
-	}
+	c.nodeImage = appendIfErr(NodeImage(c.cfg.Installation, is))
 
 	if len(errMsgs) != 0 {
 		return fmt.Errorf("%s", strings.Join(errMsgs, ","))

--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -85,6 +85,12 @@ type TyphaConfiguration struct {
 	// The health port that Felix is bound to. We configure Typha to bind to the port
 	// that is one less.
 	FelixHealthPort int
+
+	// NodeRolledOut indicates whether the calico-node DaemonSet rollout is
+	// complete. Typha is not updated until it is, so that calico-node rolls
+	// out first during upgrades: per the Calico version skew policy, Felix
+	// may be newer than Typha, but not older.
+	NodeRolledOut bool
 }
 
 // Typha creates the typha daemonset and other resources for the daemonset to operate normally.
@@ -165,7 +171,7 @@ func (c *typhaComponent) typhaPodDisruptionBudget() *policyv1.PodDisruptionBudge
 }
 
 func (c *typhaComponent) Ready() bool {
-	return true
+	return c.cfg.NodeRolledOut
 }
 
 // typhaServiceAccount creates the typha's service account.

--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -86,11 +86,14 @@ type TyphaConfiguration struct {
 	// that is one less.
 	FelixHealthPort int
 
-	// NodeRolledOut indicates whether the calico-node DaemonSet rollout is
-	// complete. Typha is not updated until it is, so that calico-node rolls
-	// out first during upgrades: per the Calico version skew policy, Felix
-	// may be newer than Typha, but not older.
-	NodeRolledOut bool
+	// DeferDeploymentUpdate indicates that the Typha Deployment should be left
+	// as-is for now: the calico-node DaemonSet is rolling out a newer version,
+	// and Typha must not be updated until no older Felix remains. Per the
+	// Calico version skew policy, Felix may be newer than Typha, but not
+	// older. Only the Deployment is deferred; all other Typha objects are
+	// still reconciled. The controller only sets this when a Typha Deployment
+	// already exists.
+	DeferDeploymentUpdate bool
 }
 
 // Typha creates the typha daemonset and other resources for the daemonset to operate normally.
@@ -133,7 +136,11 @@ func (c *typhaComponent) Objects() ([]client.Object, []client.Object) {
 	objs = append(objs, c.typhaServices()...)
 
 	// Add deployment last, as it may depend on the creation of previous objects in the list.
-	objs = append(objs, c.typhaDeployment()...)
+	// When the update is deferred, omit the Deployment so the existing one is
+	// left untouched; omitted objects are not deleted by the handler.
+	if !c.cfg.DeferDeploymentUpdate {
+		objs = append(objs, c.typhaDeployment()...)
+	}
 	if c.cfg.Installation.TyphaMetricsPort != nil {
 		objs = append(objs, c.typhaPrometheusService())
 	}
@@ -171,7 +178,7 @@ func (c *typhaComponent) typhaPodDisruptionBudget() *policyv1.PodDisruptionBudge
 }
 
 func (c *typhaComponent) Ready() bool {
-	return c.cfg.NodeRolledOut
+	return true
 }
 
 // typhaServiceAccount creates the typha's service account.


### PR DESCRIPTION
## Description

**Type of change:** bug fix

**Problem:** During upgrades, the operator applies the Typha Deployment and the calico-node DaemonSet in the same reconcile, so both roll simultaneously. Typha (typically 3 replicas) finishes its rollout in about a minute, while calico-node on a large cluster takes much longer. Felix is compatible with an older Typha, but an older Felix cannot sync with a newer Typha — so once all Typha replicas are on the new version, every still-old calico-node pod loses sync, fails its readiness probe after ~90s (3 × 30s), and goes NotReady. The DaemonSet controller does not count already-unavailable pods against `maxUnavailable`/`maxSurge`, so it then replaces pods across the whole cluster at once instead of honoring the configured rolling-update limits. On a ~200 node production cluster this presented as a cluster-wide wave of NotReady calico-node pods during a 3.31 → 3.32 upgrade.

**Fix:**
- Apply the calico-node component before the remaining components.
- After applying, read the calico-node DaemonSet directly from the API server rather than the cached client — immediately after the write, the informer cache can still hold the pre-update object whose status reports the previous rollout as complete, which would open the gate prematurely (this race was observed in testing: identical code passed or failed depending on whether the watch event beat the read).
- Gate the Typha component on the calico-node rollout being complete (`ObservedGeneration >= Generation`, all pods updated and ready) using the existing component `Ready()` mechanism.

With this ordering, new calico-node pods connect to old Typha (the compatible direction) while rolling under the configured limits, and Typha updates last, when every Felix is already on the new version. First installs are unaffected (no DaemonSet exists, so the gate is open), and in steady state the check passes immediately because the DaemonSet generation is unchanged.

**Testing:** Validated on a 30-node cluster upgrading Calico v3.31.3 → v3.32.1:
- With `nodeUpdateStrategy: {maxSurge: 4, maxUnavailable: 0}` (the affected user's configuration): calico-node Ready stayed 30/30 for the entire upgrade across every DaemonSet status transition; peak 34 concurrent pods (30 + exactly 4 surge), no limit bypass; node phase ~4 minutes; Typha updated only after all 30 nodes completed.
- With the default strategy (`maxUnavailable: 1`): Ready never dropped below 29/30 (the single pod being replaced), Typha gated for the full ~18 minute rollout and updated within seconds of the last node becoming ready.
- Without this change, the same upgrade dropped Ready to 11/30, with the DaemonSet controller replacing ~12 pods within 2 seconds.

**Affected components:** installation controller (core_controller.go), Typha render component.

## Release Note

```release-note
During upgrades, the operator now waits for the calico-node DaemonSet rollout to complete before updating Typha, preventing cluster-wide calico-node readiness disruption caused by older Felix being unable to sync with newer Typha.
```

## For PR author

- [x] Tests for change.
- [x] If changing pkg/apis/, run `make gen-files`
- [x] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.

