### PR TITLE
[v1.43] EV-6825: istio: Create RoleBindings so the waypoint controller can copy pull secrets

### DIFF
--- a/pkg/controller/gatewayapi/gatewayapi_controller.go
+++ b/pkg/controller/gatewayapi/gatewayapi_controller.go
@@ -670,40 +670,54 @@ func (r *ReconcileGatewayAPI) maintainFinalizer(ctx context.Context, gatewayAPI 
 // Gateways, so the GC removes them once the last Gateway is gone (and the GatewayAPI CR's deletion
 // doesn't strand them). Reserved namespaces are skipped; trust bundle on both variants, the rest on
 // Enterprise.
+// Each object is written once per owning Gateway, because the component handler takes a single
+// owner. MultipleOwnersLabel makes it merge that owner reference into the references already on the
+// object instead of replacing them, which is what keeps the namespace's other Gateways — and any
+// reference another feature added, such as the waypoint controller's Istio CR — in place.
 func (r *ReconcileGatewayAPI) reconcileGatewayNamespaceResources(ctx context.Context, bundle certificatemanagement.TrustedBundle, pullSecrets []*corev1.Secret, enterprise bool, gateways []gapi.Gateway, ownedClass map[string]bool) error {
-	ownersByNamespace := map[string][]metav1.OwnerReference{}
+	gatewaysByNamespace := map[string][]*gapi.Gateway{}
 	for i := range gateways {
 		gw := &gateways[i]
 		if !ownedClass[string(gw.Spec.GatewayClassName)] || gw.Namespace == common.CalicoNamespace || gw.Namespace == common.OperatorNamespace() {
 			continue
 		}
-		ownersByNamespace[gw.Namespace] = append(ownersByNamespace[gw.Namespace], metav1.OwnerReference{
-			APIVersion: "gateway.networking.k8s.io/v1",
-			Kind:       "Gateway",
-			Name:       gw.Name,
-			UID:        gw.UID,
-		})
+		gatewaysByNamespace[gw.Namespace] = append(gatewaysByNamespace[gw.Namespace], gw)
 	}
-	for namespace, owners := range ownersByNamespace {
-		var objs []client.Object
-		if bundle != nil {
-			objs = append(objs, bundle.ConfigMap(namespace))
-		}
-		if enterprise {
-			objs = append(objs,
-				gatewayapi.GatewayNamespaceServiceAccount(namespace),
-				gatewayapi.GatewayNamespaceRoleBinding(namespace),
-				render.CreateOperatorSecretsRoleBinding(namespace),
-			)
-			objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(namespace, pullSecrets...)...)...)
-		}
-		for _, obj := range objs {
-			if err := r.upsertGatewayOwned(ctx, obj, owners); err != nil {
+	for namespace, gws := range gatewaysByNamespace {
+		for _, gw := range gws {
+			// Rendered per pass: the handler stamps its owner reference onto the objects it
+			// is given and strips the label before writing them.
+			objs := gatewayNamespaceObjects(namespace, bundle, pullSecrets, enterprise)
+			hdlr := r.newComponentHandler(log, r.client, r.scheme, gw)
+			if err := hdlr.CreateOrUpdateOrDelete(ctx, render.NewPassthrough(objs, nil), nil); err != nil {
 				return err
 			}
 		}
 	}
 	return nil
+}
+
+// gatewayNamespaceObjects returns the resources a namespace hosting our Gateways needs, each marked
+// for merged ownership.
+func gatewayNamespaceObjects(namespace string, bundle certificatemanagement.TrustedBundle, pullSecrets []*corev1.Secret, enterprise bool) []client.Object {
+	var objs []client.Object
+	if bundle != nil {
+		objs = append(objs, bundle.ConfigMap(namespace))
+	}
+	if enterprise {
+		objs = append(objs,
+			gatewayapi.GatewayNamespaceServiceAccount(namespace),
+			gatewayapi.GatewayNamespaceRoleBinding(namespace),
+			render.CreateOperatorSecretsRoleBinding(namespace),
+		)
+		objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(namespace, pullSecrets...)...)...)
+	}
+	for _, obj := range objs {
+		labels := common.MapExistsOrInitialize(obj.GetLabels())
+		labels[common.MultipleOwnersLabel] = "true"
+		obj.SetLabels(labels)
+	}
+	return objs
 }
 
 // legacyGatewayOrphans returns the resources in namespace owned by the tigera-gateway-class
@@ -749,28 +763,4 @@ func (r *ReconcileGatewayAPI) legacyGatewayOrphans(ctx context.Context, namespac
 		}
 	}
 	return orphans, nil
-}
-
-// upsertGatewayOwned creates or updates obj, refreshing its owner references (and ConfigMap/Secret
-// data) so the namespace's owner set stays current as its Gateways come and go.
-func (r *ReconcileGatewayAPI) upsertGatewayOwned(ctx context.Context, desired client.Object, owners []metav1.OwnerReference) error {
-	desired.SetOwnerReferences(owners)
-	existing := desired.DeepCopyObject().(client.Object)
-	switch err := r.client.Get(ctx, client.ObjectKeyFromObject(desired), existing); {
-	case errors.IsNotFound(err):
-		return r.client.Create(ctx, desired)
-	case err != nil:
-		return err
-	default:
-		existing.SetOwnerReferences(owners)
-		switch d := desired.(type) {
-		case *corev1.ConfigMap:
-			e := existing.(*corev1.ConfigMap)
-			e.Data, e.Annotations = d.Data, d.Annotations
-		case *corev1.Secret:
-			e := existing.(*corev1.Secret)
-			e.Data, e.Type = d.Data, d.Type
-		}
-		return r.client.Update(ctx, existing)
-	}
 }

--- a/pkg/controller/gatewayapi/gatewayapi_controller_test.go
+++ b/pkg/controller/gatewayapi/gatewayapi_controller_test.go
@@ -742,6 +742,9 @@ var _ = Describe("Gateway API controller tests", func() {
 	})
 
 	It("writes per-namespace Gateway resources owned by the namespace's Gateways (Enterprise)", func() {
+		// These go through the real component handler, which is what merges each Gateway's
+		// owner reference in rather than replacing what is already there.
+		r.newComponentHandler = utils.NewComponentHandler
 		bundle, err := certificatemanagement.CreateTrustedBundleWithSystemRootCertificates(nil)
 		Expect(err).NotTo(HaveOccurred())
 		pullSecrets := []*corev1.Secret{{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret", Namespace: common.OperatorNamespace()}}}
@@ -774,6 +777,78 @@ var _ = Describe("Gateway API controller tests", func() {
 		By("skipping namespaces whose Gateway is not ours, and reserved namespaces")
 		Expect(apierrors.IsNotFound(c.Get(ctx, client.ObjectKey{Namespace: "other-ns", Name: certificatemanagement.TrustedCertConfigMapName}, &corev1.ConfigMap{}))).To(BeTrue())
 		Expect(apierrors.IsNotFound(c.Get(ctx, client.ObjectKey{Namespace: common.CalicoNamespace, Name: "waf-http-filter"}, &corev1.ServiceAccount{}))).To(BeTrue())
+	})
+
+	It("keeps owner references another feature put on the shared RoleBinding and pull secret", func() {
+		// The waypoint controller renders the same tigera-operator-secrets RoleBinding and the
+		// same pull secret copies into the same namespaces, owned by the Istio CR. Dropping
+		// those references would have the objects garbage collected along with the last of our
+		// Gateways while a waypoint in that namespace still needed them.
+		r.newComponentHandler = utils.NewComponentHandler
+		istioRef := metav1.OwnerReference{APIVersion: "operator.tigera.io/v1", Kind: "Istio", Name: "default", UID: "istio-uid"}
+
+		By("seeding both objects with an Istio owner reference")
+		rb := render.CreateOperatorSecretsRoleBinding("app-ns")
+		rb.OwnerReferences = []metav1.OwnerReference{istioRef}
+		Expect(c.Create(ctx, rb)).NotTo(HaveOccurred())
+		Expect(c.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+			Namespace:       "app-ns",
+			Name:            "tigera-pull-secret",
+			OwnerReferences: []metav1.OwnerReference{istioRef},
+		}})).NotTo(HaveOccurred())
+
+		pullSecrets := []*corev1.Secret{{ObjectMeta: metav1.ObjectMeta{Name: "tigera-pull-secret", Namespace: common.OperatorNamespace()}}}
+		gateways := []gapi.Gateway{
+			{ObjectMeta: metav1.ObjectMeta{Namespace: "app-ns", Name: "gw1", UID: "u1"}, Spec: gapi.GatewaySpec{GatewayClassName: gatewayapi.GatewayClassName}},
+		}
+		Expect(r.reconcileGatewayNamespaceResources(ctx, nil, pullSecrets, true, gateways, map[string]bool{gatewayapi.GatewayClassName: true})).NotTo(HaveOccurred())
+
+		By("keeping the Istio reference and adding our Gateway alongside it")
+		ownerKinds := func(o client.Object) []string {
+			var k []string
+			for _, ref := range o.GetOwnerReferences() {
+				k = append(k, ref.Kind+"/"+ref.Name)
+			}
+			return k
+		}
+		updatedRB := &rbacv1.RoleBinding{}
+		Expect(c.Get(ctx, client.ObjectKey{Namespace: "app-ns", Name: "tigera-operator-secrets"}, updatedRB)).NotTo(HaveOccurred())
+		Expect(ownerKinds(updatedRB)).To(ConsistOf("Istio/default", "Gateway/gw1"))
+
+		updatedSecret := &corev1.Secret{}
+		Expect(c.Get(ctx, client.ObjectKey{Namespace: "app-ns", Name: "tigera-pull-secret"}, updatedSecret)).NotTo(HaveOccurred())
+		Expect(ownerKinds(updatedSecret)).To(ConsistOf("Istio/default", "Gateway/gw1"))
+
+		By("not leaving the multiple-owners label behind on the written objects")
+		Expect(updatedRB.Labels).NotTo(HaveKey(common.MultipleOwnersLabel))
+	})
+
+	It("retains the reference of a Gateway that has changed to a class we do not own", func() {
+		// References are merged, never recomputed, so one stays until the Gateway that owns it is
+		// deleted and garbage collection removes it. A Gateway that moved to a class we do not
+		// manage therefore keeps its reference and holds the object alive. That is the accepted
+		// trade for never dropping a reference some other controller wrote: recomputing our own
+		// references on every pass is what dropped the waypoint controller's Istio reference.
+		r.newComponentHandler = utils.NewComponentHandler
+		flippedRef := metav1.OwnerReference{APIVersion: "gateway.networking.k8s.io/v1", Kind: "Gateway", Name: "flipped", UID: "u-flipped"}
+
+		rb := render.CreateOperatorSecretsRoleBinding("app-ns")
+		rb.OwnerReferences = []metav1.OwnerReference{flippedRef}
+		Expect(c.Create(ctx, rb)).NotTo(HaveOccurred())
+
+		gateways := []gapi.Gateway{
+			{ObjectMeta: metav1.ObjectMeta{Namespace: "app-ns", Name: "gw1", UID: "u1"}, Spec: gapi.GatewaySpec{GatewayClassName: gatewayapi.GatewayClassName}},
+			{ObjectMeta: metav1.ObjectMeta{Namespace: "app-ns", Name: "flipped", UID: "u-flipped"}, Spec: gapi.GatewaySpec{GatewayClassName: "not-ours"}},
+		}
+		Expect(r.reconcileGatewayNamespaceResources(ctx, nil, nil, true, gateways, map[string]bool{gatewayapi.GatewayClassName: true})).NotTo(HaveOccurred())
+
+		updatedRB := &rbacv1.RoleBinding{}
+		Expect(c.Get(ctx, client.ObjectKey{Namespace: "app-ns", Name: "tigera-operator-secrets"}, updatedRB)).NotTo(HaveOccurred())
+		var owners []string
+		for _, ref := range updatedRB.OwnerReferences {
+			owners = append(owners, ref.Kind+"/"+ref.Name)
+		}
+		Expect(owners).To(ConsistOf("Gateway/flipped", "Gateway/gw1"))
 	})
 })
 

--- a/pkg/controller/istio/istio_controller.go
+++ b/pkg/controller/istio/istio_controller.go
@@ -92,12 +92,15 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 	}
 
 	// The waypoint controller reconciles the per-Gateway state the Istio
-	// feature needs beyond istiod's own rendering. It replicates the
-	// Installation pull secret into namespaces that contain istio-waypoint
-	// Gateways, so waypoint pods can pull the Istio proxy image from a private
-	// registry (the imagePullSecrets reference injected via istiod's global
-	// config is namespace-scoped and the secret must exist in the user
-	// namespace). It also deletes the per-class resource sets that istiod
+	// feature needs beyond istiod's own rendering. It creates a
+	// tigera-operator-secrets RoleBinding in namespaces that contain
+	// istio-waypoint Gateways — granting the operator permission to manage
+	// secrets there on clusters where its ClusterRole doesn't allow
+	// cluster-wide secret writes — and replicates the Installation pull
+	// secrets into those namespaces, so waypoint pods can pull the Istio proxy
+	// image from a private registry (the imagePullSecrets reference injected
+	// via istiod's global config is namespace-scoped and the secret must exist
+	// in the user namespace). It also deletes the per-class resource sets that istiod
 	// strands when a Gateway's spec.gatewayClassName changes: istiod only
 	// applies the set for the current class and never deletes the previous
 	// class's set, and owner-reference GC only fires when the Gateway itself

--- a/pkg/controller/istio/waypoint/waypoint_controller.go
+++ b/pkg/controller/istio/waypoint/waypoint_controller.go
@@ -45,15 +45,6 @@ const (
 	// IstioWaypointClassName is the GatewayClass name used by Istio waypoints.
 	IstioWaypointClassName = "istio-waypoint"
 
-	// WaypointPullSecretLabel identifies the pull secret copies and tigera-operator-secrets
-	// RoleBindings created by this controller. Cleanup follows the egress gateway pattern:
-	// the objects carry an owner reference to the Istio CR and are removed by Kubernetes
-	// garbage collection when the CR is deleted. Objects stranded while the CR still exists
-	// (a namespace losing its last waypoint Gateway, or a pull secret being renamed in
-	// Installation) are not yet cleaned up — that gap is shared with the egress gateway and
-	// will be addressed for both together; the label marks the objects for that work.
-	WaypointPullSecretLabel = "operator.tigera.io/istio-waypoint-pull-secret"
-
 	// legacyGatewayNamespace is the pre-namespaced gateway-API install namespace, kept in
 	// sync with the const of the same name in the gatewayapi controller.
 	legacyGatewayNamespace = "tigera-gateway"
@@ -269,7 +260,6 @@ func (r *ReconcileWaypoint) pullSecretResources(ctx context.Context, reqLogger l
 	for ns := range targetNamespaces {
 		rb := render.CreateOperatorSecretsRoleBinding(ns)
 		rb.Labels = common.MapExistsOrInitialize(rb.Labels)
-		rb.Labels[WaypointPullSecretLabel] = "true"
 		rb.Labels[common.MultipleOwnersLabel] = "true"
 		objs = append(objs, rb)
 
@@ -278,7 +268,6 @@ func (r *ReconcileWaypoint) pullSecretResources(ctx context.Context, reqLogger l
 			if s.Labels == nil {
 				s.Labels = map[string]string{}
 			}
-			s.Labels[WaypointPullSecretLabel] = "true"
 			s.Labels[common.MultipleOwnersLabel] = "true"
 			objs = append(objs, s)
 		}

--- a/pkg/controller/istio/waypoint/waypoint_controller.go
+++ b/pkg/controller/istio/waypoint/waypoint_controller.go
@@ -19,11 +19,9 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -47,22 +45,42 @@ const (
 	// IstioWaypointClassName is the GatewayClass name used by Istio waypoints.
 	IstioWaypointClassName = "istio-waypoint"
 
-	// WaypointPullSecretLabel labels secrets copied by this controller. We use a label rather
-	// than owner references because the controller needs to efficiently find and clean up its
-	// managed secrets during reconciliation — for example, when pull secrets are removed from
-	// Installation or when the Istio CR is deleted. A label selector provides a simple,
-	// cross-namespace query that covers all cleanup scenarios, whereas owner references would
-	// only automate Gateway-deletion cleanup via Kubernetes garbage collection.
+	// WaypointPullSecretLabel identifies the pull secret copies and tigera-operator-secrets
+	// RoleBindings created by this controller. Cleanup follows the egress gateway pattern:
+	// the objects carry an owner reference to the Istio CR and are removed by Kubernetes
+	// garbage collection when the CR is deleted. Objects stranded while the CR still exists
+	// (a namespace losing its last waypoint Gateway, or a pull secret being renamed in
+	// Installation) are not yet cleaned up — that gap is shared with the egress gateway and
+	// will be addressed for both together; the label marks the objects for that work.
 	WaypointPullSecretLabel = "operator.tigera.io/istio-waypoint-pull-secret"
+
+	// legacyGatewayNamespace is the pre-namespaced gateway-API install namespace, kept in
+	// sync with the const of the same name in the gatewayapi controller.
+	legacyGatewayNamespace = "tigera-gateway"
 )
+
+// reservedNamespace returns true for namespaces whose pull secrets and
+// tigera-operator-secrets RoleBinding this controller must not manage: the operator
+// namespace holds the source secrets, calico-system's are managed by the installation
+// controller, and tigera-gateway's are actively torn down by the gateway-API controller's
+// legacy cleanup, which would fight copies created here.
+func reservedNamespace(ns string) bool {
+	switch ns {
+	case common.OperatorNamespace(), common.CalicoNamespace, legacyGatewayNamespace:
+		return true
+	}
+	return false
+}
 
 var log = logf.Log.WithName("controller_istio_waypoint")
 
 // Add creates the waypoint controller and adds it to the Manager. The
 // controller reconciles the per-Gateway state the Istio feature needs beyond
 // istiod's own rendering: it copies Installation pull secrets into namespaces
-// that contain istio-waypoint Gateways, and deletes the resource sets istiod
-// strands when a Gateway's spec.gatewayClassName changes.
+// that contain istio-waypoint Gateways (together with a tigera-operator-secrets
+// RoleBinding that grants the operator permission to manage secrets there), and
+// deletes the resource sets istiod strands when a Gateway's
+// spec.gatewayClassName changes.
 func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 	if !opts.EnterpriseCRDExists {
 		return nil
@@ -108,8 +126,11 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 			// pull-secret placement.
 			return string(curr.Spec.GatewayClassName) == IstioWaypointClassName
 		},
-		// Deletes only affect pull secrets: the resource sets istiod rendered
-		// are removed by Kubernetes garbage collection via owner references.
+		// The resource sets istiod rendered are removed by Kubernetes garbage
+		// collection via owner references. A waypoint Gateway delete currently
+		// triggers no cleanup of that namespace's pull secret copies (they are
+		// only GC'd with the Istio CR, matching the egress gateway pattern);
+		// the watch is kept so the planned cleanup work has the events it needs.
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			gw, ok := e.Object.(*gapi.Gateway)
 			return ok && string(gw.Spec.GatewayClassName) == IstioWaypointClassName
@@ -131,6 +152,13 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 		return fmt.Errorf("istio-waypoint-controller failed to watch Installation resource: %w", err)
 	}
 
+	// Watch secrets in the operator namespace: the Installation pull secrets live there, and
+	// changes to their contents must propagate to the copies in waypoint namespaces. The pull
+	// secret names are user-defined in Installation, so watch the whole namespace.
+	if err = utils.AddSecretsWatch(c, "", common.OperatorNamespace()); err != nil {
+		return fmt.Errorf("istio-waypoint-controller failed to watch secrets in the operator namespace: %w", err)
+	}
+
 	// Periodic reconcile as a backstop.
 	if err = utils.AddPeriodicReconcile(c, utils.PeriodicReconcileTime, &handler.EnqueueRequestForObject{}); err != nil {
 		return fmt.Errorf("istio-waypoint-controller failed to create periodic reconcile watch: %w", err)
@@ -140,8 +168,9 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 }
 
 // ReconcileWaypoint reconciles the per-Gateway state the Istio feature needs
-// beyond istiod's own rendering: it copies pull secrets to namespaces that
-// contain istio-waypoint Gateways so waypoint pods can pull images from
+// beyond istiod's own rendering: it copies pull secrets (and the
+// tigera-operator-secrets RoleBinding needed to manage them) to namespaces
+// that contain istio-waypoint Gateways so waypoint pods can pull images from
 // private registries, and deletes istiod-managed gateway resources that were
 // rendered for a GatewayClass their owning Gateway no longer uses.
 type ReconcileWaypoint struct {
@@ -156,31 +185,34 @@ func (r *ReconcileWaypoint) Reconcile(ctx context.Context, request reconcile.Req
 	reqLogger.V(1).Info("Reconciling waypoint gateway resources")
 
 	// Get the Istio CR - if not found or being deleted, the feature is
-	// inactive: copied pull secrets are stale, and istiod's gateway resources
-	// belong to a mesh the operator does not manage and must not be touched.
+	// inactive: copied pull secrets and RoleBindings are garbage collected via
+	// their owner reference to the CR, and istiod's gateway resources belong to
+	// a mesh the operator does not manage and must not be touched.
 	instance := &operatorv1.Istio{}
 	err := r.Get(ctx, utils.DefaultInstanceKey, instance)
 	if err != nil && !errors.IsNotFound(err) {
 		return reconcile.Result{}, err
 	}
 	istioActive := err == nil && instance.DeletionTimestamp.IsZero()
-	gatewaysVisible := istioActive && r.gatewayWatchReady.IsReady()
+	if !istioActive || !r.gatewayWatchReady.IsReady() {
+		return reconcile.Result{}, nil
+	}
 
-	toCreate, toDelete, err := r.pullSecretChanges(ctx, gatewaysVisible, reqLogger)
+	toCreate, err := r.pullSecretResources(ctx, reqLogger)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	if gatewaysVisible {
-		stale, err := r.staleGatewaySets(ctx, reqLogger)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-		toDelete = append(toDelete, stale...)
+	toDelete, err := r.staleGatewaySets(ctx, reqLogger)
+	if err != nil {
+		return reconcile.Result{}, err
 	}
 
-	// Use a single passthrough component to handle both creation and deletion.
-	hdlr := utils.NewComponentHandler(log, r, r.scheme, nil)
+	// Pass the Istio CR as the owner: created objects carry an owner reference to it
+	// (merged with any other owners, such as an egress gateway CR sharing the namespace,
+	// via the multiple-owners label) and are garbage collected when the CR is deleted —
+	// the same pattern the egress gateway uses with its CRs.
+	hdlr := utils.NewComponentHandler(log, r, r.scheme, instance)
 	component := render.NewPassthrough(toCreate, toDelete)
 	if err := hdlr.CreateOrUpdateOrDelete(ctx, component, nil); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to reconcile waypoint gateway resources: %w", err)
@@ -189,74 +221,68 @@ func (r *ReconcileWaypoint) Reconcile(ctx context.Context, request reconcile.Req
 	return reconcile.Result{}, nil
 }
 
-// pullSecretChanges determines which copied pull secrets need to exist
-// (toCreate) based on the namespaces that contain istio-waypoint Gateways, and
-// which existing copies are stale (toDelete). When active is false no copies
-// are desired, so every existing copy is returned as stale.
-func (r *ReconcileWaypoint) pullSecretChanges(ctx context.Context, active bool, reqLogger logr.Logger) (toCreate, toDelete []client.Object, err error) {
-	// Build the desired set of secrets if Istio is active and the Gateway watch is established.
-	if active {
-		_, installationSpec, err := utils.GetInstallationSpec(ctx, r)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				reqLogger.V(1).Info("Installation not found")
-				return nil, nil, nil
+// pullSecretResources returns the objects each waypoint namespace needs so its pods can
+// pull images from private registries: a tigera-operator-secrets RoleBinding granting the
+// operator permission to write secrets in the namespace, followed by copies of the
+// Installation pull secrets. Cleanup mirrors the egress gateway pattern: the objects are
+// owned by the Istio CR and garbage collected when it is deleted. Objects stranded while
+// the CR still exists (a removed Gateway, a renamed pull secret) are not yet cleaned up.
+func (r *ReconcileWaypoint) pullSecretResources(ctx context.Context, reqLogger logr.Logger) ([]client.Object, error) {
+	_, installationSpec, err := utils.GetInstallationSpec(ctx, r)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			reqLogger.V(1).Info("Installation not found")
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	pullSecrets, err := utils.GetInstallationPullSecrets(installationSpec, r)
+	if err != nil {
+		return nil, err
+	}
+	if len(pullSecrets) == 0 {
+		return nil, nil
+	}
+
+	// List all Gateway resources and filter for istio-waypoint class, skipping the
+	// reserved namespaces whose pull secrets and RoleBinding other controllers manage.
+	gatewayList := &gapi.GatewayList{}
+	if err := r.List(ctx, gatewayList); err != nil {
+		return nil, fmt.Errorf("failed to list Gateways: %w", err)
+	}
+
+	targetNamespaces := map[string]bool{}
+	for i := range gatewayList.Items {
+		gw := &gatewayList.Items[i]
+		if string(gw.Spec.GatewayClassName) == IstioWaypointClassName && !reservedNamespace(gw.Namespace) {
+			targetNamespaces[gw.Namespace] = true
+		}
+	}
+
+	// Build the objects for each target namespace. The RoleBinding comes first: it grants
+	// the operator permission to write secrets in the namespace, so it must exist before
+	// the secret copies are created. Both carry MultipleOwnersLabel so the component
+	// handler merges owner references with any other owners (e.g. an egress gateway CR
+	// sharing the namespace) rather than replacing them.
+	var objs []client.Object
+	for ns := range targetNamespaces {
+		rb := render.CreateOperatorSecretsRoleBinding(ns)
+		rb.Labels = common.MapExistsOrInitialize(rb.Labels)
+		rb.Labels[WaypointPullSecretLabel] = "true"
+		rb.Labels[common.MultipleOwnersLabel] = "true"
+		objs = append(objs, rb)
+
+		copied := secret.CopyToNamespace(ns, pullSecrets...)
+		for _, s := range copied {
+			if s.Labels == nil {
+				s.Labels = map[string]string{}
 			}
-			return nil, nil, err
-		}
-
-		pullSecrets, err := utils.GetInstallationPullSecrets(installationSpec, r)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		// List all Gateway resources and filter for istio-waypoint class.
-		gatewayList := &gapi.GatewayList{}
-		if err := r.List(ctx, gatewayList); err != nil {
-			return nil, nil, fmt.Errorf("failed to list Gateways: %w", err)
-		}
-
-		targetNamespaces := map[string]bool{}
-		for i := range gatewayList.Items {
-			gw := &gatewayList.Items[i]
-			if string(gw.Spec.GatewayClassName) == IstioWaypointClassName &&
-				gw.Namespace != common.OperatorNamespace() {
-				targetNamespaces[gw.Namespace] = true
-			}
-		}
-
-		// Build desired secrets for each target namespace.
-		for ns := range targetNamespaces {
-			copied := secret.CopyToNamespace(ns, pullSecrets...)
-			for _, s := range copied {
-				if s.Labels == nil {
-					s.Labels = map[string]string{}
-				}
-				s.Labels[WaypointPullSecretLabel] = "true"
-				toCreate = append(toCreate, s)
-			}
+			s.Labels[WaypointPullSecretLabel] = "true"
+			s.Labels[common.MultipleOwnersLabel] = "true"
+			objs = append(objs, s)
 		}
 	}
 
-	// Build the desired set keyed on (namespace, name) so that renamed or removed
-	// secrets are correctly detected as stale.
-	desiredSecrets := map[types.NamespacedName]bool{}
-	for _, obj := range toCreate {
-		desiredSecrets[types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}] = true
-	}
-
-	// List all existing secrets managed by this controller and mark stale ones for deletion.
-	existingSecrets := &corev1.SecretList{}
-	if err := r.List(ctx, existingSecrets, client.MatchingLabels{WaypointPullSecretLabel: "true"}); err != nil {
-		return nil, nil, fmt.Errorf("failed to list waypoint pull secrets: %w", err)
-	}
-	for i := range existingSecrets.Items {
-		s := &existingSecrets.Items[i]
-		key := types.NamespacedName{Namespace: s.Namespace, Name: s.Name}
-		if !desiredSecrets[key] {
-			toDelete = append(toDelete, s)
-		}
-	}
-
-	return toCreate, toDelete, nil
+	return objs, nil
 }

--- a/pkg/controller/istio/waypoint/waypoint_controller.go
+++ b/pkg/controller/istio/waypoint/waypoint_controller.go
@@ -225,8 +225,8 @@ func (r *ReconcileWaypoint) Reconcile(ctx context.Context, request reconcile.Req
 // pull images from private registries: a tigera-operator-secrets RoleBinding granting the
 // operator permission to write secrets in the namespace, followed by copies of the
 // Installation pull secrets. Cleanup mirrors the egress gateway pattern: the objects are
-// owned by the Istio CR and garbage collected when it is deleted. Objects stranded while
-// the CR still exists (a removed Gateway, a renamed pull secret) are not yet cleaned up.
+// garbage collected by owner reference. Objects stranded while the CR still exists and
+// is the only owner (a removed Gateway, a renamed pull secret) are not yet cleaned up.
 func (r *ReconcileWaypoint) pullSecretResources(ctx context.Context, reqLogger logr.Logger) ([]client.Object, error) {
 	_, installationSpec, err := utils.GetInstallationSpec(ctx, r)
 	if err != nil {

--- a/pkg/controller/istio/waypoint/waypoint_controller.go
+++ b/pkg/controller/istio/waypoint/waypoint_controller.go
@@ -50,14 +50,23 @@ const (
 	legacyGatewayNamespace = "tigera-gateway"
 )
 
-// reservedNamespace returns true for namespaces whose pull secrets and
-// tigera-operator-secrets RoleBinding this controller must not manage: the operator
-// namespace holds the source secrets, calico-system's are managed by the installation
-// controller, and tigera-gateway's are actively torn down by the gateway-API controller's
-// legacy cleanup, which would fight copies created here.
+// reservedNamespace returns true for namespaces whose pull secrets and tigera-operator-secrets
+// RoleBinding this controller must not manage.
+//
+// Waypoints belong in user-managed namespaces, so a waypoint Gateway should never appear in an
+// operator-managed one.
+//
+// The operator namespace holds the source secrets, and a copy keeps the source's name: the
+// handler would update the user's own secret in place and add an Istio owner reference to it.
+// That is the only owner a hand-created secret has, so deleting the Istio CR would garbage
+// collect the user's pull secret, and only the user can put it back.
+//
+// tigera-gateway's are queued for deletion by the gateway-API controller's legacy teardown, in
+// legacyTeardownObjects, which runs whenever no Gateway of a class that controller owns lives
+// there. Copies created here would be deleted and recreated for as long as both keep reconciling.
 func reservedNamespace(ns string) bool {
 	switch ns {
-	case common.OperatorNamespace(), common.CalicoNamespace, legacyGatewayNamespace:
+	case common.OperatorNamespace(), legacyGatewayNamespace:
 		return true
 	}
 	return false

--- a/pkg/controller/istio/waypoint/waypoint_controller.go
+++ b/pkg/controller/istio/waypoint/waypoint_controller.go
@@ -210,7 +210,7 @@ func (r *ReconcileWaypoint) Reconcile(ctx context.Context, request reconcile.Req
 
 	// Pass the Istio CR as the owner: created objects carry an owner reference to it
 	// (merged with any other owners, such as an egress gateway CR sharing the namespace,
-	// via the multiple-owners label) and are garbage collected when the CR is deleted —
+	// via the multiple-owners label) and are garbage collected by owner reference —
 	// the same pattern the egress gateway uses with its CRs.
 	hdlr := utils.NewComponentHandler(log, r, r.scheme, instance)
 	component := render.NewPassthrough(toCreate, toDelete)

--- a/pkg/controller/istio/waypoint/waypoint_controller.go
+++ b/pkg/controller/istio/waypoint/waypoint_controller.go
@@ -38,7 +38,7 @@ import (
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/ctrlruntime"
 	"github.com/tigera/operator/pkg/render"
-	"github.com/tigera/operator/pkg/render/common/secret"
+	"github.com/tigera/operator/pkg/render/istio"
 )
 
 const (
@@ -199,10 +199,10 @@ func (r *ReconcileWaypoint) Reconcile(ctx context.Context, request reconcile.Req
 		return reconcile.Result{}, err
 	}
 
-	// Pass the Istio CR as the owner: created objects carry an owner reference to it
-	// (merged with any other owners, such as an egress gateway CR sharing the namespace,
-	// via the multiple-owners label) and are garbage collected by owner reference —
-	// the same pattern the egress gateway uses with its CRs.
+	// Pass the Istio CR as the owner: created objects carry an owner reference to it and are
+	// garbage collected by owner reference — the same pattern the egress gateway uses with its
+	// CRs. The objects are rendered carrying MultipleOwnersLabel, so that reference is merged
+	// into the owners already on the object instead of replacing them.
 	hdlr := utils.NewComponentHandler(log, r, r.scheme, instance)
 	component := render.NewPassthrough(toCreate, toDelete)
 	if err := hdlr.CreateOrUpdateOrDelete(ctx, component, nil); err != nil {
@@ -251,26 +251,9 @@ func (r *ReconcileWaypoint) pullSecretResources(ctx context.Context, reqLogger l
 		}
 	}
 
-	// Build the objects for each target namespace. The RoleBinding comes first: it grants
-	// the operator permission to write secrets in the namespace, so it must exist before
-	// the secret copies are created. Both carry MultipleOwnersLabel so the component
-	// handler merges owner references with any other owners (e.g. an egress gateway CR
-	// sharing the namespace) rather than replacing them.
 	var objs []client.Object
 	for ns := range targetNamespaces {
-		rb := render.CreateOperatorSecretsRoleBinding(ns)
-		rb.Labels = common.MapExistsOrInitialize(rb.Labels)
-		rb.Labels[common.MultipleOwnersLabel] = "true"
-		objs = append(objs, rb)
-
-		copied := secret.CopyToNamespace(ns, pullSecrets...)
-		for _, s := range copied {
-			if s.Labels == nil {
-				s.Labels = map[string]string{}
-			}
-			s.Labels[common.MultipleOwnersLabel] = "true"
-			objs = append(objs, s)
-		}
+		objs = append(objs, istio.WaypointPullSecretObjects(ns, pullSecrets)...)
 	}
 
 	return objs, nil

--- a/pkg/controller/istio/waypoint/waypoint_controller_test.go
+++ b/pkg/controller/istio/waypoint/waypoint_controller_test.go
@@ -17,10 +17,12 @@ package waypoint
 import (
 	"context"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -34,6 +36,7 @@ import (
 	"github.com/tigera/operator/pkg/controller/certificatemanager"
 	"github.com/tigera/operator/pkg/controller/utils"
 	ctrlrfake "github.com/tigera/operator/pkg/ctrlruntime/client/fake"
+	"github.com/tigera/operator/pkg/render"
 )
 
 var _ = Describe("Waypoint controller pull secret tests", func() {
@@ -163,8 +166,24 @@ var _ = Describe("Waypoint controller pull secret tests", func() {
 		return secretList.Items
 	}
 
+	listTrackedRoleBindings := func() []rbacv1.RoleBinding {
+		rbList := &rbacv1.RoleBindingList{}
+		err := cli.List(ctx, rbList, client.MatchingLabels{WaypointPullSecretLabel: "true"})
+		Expect(err).NotTo(HaveOccurred())
+		return rbList.Items
+	}
+
+	istioOwnerRef := func(obj client.Object) *metav1.OwnerReference {
+		for _, ref := range obj.GetOwnerReferences() {
+			if ref.Kind == "Istio" {
+				return &ref
+			}
+		}
+		return nil
+	}
+
 	Context("when no pull secrets are configured", func() {
-		It("should not create any secrets", func() {
+		It("should not create any secrets or role bindings", func() {
 			Expect(cli.Create(ctx, installation)).NotTo(HaveOccurred())
 			Expect(cli.Create(ctx, istioCR)).NotTo(HaveOccurred())
 			createWaypointGateway("waypoint", "user-ns")
@@ -172,8 +191,8 @@ var _ = Describe("Waypoint controller pull secret tests", func() {
 			_, err := doReconcile()
 			Expect(err).ShouldNot(HaveOccurred())
 
-			secrets := listTrackedSecrets()
-			Expect(secrets).To(BeEmpty())
+			Expect(listTrackedSecrets()).To(BeEmpty())
+			Expect(listTrackedRoleBindings()).To(BeEmpty())
 		})
 	})
 
@@ -198,6 +217,129 @@ var _ = Describe("Waypoint controller pull secret tests", func() {
 			Expect(secrets[0].Namespace).To(Equal("user-ns"))
 			Expect(secrets[0].Name).To(Equal("my-pull-secret"))
 			Expect(secrets[0].Labels[WaypointPullSecretLabel]).To(Equal("true"))
+		})
+
+		It("should create a tigera-operator-secrets RoleBinding in the waypoint namespace", func() {
+			createWaypointGateway("waypoint", "user-ns")
+
+			_, err := doReconcile()
+			Expect(err).ShouldNot(HaveOccurred())
+
+			rbs := listTrackedRoleBindings()
+			Expect(rbs).To(HaveLen(1))
+			rb := rbs[0]
+			Expect(rb.Namespace).To(Equal("user-ns"))
+			Expect(rb.Name).To(Equal(render.TigeraOperatorSecrets))
+			Expect(rb.RoleRef.Kind).To(Equal("ClusterRole"))
+			Expect(rb.RoleRef.Name).To(Equal(render.TigeraOperatorSecrets))
+			Expect(rb.Subjects).To(ConsistOf(rbacv1.Subject{
+				Kind:      "ServiceAccount",
+				Name:      common.OperatorServiceAccount(),
+				Namespace: common.OperatorNamespace(),
+			}))
+			// The MultipleOwnersLabel is a directive to the component handler and must not persist.
+			Expect(rb.Labels).NotTo(HaveKey(common.MultipleOwnersLabel))
+		})
+
+		It("should set an owner reference to the Istio CR on copied secrets and role bindings", func() {
+			createWaypointGateway("waypoint", "user-ns")
+
+			_, err := doReconcile()
+			Expect(err).ShouldNot(HaveOccurred())
+
+			secrets := listTrackedSecrets()
+			Expect(secrets).To(HaveLen(1))
+			ref := istioOwnerRef(&secrets[0])
+			Expect(ref).NotTo(BeNil())
+			Expect(ref.Name).To(Equal("default"))
+			Expect(ref.APIVersion).To(Equal("operator.tigera.io/v1"))
+
+			rbs := listTrackedRoleBindings()
+			Expect(rbs).To(HaveLen(1))
+			ref = istioOwnerRef(&rbs[0])
+			Expect(ref).NotTo(BeNil())
+			Expect(ref.Name).To(Equal("default"))
+			Expect(ref.APIVersion).To(Equal("operator.tigera.io/v1"))
+		})
+
+		It("should update copied secrets when the base pull secret changes", func() {
+			createWaypointGateway("waypoint", "user-ns")
+
+			_, err := doReconcile()
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(listTrackedSecrets()).To(HaveLen(1))
+
+			// Rotate the base pull secret in the operator namespace.
+			base := &corev1.Secret{}
+			Expect(cli.Get(ctx, types.NamespacedName{Name: "my-pull-secret", Namespace: common.OperatorNamespace()}, base)).NotTo(HaveOccurred())
+			newData := []byte(`{"auths":{"registry.example.com":{"auth":"cm90YXRlZDpyb3RhdGVk"}}}`)
+			base.Data[".dockerconfigjson"] = newData
+			Expect(cli.Update(ctx, base)).NotTo(HaveOccurred())
+
+			_, err = doReconcile()
+			Expect(err).ShouldNot(HaveOccurred())
+
+			secrets := listTrackedSecrets()
+			Expect(secrets).To(HaveLen(1))
+			Expect(secrets[0].Data[".dockerconfigjson"]).To(Equal(newData))
+		})
+
+		It("should merge owner references on a RoleBinding shared with an egress gateway", func() {
+			// Simulate the egress gateway controller having already created the
+			// shared RoleBinding in the namespace, owned by its CR.
+			createNamespace("shared-ns")
+			rb := render.CreateOperatorSecretsRoleBinding("shared-ns")
+			rb.OwnerReferences = []metav1.OwnerReference{
+				{
+					APIVersion: "operator.tigera.io/v1",
+					Kind:       "EgressGateway",
+					Name:       "egw",
+					UID:        types.UID("egw-uid"),
+				},
+			}
+			Expect(cli.Create(ctx, rb)).NotTo(HaveOccurred())
+
+			createWaypointGateway("waypoint", "shared-ns")
+
+			_, err := doReconcile()
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// The Istio owner reference is added alongside the egress gateway's,
+			// not in place of it.
+			got := &rbacv1.RoleBinding{}
+			Expect(cli.Get(ctx, types.NamespacedName{Name: render.TigeraOperatorSecrets, Namespace: "shared-ns"}, got)).NotTo(HaveOccurred())
+			kinds := map[string]bool{}
+			for _, ref := range got.OwnerReferences {
+				kinds[ref.Kind] = true
+			}
+			Expect(kinds).To(HaveKey("EgressGateway"))
+			Expect(kinds).To(HaveKey("Istio"))
+		})
+
+		It("should order the RoleBinding ahead of the secret copies", func() {
+			// The RoleBinding grants the operator permission to write secrets in
+			// the namespace, so it must be created first.
+			createWaypointGateway("waypoint", "user-ns")
+
+			objs, err := r.pullSecretResources(ctx, logr.Discard())
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(objs).To(HaveLen(2))
+			Expect(objs[0]).To(BeAssignableToTypeOf(&rbacv1.RoleBinding{}))
+			Expect(objs[1]).To(BeAssignableToTypeOf(&corev1.Secret{}))
+		})
+
+		It("should not create resources for gateways in reserved namespaces", func() {
+			// calico-system's pull secrets and RoleBinding are managed by the
+			// installation controller, and tigera-gateway's are torn down by the
+			// gateway-API controller's legacy cleanup.
+			createWaypointGateway("waypoint-calico-system", common.CalicoNamespace)
+			createWaypointGateway("waypoint-legacy-gateway", "tigera-gateway")
+
+			_, err := doReconcile()
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Expect(listTrackedSecrets()).To(BeEmpty())
+			Expect(listTrackedRoleBindings()).To(BeEmpty())
 		})
 
 		It("should copy pull secrets only once for multiple gateways in same namespace", func() {
@@ -230,26 +372,6 @@ var _ = Describe("Waypoint controller pull secret tests", func() {
 			Expect(namespaces).To(HaveKey("ns-b"))
 		})
 
-		It("should clean up stale secrets when gateway is deleted", func() {
-			createWaypointGateway("waypoint", "user-ns")
-
-			_, err := doReconcile()
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(listTrackedSecrets()).To(HaveLen(1))
-
-			// Delete the gateway.
-			gw := &gapi.Gateway{}
-			Expect(cli.Get(ctx, types.NamespacedName{Name: "waypoint", Namespace: "user-ns"}, gw)).NotTo(HaveOccurred())
-			Expect(cli.Delete(ctx, gw)).NotTo(HaveOccurred())
-
-			// Reconcile again.
-			_, err = doReconcile()
-			Expect(err).ShouldNot(HaveOccurred())
-
-			// Secrets should be cleaned up.
-			Expect(listTrackedSecrets()).To(BeEmpty())
-		})
-
 		It("should not take action for non-matching gatewayClassName", func() {
 			createNonWaypointGateway("other-gateway", "user-ns")
 
@@ -260,7 +382,7 @@ var _ = Describe("Waypoint controller pull secret tests", func() {
 			Expect(secrets).To(BeEmpty())
 		})
 
-		It("should clean up old secret when pull secret is renamed", func() {
+		It("should copy a renamed pull secret, leaving the old copy for the planned cleanup work", func() {
 			createWaypointGateway("waypoint", "user-ns")
 
 			_, err := doReconcile()
@@ -282,10 +404,15 @@ var _ = Describe("Waypoint controller pull secret tests", func() {
 			_, err = doReconcile()
 			Expect(err).ShouldNot(HaveOccurred())
 
-			secrets = listTrackedSecrets()
-			Expect(secrets).To(HaveLen(1))
-			Expect(secrets[0].Name).To(Equal("new-pull-secret"))
-			Expect(secrets[0].Namespace).To(Equal("user-ns"))
+			// The new copy exists; the old one is stranded until the Istio CR is
+			// deleted — the same behaviour the egress gateway has today.
+			names := map[string]bool{}
+			for _, s := range listTrackedSecrets() {
+				Expect(s.Namespace).To(Equal("user-ns"))
+				names[s.Name] = true
+			}
+			Expect(names).To(HaveKey("new-pull-secret"))
+			Expect(names).To(HaveKey("my-pull-secret"))
 		})
 
 		It("should copy multiple pull secrets to waypoint namespace", func() {
@@ -329,7 +456,7 @@ var _ = Describe("Waypoint controller pull secret tests", func() {
 	})
 
 	Context("when Istio CR is deleted", func() {
-		It("should clean up all copied secrets", func() {
+		It("should reconcile without error and leave cleanup to garbage collection", func() {
 			createPullSecret("my-pull-secret")
 			installation.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
 				{Name: "my-pull-secret"},
@@ -341,16 +468,16 @@ var _ = Describe("Waypoint controller pull secret tests", func() {
 			_, err := doReconcile()
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(listTrackedSecrets()).To(HaveLen(1))
+			Expect(listTrackedRoleBindings()).To(HaveLen(1))
 
-			// Delete the Istio CR.
+			// Delete the Istio CR and reconcile again: the controller takes no
+			// action. On a real cluster the copies and RoleBindings are removed
+			// by Kubernetes garbage collection via their Istio owner reference,
+			// which the fake client does not implement.
 			Expect(cli.Delete(ctx, istioCR)).NotTo(HaveOccurred())
 
-			// Reconcile again.
 			_, err = doReconcile()
 			Expect(err).ShouldNot(HaveOccurred())
-
-			// All secrets should be cleaned up.
-			Expect(listTrackedSecrets()).To(BeEmpty())
 		})
 	})
 

--- a/pkg/controller/istio/waypoint/waypoint_controller_test.go
+++ b/pkg/controller/istio/waypoint/waypoint_controller_test.go
@@ -159,20 +159,6 @@ var _ = Describe("Waypoint controller pull secret tests", func() {
 		return r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "default"}})
 	}
 
-	listTrackedSecrets := func() []corev1.Secret {
-		secretList := &corev1.SecretList{}
-		err := cli.List(ctx, secretList, client.MatchingLabels{WaypointPullSecretLabel: "true"})
-		Expect(err).NotTo(HaveOccurred())
-		return secretList.Items
-	}
-
-	listTrackedRoleBindings := func() []rbacv1.RoleBinding {
-		rbList := &rbacv1.RoleBindingList{}
-		err := cli.List(ctx, rbList, client.MatchingLabels{WaypointPullSecretLabel: "true"})
-		Expect(err).NotTo(HaveOccurred())
-		return rbList.Items
-	}
-
 	istioOwnerRef := func(obj client.Object) *metav1.OwnerReference {
 		for _, ref := range obj.GetOwnerReferences() {
 			if ref.Kind == "Istio" {
@@ -180,6 +166,34 @@ var _ = Describe("Waypoint controller pull secret tests", func() {
 			}
 		}
 		return nil
+	}
+
+	// The objects this controller creates are identified by their Istio owner reference,
+	// the same way Kubernetes garbage collection finds them. The source pull secrets and
+	// the certificate manager secret in the operator namespace carry no owner reference,
+	// so they are excluded.
+	listOwnedSecrets := func() []corev1.Secret {
+		secretList := &corev1.SecretList{}
+		Expect(cli.List(ctx, secretList)).NotTo(HaveOccurred())
+		var owned []corev1.Secret
+		for _, s := range secretList.Items {
+			if istioOwnerRef(&s) != nil {
+				owned = append(owned, s)
+			}
+		}
+		return owned
+	}
+
+	listOwnedRoleBindings := func() []rbacv1.RoleBinding {
+		rbList := &rbacv1.RoleBindingList{}
+		Expect(cli.List(ctx, rbList)).NotTo(HaveOccurred())
+		var owned []rbacv1.RoleBinding
+		for _, rb := range rbList.Items {
+			if istioOwnerRef(&rb) != nil {
+				owned = append(owned, rb)
+			}
+		}
+		return owned
 	}
 
 	Context("when no pull secrets are configured", func() {
@@ -191,8 +205,8 @@ var _ = Describe("Waypoint controller pull secret tests", func() {
 			_, err := doReconcile()
 			Expect(err).ShouldNot(HaveOccurred())
 
-			Expect(listTrackedSecrets()).To(BeEmpty())
-			Expect(listTrackedRoleBindings()).To(BeEmpty())
+			Expect(listOwnedSecrets()).To(BeEmpty())
+			Expect(listOwnedRoleBindings()).To(BeEmpty())
 		})
 	})
 
@@ -212,11 +226,12 @@ var _ = Describe("Waypoint controller pull secret tests", func() {
 			_, err := doReconcile()
 			Expect(err).ShouldNot(HaveOccurred())
 
-			secrets := listTrackedSecrets()
+			secrets := listOwnedSecrets()
 			Expect(secrets).To(HaveLen(1))
 			Expect(secrets[0].Namespace).To(Equal("user-ns"))
 			Expect(secrets[0].Name).To(Equal("my-pull-secret"))
-			Expect(secrets[0].Labels[WaypointPullSecretLabel]).To(Equal("true"))
+			// The MultipleOwnersLabel is a directive to the component handler and must not persist.
+			Expect(secrets[0].Labels).NotTo(HaveKey(common.MultipleOwnersLabel))
 		})
 
 		It("should create a tigera-operator-secrets RoleBinding in the waypoint namespace", func() {
@@ -225,7 +240,7 @@ var _ = Describe("Waypoint controller pull secret tests", func() {
 			_, err := doReconcile()
 			Expect(err).ShouldNot(HaveOccurred())
 
-			rbs := listTrackedRoleBindings()
+			rbs := listOwnedRoleBindings()
 			Expect(rbs).To(HaveLen(1))
 			rb := rbs[0]
 			Expect(rb.Namespace).To(Equal("user-ns"))
@@ -247,14 +262,14 @@ var _ = Describe("Waypoint controller pull secret tests", func() {
 			_, err := doReconcile()
 			Expect(err).ShouldNot(HaveOccurred())
 
-			secrets := listTrackedSecrets()
+			secrets := listOwnedSecrets()
 			Expect(secrets).To(HaveLen(1))
 			ref := istioOwnerRef(&secrets[0])
 			Expect(ref).NotTo(BeNil())
 			Expect(ref.Name).To(Equal("default"))
 			Expect(ref.APIVersion).To(Equal("operator.tigera.io/v1"))
 
-			rbs := listTrackedRoleBindings()
+			rbs := listOwnedRoleBindings()
 			Expect(rbs).To(HaveLen(1))
 			ref = istioOwnerRef(&rbs[0])
 			Expect(ref).NotTo(BeNil())
@@ -267,7 +282,7 @@ var _ = Describe("Waypoint controller pull secret tests", func() {
 
 			_, err := doReconcile()
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(listTrackedSecrets()).To(HaveLen(1))
+			Expect(listOwnedSecrets()).To(HaveLen(1))
 
 			// Rotate the base pull secret in the operator namespace.
 			base := &corev1.Secret{}
@@ -279,7 +294,7 @@ var _ = Describe("Waypoint controller pull secret tests", func() {
 			_, err = doReconcile()
 			Expect(err).ShouldNot(HaveOccurred())
 
-			secrets := listTrackedSecrets()
+			secrets := listOwnedSecrets()
 			Expect(secrets).To(HaveLen(1))
 			Expect(secrets[0].Data[".dockerconfigjson"]).To(Equal(newData))
 		})
@@ -338,8 +353,8 @@ var _ = Describe("Waypoint controller pull secret tests", func() {
 			_, err := doReconcile()
 			Expect(err).ShouldNot(HaveOccurred())
 
-			Expect(listTrackedSecrets()).To(BeEmpty())
-			Expect(listTrackedRoleBindings()).To(BeEmpty())
+			Expect(listOwnedSecrets()).To(BeEmpty())
+			Expect(listOwnedRoleBindings()).To(BeEmpty())
 		})
 
 		It("should copy pull secrets only once for multiple gateways in same namespace", func() {
@@ -349,7 +364,7 @@ var _ = Describe("Waypoint controller pull secret tests", func() {
 			_, err := doReconcile()
 			Expect(err).ShouldNot(HaveOccurred())
 
-			secrets := listTrackedSecrets()
+			secrets := listOwnedSecrets()
 			Expect(secrets).To(HaveLen(1))
 			Expect(secrets[0].Namespace).To(Equal("user-ns"))
 		})
@@ -361,7 +376,7 @@ var _ = Describe("Waypoint controller pull secret tests", func() {
 			_, err := doReconcile()
 			Expect(err).ShouldNot(HaveOccurred())
 
-			secrets := listTrackedSecrets()
+			secrets := listOwnedSecrets()
 			Expect(secrets).To(HaveLen(2))
 
 			namespaces := map[string]bool{}
@@ -378,7 +393,7 @@ var _ = Describe("Waypoint controller pull secret tests", func() {
 			_, err := doReconcile()
 			Expect(err).ShouldNot(HaveOccurred())
 
-			secrets := listTrackedSecrets()
+			secrets := listOwnedSecrets()
 			Expect(secrets).To(BeEmpty())
 		})
 
@@ -388,7 +403,7 @@ var _ = Describe("Waypoint controller pull secret tests", func() {
 			_, err := doReconcile()
 			Expect(err).ShouldNot(HaveOccurred())
 
-			secrets := listTrackedSecrets()
+			secrets := listOwnedSecrets()
 			Expect(secrets).To(HaveLen(1))
 			Expect(secrets[0].Name).To(Equal("my-pull-secret"))
 
@@ -407,7 +422,7 @@ var _ = Describe("Waypoint controller pull secret tests", func() {
 			// The new copy exists; the old one is stranded until the Istio CR is
 			// deleted — the same behaviour the egress gateway has today.
 			names := map[string]bool{}
-			for _, s := range listTrackedSecrets() {
+			for _, s := range listOwnedSecrets() {
 				Expect(s.Namespace).To(Equal("user-ns"))
 				names[s.Name] = true
 			}
@@ -430,7 +445,7 @@ var _ = Describe("Waypoint controller pull secret tests", func() {
 			_, err := doReconcile()
 			Expect(err).ShouldNot(HaveOccurred())
 
-			secrets := listTrackedSecrets()
+			secrets := listOwnedSecrets()
 			Expect(secrets).To(HaveLen(2))
 
 			names := map[string]bool{}
@@ -449,8 +464,8 @@ var _ = Describe("Waypoint controller pull secret tests", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 
 			// Pull secrets already exist in the operator namespace; the controller
-			// should skip it to avoid overwriting source secrets with labeled copies.
-			secrets := listTrackedSecrets()
+			// should skip it rather than overwrite the source secrets with copies.
+			secrets := listOwnedSecrets()
 			Expect(secrets).To(BeEmpty())
 		})
 	})
@@ -467,8 +482,8 @@ var _ = Describe("Waypoint controller pull secret tests", func() {
 
 			_, err := doReconcile()
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(listTrackedSecrets()).To(HaveLen(1))
-			Expect(listTrackedRoleBindings()).To(HaveLen(1))
+			Expect(listOwnedSecrets()).To(HaveLen(1))
+			Expect(listOwnedRoleBindings()).To(HaveLen(1))
 
 			// Delete the Istio CR and reconcile again: the controller takes no
 			// action. On a real cluster the copies and RoleBindings are removed
@@ -505,7 +520,7 @@ var _ = Describe("Waypoint controller pull secret tests", func() {
 			_, err := doReconcile()
 			Expect(err).ShouldNot(HaveOccurred())
 
-			secrets := listTrackedSecrets()
+			secrets := listOwnedSecrets()
 			Expect(secrets).To(BeEmpty())
 		})
 	})

--- a/pkg/controller/istio/waypoint/waypoint_controller_test.go
+++ b/pkg/controller/istio/waypoint/waypoint_controller_test.go
@@ -343,11 +343,11 @@ var _ = Describe("Waypoint controller pull secret tests", func() {
 			Expect(objs[1]).To(BeAssignableToTypeOf(&corev1.Secret{}))
 		})
 
-		It("should not create resources for gateways in reserved namespaces", func() {
-			// calico-system's pull secrets and RoleBinding are managed by the
-			// installation controller, and tigera-gateway's are torn down by the
-			// gateway-API controller's legacy cleanup.
-			createWaypointGateway("waypoint-calico-system", common.CalicoNamespace)
+		It("should not create resources for a gateway in the legacy gateway namespace", func() {
+			// The gateway-API controller's legacy teardown queues tigera-gateway's copies
+			// and RoleBinding for deletion whenever no Gateway of a class it owns lives
+			// there, so anything created here would be deleted and recreated for as long as
+			// both controllers keep reconciling.
 			createWaypointGateway("waypoint-legacy-gateway", "tigera-gateway")
 
 			_, err := doReconcile()

--- a/pkg/render/istio/waypoint_pullsecrets.go
+++ b/pkg/render/istio/waypoint_pullsecrets.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package istio
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/tigera/operator/pkg/common"
+	"github.com/tigera/operator/pkg/render"
+	"github.com/tigera/operator/pkg/render/common/secret"
+)
+
+// WaypointPullSecretObjects returns the objects a namespace containing waypoint Gateways needs
+// so its waypoint pods can pull images from a private registry:
+//
+//   - A tigera-operator-secrets RoleBinding granting the operator permission to manage secrets
+//     in the namespace.
+//   - A copy of each Installation pull secret.
+//
+// The RoleBinding is ordered first: it is the grant that lets the operator write the copies
+// that follow it.
+//
+// Every object carries MultipleOwnersLabel, which makes the component handler merge the owner
+// reference it adds into the owners already on the object instead of replacing them. These land
+// in user namespaces that other features write to as well — an egress gateway in the same
+// namespace renders the same RoleBinding — and replacing its owner reference would have that
+// feature's objects garbage collected when the CR owning them here is deleted. Stamping the
+// label here keeps the invariant with the objects, so anything added to the set inherits it.
+//
+// Which namespaces get these is a question about live cluster state and stays with the caller.
+func WaypointPullSecretObjects(namespace string, pullSecrets []*corev1.Secret) []client.Object {
+	objs := []client.Object{render.CreateOperatorSecretsRoleBinding(namespace)}
+	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(namespace, pullSecrets...)...)...)
+
+	for _, obj := range objs {
+		labels := common.MapExistsOrInitialize(obj.GetLabels())
+		labels[common.MultipleOwnersLabel] = "true"
+		obj.SetLabels(labels)
+	}
+
+	return objs
+}

--- a/pkg/render/istio/waypoint_pullsecrets_test.go
+++ b/pkg/render/istio/waypoint_pullsecrets_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package istio_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/tigera/operator/pkg/common"
+	"github.com/tigera/operator/pkg/render/istio"
+)
+
+var _ = Describe("Waypoint pull secret render", func() {
+	const ns = "user-ns"
+
+	pullSecret := func(name string) *corev1.Secret {
+		return &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: common.OperatorNamespace(),
+			},
+			Type: corev1.SecretTypeDockerConfigJson,
+			Data: map[string][]byte{".dockerconfigjson": []byte(`{"auths":{}}`)},
+		}
+	}
+
+	Context("WaypointPullSecretObjects", func() {
+		It("returns the RoleBinding ahead of the secret copies", func() {
+			// The RoleBinding is the grant that lets the operator write the copies, so it
+			// has to be applied before them.
+			objs := istio.WaypointPullSecretObjects(ns, []*corev1.Secret{pullSecret("a"), pullSecret("b")})
+
+			Expect(objs).To(HaveLen(3))
+			Expect(objs[0]).To(BeAssignableToTypeOf(&rbacv1.RoleBinding{}))
+			Expect(objs[0].GetName()).To(Equal("tigera-operator-secrets"))
+			Expect(objs[1]).To(BeAssignableToTypeOf(&corev1.Secret{}))
+			Expect(objs[2]).To(BeAssignableToTypeOf(&corev1.Secret{}))
+		})
+
+		It("puts every object in the requested namespace", func() {
+			objs := istio.WaypointPullSecretObjects(ns, []*corev1.Secret{pullSecret("a")})
+
+			for _, o := range objs {
+				Expect(o.GetNamespace()).To(Equal(ns), "%T %s in wrong namespace", o, o.GetName())
+			}
+		})
+
+		It("marks every object for merged ownership", func() {
+			// These land in user namespaces other features write to as well, so the owner
+			// reference the component handler adds has to merge rather than replace. Without
+			// the label an owner another feature added is dropped, and its objects are
+			// garbage collected when the CR owning them here goes away.
+			objs := istio.WaypointPullSecretObjects(ns, []*corev1.Secret{pullSecret("a")})
+
+			Expect(objs).To(HaveLen(2))
+			for _, o := range objs {
+				Expect(o.GetLabels()).To(HaveKeyWithValue(common.MultipleOwnersLabel, "true"),
+					"%T %s is missing the label", o, o.GetName())
+			}
+		})
+
+		It("copies the pull secret contents and keeps the source name", func() {
+			// The copy has to be usable as an imagePullSecret, and the waypoint pod spec
+			// refers to it by the name the Installation gave it.
+			objs := istio.WaypointPullSecretObjects(ns, []*corev1.Secret{pullSecret("my-pull-secret")})
+
+			Expect(objs).To(HaveLen(2))
+			copied, ok := objs[1].(*corev1.Secret)
+			Expect(ok).To(BeTrue())
+			Expect(copied.Name).To(Equal("my-pull-secret"))
+			Expect(copied.Type).To(Equal(corev1.SecretTypeDockerConfigJson))
+			Expect(copied.Data).To(HaveKeyWithValue(".dockerconfigjson", []byte(`{"auths":{}}`)))
+		})
+
+		It("returns only the RoleBinding when there are no pull secrets", func() {
+			objs := istio.WaypointPullSecretObjects(ns, nil)
+
+			Expect(objs).To(HaveLen(1))
+			Expect(objs[0]).To(BeAssignableToTypeOf(&rbacv1.RoleBinding{}))
+		})
+	})
+})


### PR DESCRIPTION
**Cherry-pick history**
- Pick onto **release-v1.43**: tigera/operator#5068

## Description

Bug fix / follow-up for the istio waypoint feature (Calico Enterprise only).

The waypoint controller copies Installation pull secrets into user namespaces that contain
istio-waypoint Gateways, but the operator has no cluster-wide permission to write Secrets —
writes are only authorized in namespaces where a RoleBinding binds the
`tigera-operator-secrets` ClusterRole to the operator's ServiceAccount.

This only happened to work because of the combined calico images, and calico-node is running as a DaemonSet. However, the operator was constantly trying to create the pull secret and failing, writing error logs regularly.

I've used the Gateway API code as an example of how to fix this.

- Create the `tigera-operator-secrets` RoleBinding in every namespace it writes pull secret
  copies into.
- Preserve copies and RoleBindings co-owned by other features (e.g. egress gateway): shared
  objects keep their owner references via the multiple-owners label, and stale objects are left for Kubernetes GC. This follows the same behaviour as the Gateway, and a general solution to clean up stale objects will be implemented later.
- Skip reserved namespaces (`tigera-operator`, `calico-system`, `tigera-gateway`) whose pull
  secrets and RoleBindings are managed by other controllers.

Testing: unit tests extended in `pkg/controller/istio/waypoint` covering RoleBinding
creation ordering, co-owned secret/binding preservation, reserved namespaces, and
watch-not-ready behavior; `go build`, `go vet`, and the istio/waypoint test suites pass.

## Release Note

```release-note
TBD
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.

