### PR TITLE
EV-6919: Fix multi owner write issues

### DIFF
--- a/pkg/common/components.go
+++ b/pkg/common/components.go
@@ -15,6 +15,7 @@
 package common
 
 import (
+	"slices"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,15 +48,25 @@ func MapExistsOrInitialize(m map[string]string) map[string]string {
 }
 
 // MergeOwnerReferences merges desired and current owner references, removing the duplicates.
+// A UID identifies an owner, so desired's version of a reference wins over current's.
+//
+// The result is sorted by UID, which keeps the merge convergent when more than one controller
+// writes the object. Each caller passes its own reference in desired, so an order that followed
+// the arguments would put a different reference first depending on who wrote last, and the two
+// controllers would rewrite the object in turn for as long as both keep reconciling. Order carries
+// no meaning to Kubernetes: owner references are a set, and the controller reference is identified
+// by its Controller field rather than its position.
 func MergeOwnerReferences(desired, current []metav1.OwnerReference) []metav1.OwnerReference {
-	mergedOwnerReferences := append(desired, current...)
-	allKeys := make(map[metav1.OwnerReference]bool)
-	refList := []metav1.OwnerReference{}
-	for _, item := range mergedOwnerReferences {
-		if _, ok := allKeys[item]; !ok {
+	refList := make([]metav1.OwnerReference, 0, len(desired)+len(current))
+	seen := make(map[string]bool, len(desired)+len(current))
+	for _, item := range slices.Concat(desired, current) {
+		if !seen[string(item.UID)] {
 			refList = append(refList, item)
-			allKeys[item] = true
+			seen[string(item.UID)] = true
 		}
 	}
+	slices.SortFunc(refList, func(a, b metav1.OwnerReference) int {
+		return strings.Compare(string(a.UID), string(b.UID))
+	})
 	return refList
 }

--- a/pkg/common/components_test.go
+++ b/pkg/common/components_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+)
+
+var _ = Describe("MergeOwnerReferences", func() {
+	ref := func(name, uid string) metav1.OwnerReference {
+		return metav1.OwnerReference{
+			APIVersion: "operator.tigera.io/v1",
+			Kind:       "EgressGateway",
+			Name:       name,
+			UID:        types.UID(uid),
+		}
+	}
+	refA := ref("egw-a", "aaaa-1111")
+	refB := ref("egw-b", "bbbb-2222")
+
+	It("is convergent regardless of which owner writes last", func() {
+		// Each controller passes only its own reference as desired. Whichever
+		// writes second must reproduce the object it found, or the two rewrite
+		// the object in turn on every reconcile.
+		byA := MergeOwnerReferences([]metav1.OwnerReference{refA}, []metav1.OwnerReference{refB, refA})
+		byB := MergeOwnerReferences([]metav1.OwnerReference{refB}, []metav1.OwnerReference{refA, refB})
+		Expect(byA).To(Equal(byB))
+
+		// Merging a reference already present changes nothing.
+		Expect(MergeOwnerReferences([]metav1.OwnerReference{refA}, byA)).To(Equal(byA))
+	})
+
+	It("orders the result by UID", func() {
+		merged := MergeOwnerReferences([]metav1.OwnerReference{refB}, []metav1.OwnerReference{refA})
+		Expect(merged).To(Equal([]metav1.OwnerReference{refA, refB}))
+	})
+
+	It("keeps desired's version of a reference that is already on the object", func() {
+		// A re-rendered reference with corrected fields (e.g. a bumped APIVersion)
+		// must replace the stored one.
+		updated := refA
+		updated.APIVersion = "operator.tigera.io/v2"
+		merged := MergeOwnerReferences([]metav1.OwnerReference{updated}, []metav1.OwnerReference{refA, refB})
+		Expect(merged).To(ConsistOf(updated, refB))
+	})
+
+	It("deduplicates by UID even when pointer fields differ", func() {
+		// The pointer fields make whole-struct comparison identity-based: a
+		// reference with Controller set and one without are the same owner.
+		controller := refA
+		controller.Controller = ptr.To(true)
+		merged := MergeOwnerReferences([]metav1.OwnerReference{controller}, []metav1.OwnerReference{refA, refB})
+		Expect(merged).To(HaveLen(2))
+		Expect(merged).To(ContainElement(controller))
+	})
+
+	It("does not mutate the caller's slices", func() {
+		desired := make([]metav1.OwnerReference, 1, 3)
+		desired[0] = refA
+		current := []metav1.OwnerReference{refB}
+		MergeOwnerReferences(desired, current)
+		Expect(desired).To(Equal([]metav1.OwnerReference{refA}))
+		Expect(current).To(Equal([]metav1.OwnerReference{refB}))
+	})
+})

--- a/pkg/controller/utils/component.go
+++ b/pkg/controller/utils/component.go
@@ -253,7 +253,7 @@ func (c *componentHandler) createOrUpdateObject(ctx context.Context, obj client.
 	setProbeTimeouts(obj)
 
 	// Make sure we have our standard selector and pod labels
-	setStandardSelectorAndLabels(obj, c.cr)
+	setStandardSelectorAndLabels(obj, c.cr, multipleOwners)
 
 	if err := ensureTLSCiphers(obj, installationSpec); err != nil {
 		return fmt.Errorf("failed to set TLS Ciphers: %w", err)
@@ -1041,7 +1041,7 @@ func setProbeTimeouts(obj client.Object) {
 // It will also set the k8s-app and app.kubernetes.io/name Labels on the podTemplates
 // for Deployments and Daemonsets. If there is no Selector specified a selector will also be added
 // that selects the k8s-app label.
-func setStandardSelectorAndLabels(obj client.Object, customResource metav1.Object) {
+func setStandardSelectorAndLabels(obj client.Object, customResource metav1.Object, multipleOwners bool) {
 	if obj.GetLabels() == nil {
 		obj.SetLabels(make(map[string]string))
 	}
@@ -1049,8 +1049,15 @@ func setStandardSelectorAndLabels(obj client.Object, customResource metav1.Objec
 		// We do not want to set these labels on objects without a CR. They are usually deliberately not getting an
 		// owner ref and are not controlled by our operator.
 		addNameLabel(obj, obj.GetName())
-		addInstanceLabel(obj, customResource)
-		addComponentLabel(obj, customResource)
+		if !multipleOwners {
+			// The instance and component labels identify the owning CR. An object shared by
+			// several owners has no single identity to stamp: each writer would stamp its own
+			// CR's name and kind, the values would flip with every writer, and the object
+			// would be rewritten on every reconcile for as long as the owners keep
+			// reconciling. Values already on the object are left as they are.
+			addInstanceLabel(obj, customResource)
+			addComponentLabel(obj, customResource)
+		}
 		addPartOfLabel(obj)
 		addManagedByLabel(obj)
 	}

--- a/pkg/controller/utils/component_test.go
+++ b/pkg/controller/utils/component_test.go
@@ -642,6 +642,54 @@ var _ = Describe("Component handler tests", func() {
 		Expect(ns.GetLabels()).To(Equal(expectedLabels))
 	})
 
+	It("skips the per-owner instance and component labels on objects shared by multiple owners", func() {
+		// A shared object is written by more than one controller, each passing its own CR.
+		// The instance and component labels identify the writing CR, so stamping them would
+		// flip the values with every writer and the object would be rewritten on every
+		// reconcile. The writer-independent labels are still applied.
+		sharedRoleBinding := func() *rbacv1.RoleBinding {
+			return &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "shared-rolebinding",
+					Namespace: "test-namespace",
+					Labels:    map[string]string{common.MultipleOwnersLabel: "true"},
+				},
+			}
+		}
+		fc := &fakeComponent{
+			supportedOSType: rmeta.OSTypeLinux,
+			objs:            []client.Object{sharedRoleBinding()},
+		}
+
+		Expect(handler.CreateOrUpdateOrDelete(ctx, fc, sm)).To(BeNil())
+
+		rbKey := client.ObjectKey{Namespace: "test-namespace", Name: "shared-rolebinding"}
+		rb := &rbacv1.RoleBinding{}
+		Expect(c.Get(ctx, rbKey, rb)).To(BeNil())
+		Expect(rb.GetLabels()).To(Equal(map[string]string{
+			"app.kubernetes.io/managed-by": "tigera-operator",
+			"app.kubernetes.io/name":       "shared-rolebinding",
+			"app.kubernetes.io/part-of":    "Calico",
+			"k8s-app":                      "shared-rolebinding",
+		}))
+
+		By("leaving an instance label stamped by an earlier writer as it is")
+		rb.Labels["app.kubernetes.io/instance"] = "some-other-owner"
+		Expect(c.Update(ctx, rb)).NotTo(HaveOccurred())
+
+		fc = &fakeComponent{
+			supportedOSType: rmeta.OSTypeLinux,
+			objs:            []client.Object{sharedRoleBinding()},
+		}
+		Expect(handler.CreateOrUpdateOrDelete(ctx, fc, sm)).To(BeNil())
+
+		rb = &rbacv1.RoleBinding{}
+		Expect(c.Get(ctx, rbKey, rb)).To(BeNil())
+		Expect(rb.GetLabels()).To(HaveKeyWithValue("app.kubernetes.io/instance", "some-other-owner"))
+		Expect(rb.GetLabels()).NotTo(HaveKey("app.kubernetes.io/component"))
+		Expect(rb.GetLabels()).NotTo(HaveKey(common.MultipleOwnersLabel))
+	})
+
 	Context("ensureTLSCiphers", func() {
 		cipher1 := operatorv1.TLS_AES_128_GCM_SHA256
 		cipher2 := operatorv1.TLS_AES_256_GCM_SHA384


### PR DESCRIPTION
## Description

Objects shared by multiple owners (`operator.tigera.io/multipleOwners` label —
pull-secret copies, the `tigera-operator-secrets` RoleBinding, and the gateway trust-bundle
ConfigMap) were rewritten on every alternating reconcile by their owning controllers,
indefinitely. Two independent per-writer fields caused this:

1. `common.MergeOwnerReferences` put the writer's own owner reference first, so each controller
   reordered the references written by the previous one. Fixed by sorting the merged references
   by UID so every writer converges on identical bytes; the dedup key also moves from the whole
   struct (which compared `*bool` pointers by identity) to the UID, and `slices.Concat` replaces
   an `append` that could mutate the caller's slice.
2. The component handler stamped `app.kubernetes.io/instance` and `/component` from the writing
   CR, so shared objects flipped identity labels between owners. Fixed by skipping those two
   per-owner labels on multi-owner objects; writer-independent labels still apply, and values an
   earlier writer stamped are left in place.

## Release Note

```release-note
Fixed continuous rewrites of operator-managed objects shared by multiple owners (pull-secret copies, the tigera-operator-secrets RoleBinding, and gateway trust-bundle ConfigMaps): owner references are now merged in a stable order and per-owner identity labels are no longer written to shared objects, eliminating the resulting API server write and audit-log churn.
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files` (not applicable)
- [ ] If changing versions, run `make gen-versions` (not applicable)

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
