### PR TITLE
Read the DatastoreMigration CRD at v1

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -100,7 +100,6 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(apiextensions.AddToScheme(scheme))
 	utilruntime.Must(operatortigeraiov1.AddToScheme(scheme))
-	utilruntime.Must(datastoremigration.AddToScheme(scheme))
 }
 
 func printVersion() {
@@ -250,6 +249,11 @@ If a value other than 'all' is specified, the first CRD with a prefix of the spe
 		log.Error(err, "")
 		os.Exit(1)
 	}
+
+	// Calico v3.32 serves DatastoreMigration at v1beta1 and v3.33 at v1, so resolve which
+	// before registering the type.
+	datastoremigration.ResolveServedVersion(cs.Discovery())
+	utilruntime.Must(datastoremigration.AddToScheme(scheme))
 
 	v3CRDs, err := apis.UseV3CRDS(cfg)
 	if err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -39,7 +39,6 @@ import (
 	"github.com/tigera/operator/pkg/common/discovery"
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/controller/metrics"
-	"github.com/tigera/operator/pkg/controller/migration/datastoremigration"
 	"github.com/tigera/operator/pkg/controller/options"
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/dns"
@@ -249,11 +248,6 @@ If a value other than 'all' is specified, the first CRD with a prefix of the spe
 		log.Error(err, "")
 		os.Exit(1)
 	}
-
-	// Calico v3.32 serves DatastoreMigration at v1beta1 and v3.33 at v1, so resolve which
-	// before registering the type.
-	datastoremigration.ResolveServedVersion(cs.Discovery())
-	utilruntime.Must(datastoremigration.AddToScheme(scheme))
 
 	v3CRDs, err := apis.UseV3CRDS(cfg)
 	if err != nil {

--- a/pkg/apis/version.go
+++ b/pkg/apis/version.go
@@ -133,7 +133,10 @@ func requireMAPForV3(useV3 bool, disco discovery.DiscoveryInterface) (bool, erro
 // checkDatastoreMigration reports whether a DatastoreMigration CR exists in a phase that
 // means v3 CRDs. Runs before the manager cache exists.
 func checkDatastoreMigration(disco discovery.DiscoveryInterface, dyn dynamic.Interface) (bool, error) {
-	gv, ok := datastoremigration.ServedGroupVersion(disco)
+	gv, ok, err := datastoremigration.ServedGroupVersion(disco)
+	if err != nil {
+		return false, err
+	}
 	if !ok {
 		return false, nil
 	}

--- a/pkg/apis/version.go
+++ b/pkg/apis/version.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
@@ -31,10 +32,12 @@ import (
 	"github.com/tigera/operator/pkg/controller/migration/datastoremigration"
 )
 
-var datastoreMigrationGVR = schema.GroupVersionResource{
-	Group:    "migration.projectcalico.org",
-	Version:  "v1beta1",
-	Resource: "datastoremigrations",
+var datastoreMigrationGVR = datastoremigration.SchemeGroupVersion.WithResource("datastoremigrations")
+
+// legacyDatastoreMigrationGVR is the pre-GA resource, served by Calico v3.32.
+// TODO: remove in v3.34.
+func legacyDatastoreMigrationGVR() schema.GroupVersionResource {
+	return datastoremigration.LegacySchemeGroupVersion.WithResource("datastoremigrations")
 }
 
 const (
@@ -141,6 +144,14 @@ func requireMAPForV3(useV3 bool, disco discovery.DiscoveryInterface) (bool, erro
 // This is used at startup before the manager cache is available.
 func checkDatastoreMigration(dyn dynamic.Interface) (bool, error) {
 	list, err := dyn.Resource(datastoreMigrationGVR).List(context.Background(), metav1.ListOptions{})
+	if err != nil && apierrors.IsNotFound(err) {
+		// A cluster that migrated on v3.32 only has the v1beta1 resource. Without
+		// this, UseV3CRDS falls through to API discovery, which still sees both
+		// groups (the v1 CRDs live until the user deletes the migration CR) and
+		// answers "use v1 CRDs" for a cluster that has already migrated.
+		// TODO: remove in v3.34.
+		list, err = dyn.Resource(legacyDatastoreMigrationGVR()).List(context.Background(), metav1.ListOptions{})
+	}
 	if err != nil {
 		return false, err
 	}

--- a/pkg/apis/version.go
+++ b/pkg/apis/version.go
@@ -36,9 +36,7 @@ var datastoreMigrationGVR = datastoremigration.SchemeGroupVersion.WithResource("
 
 // legacyDatastoreMigrationGVR is the pre-GA resource, served by Calico v3.32.
 // TODO: remove in v3.34.
-func legacyDatastoreMigrationGVR() schema.GroupVersionResource {
-	return datastoremigration.LegacySchemeGroupVersion.WithResource("datastoremigrations")
-}
+var legacyDatastoreMigrationGVR = datastoremigration.LegacySchemeGroupVersion.WithResource("datastoremigrations")
 
 const (
 	mutatingAdmissionPolicyGroup = "admissionregistration.k8s.io"
@@ -141,16 +139,19 @@ func requireMAPForV3(useV3 bool, disco discovery.DiscoveryInterface) (bool, erro
 
 // checkDatastoreMigration uses a dynamic client to look for a DatastoreMigration CR
 // and returns true if one exists in a phase that indicates v3 CRDs should be used.
-// This is used at startup before the manager cache is available.
+// It tries the v1 resource first and falls back to the legacy v1beta1 resource if
+// the v1 CRD isn't installed. This is used at startup before the manager cache is
+// available.
 func checkDatastoreMigration(dyn dynamic.Interface) (bool, error) {
 	list, err := dyn.Resource(datastoreMigrationGVR).List(context.Background(), metav1.ListOptions{})
-	if err != nil && apierrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		// A cluster that migrated on v3.32 only has the v1beta1 resource. Without
 		// this, UseV3CRDS falls through to API discovery, which still sees both
-		// groups (the v1 CRDs live until the user deletes the migration CR) and
-		// answers "use v1 CRDs" for a cluster that has already migrated.
+		// groups (the crd.projectcalico.org CRDs may still be present after the
+		// migration converges) and answers "use v1 CRDs" for a cluster that has
+		// already migrated.
 		// TODO: remove in v3.34.
-		list, err = dyn.Resource(legacyDatastoreMigrationGVR()).List(context.Background(), metav1.ListOptions{})
+		list, err = dyn.Resource(legacyDatastoreMigrationGVR).List(context.Background(), metav1.ListOptions{})
 	}
 	if err != nil {
 		return false, err

--- a/pkg/apis/version.go
+++ b/pkg/apis/version.go
@@ -20,7 +20,6 @@ import (
 	"os"
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
@@ -31,12 +30,6 @@ import (
 
 	"github.com/tigera/operator/pkg/controller/migration/datastoremigration"
 )
-
-var datastoreMigrationGVR = datastoremigration.SchemeGroupVersion.WithResource("datastoremigrations")
-
-// legacyDatastoreMigrationGVR is the pre-GA resource, served by Calico v3.32.
-// TODO: remove in v3.34.
-var legacyDatastoreMigrationGVR = datastoremigration.LegacySchemeGroupVersion.WithResource("datastoremigrations")
 
 const (
 	mutatingAdmissionPolicyGroup = "admissionregistration.k8s.io"
@@ -83,7 +76,7 @@ func useV3CRDs(disco discovery.DiscoveryInterface, dyn dynamic.Interface) (bool,
 	// should be used. This handles operator restarts during or after migration.
 	// This runs before the manager cache is started, so we use a dynamic client
 	// directly rather than the cached datastoremigration.GetPhase().
-	if migrated, err := checkDatastoreMigration(dyn); err != nil {
+	if migrated, err := checkDatastoreMigration(disco, dyn); err != nil {
 		log.Info("Failed to check DatastoreMigration CR, falling through to API discovery", "error", err)
 	} else if migrated {
 		return requireMAPForV3(true, disco)
@@ -137,16 +130,15 @@ func requireMAPForV3(useV3 bool, disco discovery.DiscoveryInterface) (bool, erro
 	return useV3, nil
 }
 
-// checkDatastoreMigration uses a dynamic client to look for a DatastoreMigration CR
-// and returns true if one exists in a phase that indicates v3 CRDs should be used.
-// This is used at startup before the manager cache is available.
-func checkDatastoreMigration(dyn dynamic.Interface) (bool, error) {
-	list, err := dyn.Resource(datastoreMigrationGVR).List(context.Background(), metav1.ListOptions{})
-	if apierrors.IsNotFound(err) {
-		// A cluster that migrated on v3.32 only has the v1beta1 resource.
-		// TODO: remove in v3.34.
-		list, err = dyn.Resource(legacyDatastoreMigrationGVR).List(context.Background(), metav1.ListOptions{})
+// checkDatastoreMigration reports whether a DatastoreMigration CR exists in a phase that
+// means v3 CRDs. Runs before the manager cache exists.
+func checkDatastoreMigration(disco discovery.DiscoveryInterface, dyn dynamic.Interface) (bool, error) {
+	gv, ok := datastoremigration.ServedGroupVersion(disco)
+	if !ok {
+		return false, nil
 	}
+
+	list, err := dyn.Resource(gv.WithResource(datastoremigration.Resource)).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		return false, err
 	}

--- a/pkg/apis/version.go
+++ b/pkg/apis/version.go
@@ -139,17 +139,11 @@ func requireMAPForV3(useV3 bool, disco discovery.DiscoveryInterface) (bool, erro
 
 // checkDatastoreMigration uses a dynamic client to look for a DatastoreMigration CR
 // and returns true if one exists in a phase that indicates v3 CRDs should be used.
-// It tries the v1 resource first and falls back to the legacy v1beta1 resource if
-// the v1 CRD isn't installed. This is used at startup before the manager cache is
-// available.
+// This is used at startup before the manager cache is available.
 func checkDatastoreMigration(dyn dynamic.Interface) (bool, error) {
 	list, err := dyn.Resource(datastoreMigrationGVR).List(context.Background(), metav1.ListOptions{})
 	if apierrors.IsNotFound(err) {
-		// A cluster that migrated on v3.32 only has the v1beta1 resource. Without
-		// this, UseV3CRDS falls through to API discovery, which still sees both
-		// groups (the crd.projectcalico.org CRDs may still be present after the
-		// migration converges) and answers "use v1 CRDs" for a cluster that has
-		// already migrated.
+		// A cluster that migrated on v3.32 only has the v1beta1 resource.
 		// TODO: remove in v3.34.
 		list, err = dyn.Resource(legacyDatastoreMigrationGVR).List(context.Background(), metav1.ListOptions{})
 	}

--- a/pkg/apis/version_test.go
+++ b/pkg/apis/version_test.go
@@ -85,13 +85,8 @@ func TestUseV3CRDs(t *testing.T) {
 	}
 }
 
-// TestCheckDatastoreMigrationFallsBackToLegacyGVR covers a cluster that migrated on v3.32:
-// it has a v1beta1 DatastoreMigration CR in the Converged phase, and the v1 CRD isn't
-// installed yet (the same way an apiserver 404s a List against a resource with no CRD).
-// checkDatastoreMigration has to find the legacy resource, otherwise UseV3CRDS falls
-// through to API discovery, sees both crd.projectcalico.org and projectcalico.org/v3
-// groups (the crd.projectcalico.org CRDs may still be present after the migration
-// converges), and answers "use v1 CRDs" for a cluster that already migrated.
+// A cluster that migrated on v3.32 has a Converged v1beta1 CR and no v1 CRD, and still
+// has to be detected as migrated.
 // TODO: remove in v3.34, alongside legacyDatastoreMigrationGVR.
 func TestCheckDatastoreMigrationFallsBackToLegacyGVR(t *testing.T) {
 	obj := &unstructured.Unstructured{Object: map[string]interface{}{
@@ -110,10 +105,7 @@ func TestCheckDatastoreMigrationFallsBackToLegacyGVR(t *testing.T) {
 		obj,
 	)
 
-	// Simulate the v1 CRD not being installed yet: a List against the v1 resource 404s.
-	// The fake dynamic client has no route table of its own, so a reactor is the only
-	// way to make a GVR return NotFound. The v1beta1 List is left alone so it hits the
-	// tracker and finds the object above.
+	// A reactor is the only way to make one GVR 404 on the fake dynamic client.
 	dc.PrependReactor("list", "datastoremigrations", func(action ktesting.Action) (bool, runtime.Object, error) {
 		if action.GetResource() == datastoreMigrationGVR {
 			return true, nil, apierrors.NewGenericServerResponse(404, "get", datastoreMigrationGVR.GroupResource(), "", "404 page not found", 0, true)

--- a/pkg/apis/version_test.go
+++ b/pkg/apis/version_test.go
@@ -17,14 +17,12 @@ package apis
 import (
 	"testing"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
-	ktesting "k8s.io/client-go/testing"
 
 	"github.com/tigera/operator/pkg/controller/migration/datastoremigration"
 )
@@ -41,7 +39,10 @@ func mapResourceList() *metav1.APIResourceList {
 func emptyDynamicClient() *dynamicfake.FakeDynamicClient {
 	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
 		runtime.NewScheme(),
-		map[schema.GroupVersionResource]string{datastoreMigrationGVR: "DatastoreMigrationList"},
+		map[schema.GroupVersionResource]string{
+			datastoremigration.GroupVersionV1.WithResource(datastoremigration.Resource):      "DatastoreMigrationList",
+			datastoremigration.GroupVersionV1beta1.WithResource(datastoremigration.Resource): "DatastoreMigrationList",
+		},
 	)
 }
 
@@ -87,11 +88,11 @@ func TestUseV3CRDs(t *testing.T) {
 
 // A cluster that migrated on v3.32 has a Converged v1beta1 CR and no v1 CRD, and still
 // has to be detected as migrated.
-// TODO: remove in v3.34, alongside legacyDatastoreMigrationGVR.
+// TODO: remove in v3.34, alongside GroupVersionV1beta1.
 func TestCheckDatastoreMigrationFallsBackToLegacyGVR(t *testing.T) {
 	obj := &unstructured.Unstructured{Object: map[string]interface{}{
-		"apiVersion": datastoremigration.LegacySchemeGroupVersion.String(),
-		"kind":       "DatastoreMigration",
+		"apiVersion": datastoremigration.GroupVersionV1beta1.String(),
+		"kind":       datastoremigration.Kind,
 		"metadata":   map[string]interface{}{"name": "v1-to-v3"},
 		"status":     map[string]interface{}{"phase": datastoremigration.PhaseConverged},
 	}}
@@ -99,26 +100,36 @@ func TestCheckDatastoreMigrationFallsBackToLegacyGVR(t *testing.T) {
 	dc := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
 		runtime.NewScheme(),
 		map[schema.GroupVersionResource]string{
-			datastoreMigrationGVR:       "DatastoreMigrationList",
-			legacyDatastoreMigrationGVR: "DatastoreMigrationList",
+			datastoremigration.GroupVersionV1beta1.WithResource(datastoremigration.Resource): "DatastoreMigrationList",
 		},
 		obj,
 	)
 
-	// A reactor is the only way to make one GVR 404 on the fake dynamic client.
-	dc.PrependReactor("list", "datastoremigrations", func(action ktesting.Action) (bool, runtime.Object, error) {
-		if action.GetResource() == datastoreMigrationGVR {
-			return true, nil, apierrors.NewGenericServerResponse(404, "get", datastoreMigrationGVR.GroupResource(), "", "404 page not found", 0, true)
-		}
-		return false, nil, nil
-	})
+	cs := fake.NewClientset()
+	cs.Resources = []*metav1.APIResourceList{{
+		GroupVersion: datastoremigration.GroupVersionV1beta1.String(),
+		APIResources: []metav1.APIResource{{Name: datastoremigration.Resource, Kind: datastoremigration.Kind}},
+	}}
 
-	migrated, err := checkDatastoreMigration(dc)
+	migrated, err := checkDatastoreMigration(cs.Discovery(), dc)
 	if err != nil {
 		t.Fatalf("checkDatastoreMigration() error = %v", err)
 	}
 	if !migrated {
 		t.Errorf("checkDatastoreMigration() = false, want true (should fall back to the legacy v1beta1 resource)")
+	}
+}
+
+// A cluster with no DatastoreMigration CRD at all must not look migrated.
+func TestCheckDatastoreMigrationWithoutCRD(t *testing.T) {
+	cs := fake.NewClientset()
+
+	migrated, err := checkDatastoreMigration(cs.Discovery(), emptyDynamicClient())
+	if err != nil {
+		t.Fatalf("checkDatastoreMigration() error = %v", err)
+	}
+	if migrated {
+		t.Errorf("checkDatastoreMigration() = true, want false")
 	}
 }
 

--- a/pkg/apis/version_test.go
+++ b/pkg/apis/version_test.go
@@ -17,11 +17,16 @@ package apis
 import (
 	"testing"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+
+	"github.com/tigera/operator/pkg/controller/migration/datastoremigration"
 )
 
 func mapResourceList() *metav1.APIResourceList {
@@ -77,6 +82,50 @@ func TestUseV3CRDs(t *testing.T) {
 				t.Errorf("useV3CRDs() = %t, want %t", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestCheckDatastoreMigrationFallsBackToLegacyGVR covers a cluster that migrated on v3.32:
+// it has a v1beta1 DatastoreMigration CR in the Converged phase, and the v1 CRD isn't
+// installed yet (the same way an apiserver 404s a List against a resource with no CRD).
+// checkDatastoreMigration has to find the legacy resource, otherwise UseV3CRDS falls
+// through to API discovery, sees both crd.projectcalico.org and projectcalico.org/v3
+// groups (the v1 CRDs live until the user deletes the migration CR), and answers "use v1
+// CRDs" for a cluster that already migrated.
+// TODO: remove in v3.34, alongside legacyDatastoreMigrationGVR.
+func TestCheckDatastoreMigrationFallsBackToLegacyGVR(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": datastoremigration.LegacySchemeGroupVersion.String(),
+		"kind":       "DatastoreMigration",
+		"metadata":   map[string]interface{}{"name": "v1-to-v3"},
+		"status":     map[string]interface{}{"phase": datastoremigration.PhaseConverged},
+	}}
+
+	dc := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			datastoreMigrationGVR:         "DatastoreMigrationList",
+			legacyDatastoreMigrationGVR(): "DatastoreMigrationList",
+		},
+		obj,
+	)
+
+	// Simulate the v1 CRD not being installed yet: a List against the v1 resource 404s,
+	// the way a real apiserver responds when the CRD doesn't exist. The v1beta1 List is
+	// left alone so it hits the tracker and finds the object above.
+	dc.PrependReactor("list", "datastoremigrations", func(action ktesting.Action) (bool, runtime.Object, error) {
+		if action.GetResource() == datastoreMigrationGVR {
+			return true, nil, apierrors.NewNotFound(datastoreMigrationGVR.GroupResource(), "")
+		}
+		return false, nil, nil
+	})
+
+	migrated, err := checkDatastoreMigration(dc)
+	if err != nil {
+		t.Fatalf("checkDatastoreMigration() error = %v", err)
+	}
+	if !migrated {
+		t.Errorf("checkDatastoreMigration() = false, want true (should fall back to the legacy v1beta1 resource)")
 	}
 }
 

--- a/pkg/apis/version_test.go
+++ b/pkg/apis/version_test.go
@@ -90,8 +90,8 @@ func TestUseV3CRDs(t *testing.T) {
 // installed yet (the same way an apiserver 404s a List against a resource with no CRD).
 // checkDatastoreMigration has to find the legacy resource, otherwise UseV3CRDS falls
 // through to API discovery, sees both crd.projectcalico.org and projectcalico.org/v3
-// groups (the v1 CRDs live until the user deletes the migration CR), and answers "use v1
-// CRDs" for a cluster that already migrated.
+// groups (the crd.projectcalico.org CRDs may still be present after the migration
+// converges), and answers "use v1 CRDs" for a cluster that already migrated.
 // TODO: remove in v3.34, alongside legacyDatastoreMigrationGVR.
 func TestCheckDatastoreMigrationFallsBackToLegacyGVR(t *testing.T) {
 	obj := &unstructured.Unstructured{Object: map[string]interface{}{
@@ -104,18 +104,19 @@ func TestCheckDatastoreMigrationFallsBackToLegacyGVR(t *testing.T) {
 	dc := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
 		runtime.NewScheme(),
 		map[schema.GroupVersionResource]string{
-			datastoreMigrationGVR:         "DatastoreMigrationList",
-			legacyDatastoreMigrationGVR(): "DatastoreMigrationList",
+			datastoreMigrationGVR:       "DatastoreMigrationList",
+			legacyDatastoreMigrationGVR: "DatastoreMigrationList",
 		},
 		obj,
 	)
 
-	// Simulate the v1 CRD not being installed yet: a List against the v1 resource 404s,
-	// the way a real apiserver responds when the CRD doesn't exist. The v1beta1 List is
-	// left alone so it hits the tracker and finds the object above.
+	// Simulate the v1 CRD not being installed yet: a List against the v1 resource 404s.
+	// The fake dynamic client has no route table of its own, so a reactor is the only
+	// way to make a GVR return NotFound. The v1beta1 List is left alone so it hits the
+	// tracker and finds the object above.
 	dc.PrependReactor("list", "datastoremigrations", func(action ktesting.Action) (bool, runtime.Object, error) {
 		if action.GetResource() == datastoreMigrationGVR {
-			return true, nil, apierrors.NewNotFound(datastoreMigrationGVR.GroupResource(), "")
+			return true, nil, apierrors.NewGenericServerResponse(404, "get", datastoreMigrationGVR.GroupResource(), "", "404 page not found", 0, true)
 		}
 		return false, nil, nil
 	})

--- a/pkg/apis/version_test.go
+++ b/pkg/apis/version_test.go
@@ -15,14 +15,17 @@
 package apis
 
 import (
+	"errors"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	discoveryfake "k8s.io/client-go/discovery/fake"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
 
 	"github.com/tigera/operator/pkg/controller/migration/datastoremigration"
 )
@@ -130,6 +133,22 @@ func TestCheckDatastoreMigrationWithoutCRD(t *testing.T) {
 	}
 	if migrated {
 		t.Errorf("checkDatastoreMigration() = true, want false")
+	}
+}
+
+// A discovery failure must error rather than read as "no migration".
+func TestCheckDatastoreMigrationReportsDiscoveryFailure(t *testing.T) {
+	cs := fake.NewClientset()
+	disco, ok := cs.Discovery().(*discoveryfake.FakeDiscovery)
+	if !ok {
+		t.Fatalf("discovery client is %T, want *discoveryfake.FakeDiscovery", cs.Discovery())
+	}
+	disco.PrependReactor("get", "resource", func(clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("connection refused")
+	})
+
+	if _, err := checkDatastoreMigration(disco, emptyDynamicClient()); err == nil {
+		t.Error("checkDatastoreMigration() error = nil, want an error")
 	}
 }
 

--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -211,9 +211,14 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 	// to migration phase changes (e.g., goes hands-off during Migrating).
 	// Uses ResourceVersionChangedPredicate because migration phase transitions
 	// are status-only updates that don't bump generation.
-	go utils.WaitToAddResourceWatch(c, opts.K8sClientset, log, r.migrationWatchReady, []client.Object{
-		datastoremigration.WatchObject(),
-	}, predicate.ResourceVersionChangedPredicate{})
+	go func() {
+		// Calico v3.32 serves DatastoreMigration at v1beta1 and v3.33 at v1, so wait for the
+		// CRD before picking a version.
+		datastoremigration.WaitForServedVersion(opts.ShutdownContext, opts.K8sClientset.Discovery())
+		utils.WaitToAddResourceWatch(c, opts.K8sClientset, log, r.migrationWatchReady, []client.Object{
+			datastoremigration.WatchObject(),
+		}, predicate.ResourceVersionChangedPredicate{})
+	}()
 
 	log.V(5).Info("Controller created and Watches setup")
 	return nil

--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -212,9 +212,7 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 	// Uses ResourceVersionChangedPredicate because migration phase transitions
 	// are status-only updates that don't bump generation.
 	go utils.WaitToAddResourceWatch(c, opts.K8sClientset, log, r.migrationWatchReady, []client.Object{
-		&datastoremigration.DatastoreMigration{
-			TypeMeta: metav1.TypeMeta{Kind: "DatastoreMigration", APIVersion: datastoremigration.SchemeGroupVersion.String()},
-		},
+		datastoremigration.WatchObject(),
 	}, predicate.ResourceVersionChangedPredicate{})
 
 	log.V(5).Info("Controller created and Watches setup")

--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -211,6 +211,9 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 	// to migration phase changes (e.g., goes hands-off during Migrating).
 	// Uses ResourceVersionChangedPredicate because migration phase transitions
 	// are status-only updates that don't bump generation.
+	//
+	// This is v1 only with no v1beta1 fallback; see the same watch registration in
+	// pkg/controller/installation/core_controller.go for why.
 	go utils.WaitToAddResourceWatch(c, opts.K8sClientset, log, r.migrationWatchReady, []client.Object{
 		&datastoremigration.DatastoreMigration{
 			TypeMeta: metav1.TypeMeta{Kind: "DatastoreMigration", APIVersion: datastoremigration.SchemeGroupVersion.String()},

--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -211,9 +211,6 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 	// to migration phase changes (e.g., goes hands-off during Migrating).
 	// Uses ResourceVersionChangedPredicate because migration phase transitions
 	// are status-only updates that don't bump generation.
-	//
-	// This is v1 only with no v1beta1 fallback; see the same watch registration in
-	// pkg/controller/installation/core_controller.go for why.
 	go utils.WaitToAddResourceWatch(c, opts.K8sClientset, log, r.migrationWatchReady, []client.Object{
 		&datastoremigration.DatastoreMigration{
 			TypeMeta: metav1.TypeMeta{Kind: "DatastoreMigration", APIVersion: datastoremigration.SchemeGroupVersion.String()},

--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -213,7 +213,7 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 	// are status-only updates that don't bump generation.
 	go utils.WaitToAddResourceWatch(c, opts.K8sClientset, log, r.migrationWatchReady, []client.Object{
 		&datastoremigration.DatastoreMigration{
-			TypeMeta: metav1.TypeMeta{Kind: "DatastoreMigration", APIVersion: "migration.projectcalico.org/v1beta1"},
+			TypeMeta: metav1.TypeMeta{Kind: "DatastoreMigration", APIVersion: datastoremigration.SchemeGroupVersion.String()},
 		},
 	}, predicate.ResourceVersionChangedPredicate{})
 

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -301,6 +301,14 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 	// migration state changes (e.g., Converged → triggers env var injection on components).
 	// Uses ResourceVersionChangedPredicate because migration phase transitions
 	// are status-only updates that don't bump generation.
+	//
+	// This watch is registered at v1 only, with no v1beta1 fallback. That's deliberate:
+	// the v1 CRD serves v1 only, so upgrading a v3.32-migrated cluster requires deleting
+	// the old CRD first (Kubernetes rejects dropping a version still in
+	// status.storedVersions), and that deletion cascades to the DatastoreMigration CR.
+	// After a supported upgrade there is therefore no CR to watch. The uncovered case,
+	// upgrading the operator while a v3.32 migration is still in flight, is not a
+	// supported sequence.
 	go utils.WaitToAddResourceWatch(c, opts.K8sClientset, log, ri.migrationWatchReady, []client.Object{
 		&datastoremigration.DatastoreMigration{
 			TypeMeta: metav1.TypeMeta{Kind: "DatastoreMigration", APIVersion: datastoremigration.SchemeGroupVersion.String()},

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -303,7 +303,7 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 	// are status-only updates that don't bump generation.
 	go utils.WaitToAddResourceWatch(c, opts.K8sClientset, log, ri.migrationWatchReady, []client.Object{
 		&datastoremigration.DatastoreMigration{
-			TypeMeta: metav1.TypeMeta{Kind: "DatastoreMigration", APIVersion: "migration.projectcalico.org/v1beta1"},
+			TypeMeta: metav1.TypeMeta{Kind: "DatastoreMigration", APIVersion: datastoremigration.SchemeGroupVersion.String()},
 		},
 	}, predicate.ResourceVersionChangedPredicate{})
 

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -301,9 +301,14 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 	// migration state changes (e.g., Converged → triggers env var injection on components).
 	// Uses ResourceVersionChangedPredicate because migration phase transitions
 	// are status-only updates that don't bump generation.
-	go utils.WaitToAddResourceWatch(c, opts.K8sClientset, log, ri.migrationWatchReady, []client.Object{
-		datastoremigration.WatchObject(),
-	}, predicate.ResourceVersionChangedPredicate{})
+	go func() {
+		// Calico v3.32 serves DatastoreMigration at v1beta1 and v3.33 at v1, so wait for the
+		// CRD before picking a version.
+		datastoremigration.WaitForServedVersion(opts.ShutdownContext, opts.K8sClientset.Discovery())
+		utils.WaitToAddResourceWatch(c, opts.K8sClientset, log, ri.migrationWatchReady, []client.Object{
+			datastoremigration.WatchObject(),
+		}, predicate.ResourceVersionChangedPredicate{})
+	}()
 
 	return nil
 }

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -301,12 +301,8 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 	// migration state changes (e.g., Converged → triggers env var injection on components).
 	// Uses ResourceVersionChangedPredicate because migration phase transitions
 	// are status-only updates that don't bump generation.
-	// v1 only, with no v1beta1 fallback: upgrading a v3.32-migrated cluster means
-	// deleting the old CRD, which takes the CR with it, so there is nothing to watch.
 	go utils.WaitToAddResourceWatch(c, opts.K8sClientset, log, ri.migrationWatchReady, []client.Object{
-		&datastoremigration.DatastoreMigration{
-			TypeMeta: metav1.TypeMeta{Kind: "DatastoreMigration", APIVersion: datastoremigration.SchemeGroupVersion.String()},
-		},
+		datastoremigration.WatchObject(),
 	}, predicate.ResourceVersionChangedPredicate{})
 
 	return nil

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -301,14 +301,8 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 	// migration state changes (e.g., Converged → triggers env var injection on components).
 	// Uses ResourceVersionChangedPredicate because migration phase transitions
 	// are status-only updates that don't bump generation.
-	//
-	// This watch is registered at v1 only, with no v1beta1 fallback. That's deliberate:
-	// the v1 CRD serves v1 only, so upgrading a v3.32-migrated cluster requires deleting
-	// the old CRD first (Kubernetes rejects dropping a version still in
-	// status.storedVersions), and that deletion cascades to the DatastoreMigration CR.
-	// After a supported upgrade there is therefore no CR to watch. The uncovered case,
-	// upgrading the operator while a v3.32 migration is still in flight, is not a
-	// supported sequence.
+	// v1 only, with no v1beta1 fallback: upgrading a v3.32-migrated cluster means
+	// deleting the old CRD, which takes the CR with it, so there is nothing to watch.
 	go utils.WaitToAddResourceWatch(c, opts.K8sClientset, log, ri.migrationWatchReady, []client.Object{
 		&datastoremigration.DatastoreMigration{
 			TypeMeta: metav1.TypeMeta{Kind: "DatastoreMigration", APIVersion: datastoremigration.SchemeGroupVersion.String()},

--- a/pkg/controller/migration/datastoremigration/types.go
+++ b/pkg/controller/migration/datastoremigration/types.go
@@ -15,14 +15,13 @@
 package datastoremigration
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 const (
 	GroupName = "migration.projectcalico.org"
 	Kind      = "DatastoreMigration"
+	ListKind  = "DatastoreMigrationList"
 	Resource  = "datastoremigrations"
 )
 
@@ -33,67 +32,4 @@ var (
 	// GroupVersionV1beta1 is the pre-GA group/version, deprecated but still served in v3.33.
 	// TODO: remove in v3.34.
 	GroupVersionV1beta1 = schema.GroupVersion{Group: GroupName, Version: "v1beta1"}
-
-	// SchemeGroupVersion is the version the operator reads DatastoreMigration at.
-	// ResolveServedVersion replaces it at startup, before AddToScheme runs.
-	SchemeGroupVersion = GroupVersionV1
-
-	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
-	AddToScheme   = SchemeBuilder.AddToScheme
 )
-
-func addKnownTypes(scheme *runtime.Scheme) error {
-	scheme.AddKnownTypes(SchemeGroupVersion,
-		&DatastoreMigration{},
-		&DatastoreMigrationList{},
-	)
-	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
-	return nil
-}
-
-// DatastoreMigration is a minimal stub of the CR, carrying only the fields the operator
-// reads at either version.
-type DatastoreMigration struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Status            DatastoreMigrationStatus `json:"status,omitempty"`
-}
-
-type DatastoreMigrationStatus struct {
-	Phase string `json:"phase,omitempty"`
-}
-
-func (in *DatastoreMigration) DeepCopyObject() runtime.Object {
-	if in == nil {
-		return nil
-	}
-	out := new(DatastoreMigration)
-	in.DeepCopyInto(&out.ObjectMeta)
-	out.TypeMeta = in.TypeMeta
-	out.Status = in.Status
-	return out
-}
-
-// DatastoreMigrationList is a list of DatastoreMigration resources.
-type DatastoreMigrationList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []DatastoreMigration `json:"items"`
-}
-
-func (in *DatastoreMigrationList) DeepCopyObject() runtime.Object {
-	if in == nil {
-		return nil
-	}
-	out := new(DatastoreMigrationList)
-	out.TypeMeta = in.TypeMeta
-	in.DeepCopyInto(&out.ListMeta)
-	if in.Items != nil {
-		out.Items = make([]DatastoreMigration, len(in.Items))
-		for i := range in.Items {
-			item := in.Items[i].DeepCopyObject().(*DatastoreMigration)
-			out.Items[i] = *item
-		}
-	}
-	return out
-}

--- a/pkg/controller/migration/datastoremigration/types.go
+++ b/pkg/controller/migration/datastoremigration/types.go
@@ -21,12 +21,10 @@ import (
 )
 
 var (
-	// SchemeGroupVersion is the group/version this operator reads DatastoreMigration
-	// resources at. Everything that needs the version string derives it from here.
+	// SchemeGroupVersion is the group/version this operator reads DatastoreMigration at.
 	SchemeGroupVersion = schema.GroupVersion{Group: "migration.projectcalico.org", Version: "v1"}
 
 	// LegacySchemeGroupVersion is the pre-GA group/version, served by Calico v3.32.
-	// Kept so a cluster that migrated on v3.32 is still detected as migrated.
 	// TODO: remove in v3.34.
 	LegacySchemeGroupVersion = schema.GroupVersion{Group: "migration.projectcalico.org", Version: "v1beta1"}
 

--- a/pkg/controller/migration/datastoremigration/types.go
+++ b/pkg/controller/migration/datastoremigration/types.go
@@ -21,9 +21,17 @@ import (
 )
 
 var (
-	SchemeGroupVersion = schema.GroupVersion{Group: "migration.projectcalico.org", Version: "v1beta1"}
-	SchemeBuilder      = runtime.NewSchemeBuilder(addKnownTypes)
-	AddToScheme        = SchemeBuilder.AddToScheme
+	// SchemeGroupVersion is the group/version this operator reads DatastoreMigration
+	// resources at. Everything that needs the version string derives it from here.
+	SchemeGroupVersion = schema.GroupVersion{Group: "migration.projectcalico.org", Version: "v1"}
+
+	// LegacySchemeGroupVersion is the pre-GA group/version, served by Calico v3.32.
+	// Kept so a cluster that migrated on v3.32 is still detected as migrated.
+	// TODO: remove in v3.34.
+	LegacySchemeGroupVersion = schema.GroupVersion{Group: "migration.projectcalico.org", Version: "v1beta1"}
+
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+	AddToScheme   = SchemeBuilder.AddToScheme
 )
 
 func addKnownTypes(scheme *runtime.Scheme) error {
@@ -35,7 +43,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	return nil
 }
 
-// DatastoreMigration is a minimal stub for the migration.projectcalico.org/v1beta1
+// DatastoreMigration is a minimal stub for the migration.projectcalico.org/v1
 // DatastoreMigration CR. It contains only the fields the operator needs to read,
 // allowing controller-runtime to cache these objects via a typed watch.
 type DatastoreMigration struct {

--- a/pkg/controller/migration/datastoremigration/types.go
+++ b/pkg/controller/migration/datastoremigration/types.go
@@ -20,13 +20,23 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-var (
-	// SchemeGroupVersion is the group/version this operator reads DatastoreMigration at.
-	SchemeGroupVersion = schema.GroupVersion{Group: "migration.projectcalico.org", Version: "v1"}
+const (
+	GroupName = "migration.projectcalico.org"
+	Kind      = "DatastoreMigration"
+	Resource  = "datastoremigrations"
+)
 
-	// LegacySchemeGroupVersion is the pre-GA group/version, served by Calico v3.32.
+var (
+	// GroupVersionV1 is the GA group/version, the storage version from Calico v3.33.
+	GroupVersionV1 = schema.GroupVersion{Group: GroupName, Version: "v1"}
+
+	// GroupVersionV1beta1 is the pre-GA group/version, deprecated but still served in v3.33.
 	// TODO: remove in v3.34.
-	LegacySchemeGroupVersion = schema.GroupVersion{Group: "migration.projectcalico.org", Version: "v1beta1"}
+	GroupVersionV1beta1 = schema.GroupVersion{Group: GroupName, Version: "v1beta1"}
+
+	// SchemeGroupVersion is the version the operator reads DatastoreMigration at.
+	// ResolveServedVersion replaces it at startup, before AddToScheme runs.
+	SchemeGroupVersion = GroupVersionV1
 
 	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 	AddToScheme   = SchemeBuilder.AddToScheme
@@ -41,9 +51,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	return nil
 }
 
-// DatastoreMigration is a minimal stub for the migration.projectcalico.org/v1
-// DatastoreMigration CR. It contains only the fields the operator needs to read,
-// allowing controller-runtime to cache these objects via a typed watch.
+// DatastoreMigration is a minimal stub of the CR, carrying only the fields the operator
+// reads at either version.
 type DatastoreMigration struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/controller/migration/datastoremigration/utils.go
+++ b/pkg/controller/migration/datastoremigration/utils.go
@@ -19,6 +19,7 @@ package datastoremigration
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -38,14 +39,22 @@ func get(c client.Client) (string, bool) {
 	if c == nil {
 		return "", false
 	}
-	list := &DatastoreMigrationList{}
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(ServedVersion().WithKind(ListKind))
 	if err := c.List(context.Background(), list, client.Limit(1)); err != nil {
+		log.V(1).Info("Failed to list DatastoreMigrations", "error", err)
 		return "", false
 	}
 	if len(list.Items) == 0 {
 		return "", false
 	}
-	return list.Items[0].Status.Phase, true
+
+	phase, _, err := unstructured.NestedString(list.Items[0].Object, "status", "phase")
+	if err != nil {
+		log.V(1).Info("DatastoreMigration has a malformed phase", "error", err)
+		return "", true
+	}
+	return phase, true
 }
 
 // GetPhase returns the phase of the first DatastoreMigration CR, or empty

--- a/pkg/controller/migration/datastoremigration/utils_test.go
+++ b/pkg/controller/migration/datastoremigration/utils_test.go
@@ -41,7 +41,7 @@ func migrationCR(name, phase string) *DatastoreMigration {
 	obj := &DatastoreMigration{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "DatastoreMigration",
-			APIVersion: "migration.projectcalico.org/v1beta1",
+			APIVersion: SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{Name: name},
 	}

--- a/pkg/controller/migration/datastoremigration/utils_test.go
+++ b/pkg/controller/migration/datastoremigration/utils_test.go
@@ -19,17 +19,22 @@ import (
 
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func newFakeClient(t *testing.T, objects ...*DatastoreMigration) client.Client {
+func newFakeClient(t *testing.T, gv schema.GroupVersion, objects ...*unstructured.Unstructured) client.Client {
 	t.Helper()
 	scheme := runtime.NewScheme()
-	if err := AddToScheme(scheme); err != nil {
-		t.Fatalf("failed to add scheme: %v", err)
+	for _, v := range []schema.GroupVersion{GroupVersionV1, GroupVersionV1beta1} {
+		scheme.AddKnownTypeWithName(v.WithKind(Kind), &unstructured.Unstructured{})
+		scheme.AddKnownTypeWithName(v.WithKind(ListKind), &unstructured.UnstructuredList{})
+		metav1.AddToGroupVersion(scheme, v)
 	}
+
 	b := fake.NewClientBuilder().WithScheme(scheme)
 	for _, obj := range objects {
 		b = b.WithObjects(obj)
@@ -37,16 +42,14 @@ func newFakeClient(t *testing.T, objects ...*DatastoreMigration) client.Client {
 	return b.Build()
 }
 
-func migrationCR(name, phase string) *DatastoreMigration {
-	obj := &DatastoreMigration{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "DatastoreMigration",
-			APIVersion: SchemeGroupVersion.String(),
-		},
-		ObjectMeta: metav1.ObjectMeta{Name: name},
-	}
+func migrationCR(gv schema.GroupVersion, name, phase string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(gv.WithKind(Kind))
+	obj.SetName(name)
 	if phase != "" {
-		obj.Status.Phase = phase
+		if err := unstructured.SetNestedField(obj.Object, phase, "status", "phase"); err != nil {
+			panic(err)
+		}
 	}
 	return obj
 }
@@ -54,7 +57,8 @@ func migrationCR(name, phase string) *DatastoreMigration {
 func TestGetPhaseAndExists(t *testing.T) {
 	tests := []struct {
 		name      string
-		objects   []*DatastoreMigration
+		phase     string
+		noCR      bool
 		nilClient bool
 		wantPhase string
 		wantExist bool
@@ -67,48 +71,78 @@ func TestGetPhaseAndExists(t *testing.T) {
 		},
 		{
 			name:      "no CRs",
+			noCR:      true,
 			wantPhase: "",
 			wantExist: false,
 		},
 		{
 			name:      "CR with no status",
-			objects:   []*DatastoreMigration{migrationCR("default", "")},
 			wantPhase: "",
 			wantExist: true,
 		},
 		{
 			name:      "CR in Migrating phase",
-			objects:   []*DatastoreMigration{migrationCR("default", PhaseMigrating)},
+			phase:     PhaseMigrating,
 			wantPhase: PhaseMigrating,
 			wantExist: true,
 		},
 		{
 			name:      "CR in Converged phase",
-			objects:   []*DatastoreMigration{migrationCR("default", PhaseConverged)},
+			phase:     PhaseConverged,
 			wantPhase: PhaseConverged,
 			wantExist: true,
 		},
 		{
 			name:      "CR in Complete phase",
-			objects:   []*DatastoreMigration{migrationCR("default", PhaseComplete)},
+			phase:     PhaseComplete,
 			wantPhase: PhaseComplete,
 			wantExist: true,
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			g := NewWithT(t)
+	// Both served versions are read through the same unstructured path, so run each case twice.
+	for _, gv := range []schema.GroupVersion{GroupVersionV1, GroupVersionV1beta1} {
+		for _, tt := range tests {
+			t.Run(gv.Version+"/"+tt.name, func(t *testing.T) {
+				g := NewWithT(t)
+				defer withServedVersion(t, gv)()
 
-			if tt.nilClient {
-				g.Expect(GetPhase(nil)).To(Equal(tt.wantPhase))
-				g.Expect(Exists(nil)).To(Equal(tt.wantExist))
-				return
-			}
+				if tt.nilClient {
+					g.Expect(GetPhase(nil)).To(Equal(tt.wantPhase))
+					g.Expect(Exists(nil)).To(Equal(tt.wantExist))
+					return
+				}
 
-			c := newFakeClient(t, tt.objects...)
-			g.Expect(GetPhase(c)).To(Equal(tt.wantPhase))
-			g.Expect(Exists(c)).To(Equal(tt.wantExist))
-		})
+				var objects []*unstructured.Unstructured
+				if !tt.noCR {
+					objects = append(objects, migrationCR(gv, "default", tt.phase))
+				}
+
+				c := newFakeClient(t, gv, objects...)
+				g.Expect(GetPhase(c)).To(Equal(tt.wantPhase))
+				g.Expect(Exists(c)).To(Equal(tt.wantExist))
+			})
+		}
 	}
+}
+
+// A CR written at the version the cluster doesn't serve must not be read as present.
+func TestGetPhaseUsesTheServedVersion(t *testing.T) {
+	g := NewWithT(t)
+	defer withServedVersion(t, GroupVersionV1)()
+
+	c := newFakeClient(t, GroupVersionV1beta1, migrationCR(GroupVersionV1beta1, "default", PhaseMigrating))
+	g.Expect(GetPhase(c)).To(BeEmpty())
+
+	defer withServedVersion(t, GroupVersionV1beta1)()
+	g.Expect(GetPhase(c)).To(Equal(PhaseMigrating))
+}
+
+func withServedVersion(t *testing.T, gv schema.GroupVersion) func() {
+	t.Helper()
+	restore := restoreServedVersion(t)
+	servedMutex.Lock()
+	servedVersion = gv
+	servedMutex.Unlock()
+	return restore
 }

--- a/pkg/controller/migration/datastoremigration/version.go
+++ b/pkg/controller/migration/datastoremigration/version.go
@@ -15,52 +15,89 @@
 package datastoremigration
 
 import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	initialRetry = 1 * time.Second
+	maxRetry     = 30 * time.Second
 )
 
 var log = ctrl.Log.WithName("datastoremigration")
 
-// ResolveServedVersion points the package at the version the cluster serves. Call it before
-// AddToScheme: scheme, cache and watches must agree.
-func ResolveServedVersion(disco discovery.DiscoveryInterface) {
-	gv, ok := ServedGroupVersion(disco)
-	if !ok {
-		// The CRD is installed by the user when they migrate, so it's usually absent at startup.
-		log.V(1).Info("No DatastoreMigration CRD served, defaulting", "groupVersion", SchemeGroupVersion)
-		return
-	}
-	log.Info("Resolved served DatastoreMigration version", "groupVersion", gv)
-	SchemeGroupVersion = gv
+var (
+	servedMutex   sync.RWMutex
+	servedVersion = GroupVersionV1
+)
+
+// ServedVersion returns the group/version the operator reads DatastoreMigration at. It is v1
+// until WaitForServedVersion finds out what the cluster serves.
+func ServedVersion() schema.GroupVersion {
+	servedMutex.RLock()
+	defer servedMutex.RUnlock()
+	return servedVersion
 }
 
-// ServedGroupVersion returns the DatastoreMigration group/version the cluster serves, preferring v1.
-// The second return is false when the CRD isn't installed.
-func ServedGroupVersion(disco discovery.DiscoveryInterface) (schema.GroupVersion, bool) {
+// WaitForServedVersion records the served version once the CRD appears. The user installs it
+// at migration time, so expect a wait.
+func WaitForServedVersion(ctx context.Context, disco discovery.DiscoveryInterface) {
+	delay := initialRetry
+	for {
+		gv, ok, err := ServedGroupVersion(disco)
+		switch {
+		case err != nil:
+			log.Error(err, "Failed to look up served DatastoreMigration versions - will retry")
+		case ok:
+			servedMutex.Lock()
+			servedVersion = gv
+			servedMutex.Unlock()
+			log.Info("Resolved served DatastoreMigration version", "groupVersion", gv)
+			return
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(delay):
+		}
+		delay = min(delay*2, maxRetry)
+	}
+}
+
+// ServedGroupVersion returns the served group/version, preferring v1. The bool is false when
+// the CRD isn't installed; a failed lookup errors.
+func ServedGroupVersion(disco discovery.DiscoveryInterface) (schema.GroupVersion, bool, error) {
 	for _, gv := range []schema.GroupVersion{GroupVersionV1, GroupVersionV1beta1} {
 		resources, err := disco.ServerResourcesForGroupVersion(gv.String())
 		if err != nil {
-			if !apierrors.IsNotFound(err) {
-				log.Error(err, "Failed to look up served DatastoreMigration versions", "groupVersion", gv)
+			if apierrors.IsNotFound(err) {
+				continue
 			}
-			continue
+			return schema.GroupVersion{}, false, fmt.Errorf("look up %s: %w", gv, err)
 		}
 		for _, r := range resources.APIResources {
 			if r.Name == Resource {
-				return gv, true
+				return gv, true, nil
 			}
 		}
 	}
-	return schema.GroupVersion{}, false
+	return schema.GroupVersion{}, false, nil
 }
 
-// WatchObject returns an empty DatastoreMigration stamped with the resolved group/version, for
-// controllers registering a watch.
-func WatchObject() *DatastoreMigration {
-	return &DatastoreMigration{
-		TypeMeta: metav1.TypeMeta{Kind: Kind, APIVersion: SchemeGroupVersion.String()},
-	}
+// WatchObject returns an empty DatastoreMigration at the served version, for controllers
+// registering a watch.
+func WatchObject() client.Object {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(ServedVersion().WithKind(Kind))
+	return u
 }

--- a/pkg/controller/migration/datastoremigration/version.go
+++ b/pkg/controller/migration/datastoremigration/version.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datastoremigration
+
+import (
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var log = ctrl.Log.WithName("datastoremigration")
+
+// ResolveServedVersion points the package at the version the cluster serves. Call it before
+// AddToScheme: scheme, cache and watches must agree.
+func ResolveServedVersion(disco discovery.DiscoveryInterface) {
+	gv, ok := ServedGroupVersion(disco)
+	if !ok {
+		// The CRD is installed by the user when they migrate, so it's usually absent at startup.
+		log.V(1).Info("No DatastoreMigration CRD served, defaulting", "groupVersion", SchemeGroupVersion)
+		return
+	}
+	log.Info("Resolved served DatastoreMigration version", "groupVersion", gv)
+	SchemeGroupVersion = gv
+}
+
+// ServedGroupVersion returns the DatastoreMigration group/version the cluster serves, preferring v1.
+// The second return is false when the CRD isn't installed.
+func ServedGroupVersion(disco discovery.DiscoveryInterface) (schema.GroupVersion, bool) {
+	for _, gv := range []schema.GroupVersion{GroupVersionV1, GroupVersionV1beta1} {
+		resources, err := disco.ServerResourcesForGroupVersion(gv.String())
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				log.Error(err, "Failed to look up served DatastoreMigration versions", "groupVersion", gv)
+			}
+			continue
+		}
+		for _, r := range resources.APIResources {
+			if r.Name == Resource {
+				return gv, true
+			}
+		}
+	}
+	return schema.GroupVersion{}, false
+}
+
+// WatchObject returns an empty DatastoreMigration stamped with the resolved group/version, for
+// controllers registering a watch.
+func WatchObject() *DatastoreMigration {
+	return &DatastoreMigration{
+		TypeMeta: metav1.TypeMeta{Kind: Kind, APIVersion: SchemeGroupVersion.String()},
+	}
+}

--- a/pkg/controller/migration/datastoremigration/version_test.go
+++ b/pkg/controller/migration/datastoremigration/version_test.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datastoremigration
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// discoveryServing returns a discovery client serving datastoremigrations at each given version.
+func discoveryServing(versions ...schema.GroupVersion) discovery.DiscoveryInterface {
+	c := fake.NewClientset()
+	for _, gv := range versions {
+		c.Resources = append(c.Resources, &metav1.APIResourceList{
+			GroupVersion: gv.String(),
+			APIResources: []metav1.APIResource{{Name: Resource, Kind: Kind}},
+		})
+	}
+	return c.Discovery()
+}
+
+func TestServedGroupVersion(t *testing.T) {
+	cases := []struct {
+		name   string
+		disco  discovery.DiscoveryInterface
+		want   schema.GroupVersion
+		wantOK bool
+	}{
+		{"v1 only", discoveryServing(GroupVersionV1), GroupVersionV1, true},
+		{"v1beta1 only", discoveryServing(GroupVersionV1beta1), GroupVersionV1beta1, true},
+		{"both served prefers v1", discoveryServing(GroupVersionV1beta1, GroupVersionV1), GroupVersionV1, true},
+		{"neither served", discoveryServing(), schema.GroupVersion{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := ServedGroupVersion(tc.disco)
+			if ok != tc.wantOK {
+				t.Fatalf("ServedGroupVersion() ok = %t, want %t", ok, tc.wantOK)
+			}
+			if got != tc.want {
+				t.Errorf("ServedGroupVersion() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestServedGroupVersionIgnoresGroupWithoutResource(t *testing.T) {
+	c := fake.NewClientset()
+	c.Resources = []*metav1.APIResourceList{{GroupVersion: GroupVersionV1.String()}}
+
+	if _, ok := ServedGroupVersion(c.Discovery()); ok {
+		t.Error("ServedGroupVersion() = true, want false when the group serves no datastoremigrations")
+	}
+}
+
+func TestResolveServedVersion(t *testing.T) {
+	cases := []struct {
+		name  string
+		disco discovery.DiscoveryInterface
+		want  schema.GroupVersion
+	}{
+		{"switches to the legacy version", discoveryServing(GroupVersionV1beta1), GroupVersionV1beta1},
+		{"stays on v1 when nothing is served", discoveryServing(), GroupVersionV1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			original := SchemeGroupVersion
+			t.Cleanup(func() { SchemeGroupVersion = original })
+
+			ResolveServedVersion(tc.disco)
+			if SchemeGroupVersion != tc.want {
+				t.Fatalf("SchemeGroupVersion = %v, want %v", SchemeGroupVersion, tc.want)
+			}
+			if got := WatchObject().APIVersion; got != tc.want.String() {
+				t.Errorf("WatchObject() APIVersion = %q, want %q", got, tc.want.String())
+			}
+		})
+	}
+}

--- a/pkg/controller/migration/datastoremigration/version_test.go
+++ b/pkg/controller/migration/datastoremigration/version_test.go
@@ -15,7 +15,11 @@
 package datastoremigration
 
 import (
+	"context"
+	"errors"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -35,6 +39,22 @@ func discoveryServing(versions ...schema.GroupVersion) discovery.DiscoveryInterf
 	return c.Discovery()
 }
 
+// failingDiscovery fails the first failures lookups, then behaves like the wrapped client.
+type failingDiscovery struct {
+	discovery.DiscoveryInterface
+
+	remaining atomic.Int32
+	attempts  atomic.Int32
+}
+
+func (d *failingDiscovery) ServerResourcesForGroupVersion(gv string) (*metav1.APIResourceList, error) {
+	d.attempts.Add(1)
+	if d.remaining.Add(-1) >= 0 {
+		return nil, errors.New("connection refused")
+	}
+	return d.DiscoveryInterface.ServerResourcesForGroupVersion(gv)
+}
+
 func TestServedGroupVersion(t *testing.T) {
 	cases := []struct {
 		name   string
@@ -49,7 +69,10 @@ func TestServedGroupVersion(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, ok := ServedGroupVersion(tc.disco)
+			got, ok, err := ServedGroupVersion(tc.disco)
+			if err != nil {
+				t.Fatalf("ServedGroupVersion() error = %v, want nil", err)
+			}
 			if ok != tc.wantOK {
 				t.Fatalf("ServedGroupVersion() ok = %t, want %t", ok, tc.wantOK)
 			}
@@ -64,32 +87,93 @@ func TestServedGroupVersionIgnoresGroupWithoutResource(t *testing.T) {
 	c := fake.NewClientset()
 	c.Resources = []*metav1.APIResourceList{{GroupVersion: GroupVersionV1.String()}}
 
-	if _, ok := ServedGroupVersion(c.Discovery()); ok {
+	_, ok, err := ServedGroupVersion(c.Discovery())
+	if err != nil {
+		t.Fatalf("ServedGroupVersion() error = %v, want nil", err)
+	}
+	if ok {
 		t.Error("ServedGroupVersion() = true, want false when the group serves no datastoremigrations")
 	}
 }
 
-func TestResolveServedVersion(t *testing.T) {
+// A lookup failure must not read as an absent CRD, or we'd pin the wrong version.
+func TestServedGroupVersionReportsLookupFailure(t *testing.T) {
+	disco := &failingDiscovery{DiscoveryInterface: discoveryServing(GroupVersionV1beta1)}
+	disco.remaining.Store(1)
+
+	if _, ok, err := ServedGroupVersion(disco); err == nil {
+		t.Errorf("ServedGroupVersion() ok = %t, err = nil, want an error", ok)
+	}
+}
+
+func TestWaitForServedVersion(t *testing.T) {
 	cases := []struct {
 		name  string
 		disco discovery.DiscoveryInterface
 		want  schema.GroupVersion
 	}{
-		{"switches to the legacy version", discoveryServing(GroupVersionV1beta1), GroupVersionV1beta1},
-		{"stays on v1 when nothing is served", discoveryServing(), GroupVersionV1},
+		{"picks up the legacy version", discoveryServing(GroupVersionV1beta1), GroupVersionV1beta1},
+		{"picks up v1", discoveryServing(GroupVersionV1), GroupVersionV1},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			original := SchemeGroupVersion
-			t.Cleanup(func() { SchemeGroupVersion = original })
+			defer restoreServedVersion(t)()
 
-			ResolveServedVersion(tc.disco)
-			if SchemeGroupVersion != tc.want {
-				t.Fatalf("SchemeGroupVersion = %v, want %v", SchemeGroupVersion, tc.want)
+			WaitForServedVersion(context.Background(), tc.disco)
+			if got := ServedVersion(); got != tc.want {
+				t.Fatalf("ServedVersion() = %v, want %v", got, tc.want)
 			}
-			if got := WatchObject().APIVersion; got != tc.want.String() {
-				t.Errorf("WatchObject() APIVersion = %q, want %q", got, tc.want.String())
+			if got := WatchObject().GetObjectKind().GroupVersionKind().GroupVersion(); got != tc.want {
+				t.Errorf("WatchObject() group version = %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+// The CRD is normally installed long after startup, so a missing one can't resolve to v1.
+func TestWaitForServedVersionWaitsForTheCRD(t *testing.T) {
+	defer restoreServedVersion(t)()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		WaitForServedVersion(ctx, discoveryServing())
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("WaitForServedVersion() did not return when the context was cancelled")
+	}
+	if got := ServedVersion(); got != GroupVersionV1 {
+		t.Errorf("ServedVersion() = %v, want the %v default", got, GroupVersionV1)
+	}
+}
+
+func TestWaitForServedVersionRetriesLookupFailures(t *testing.T) {
+	defer restoreServedVersion(t)()
+
+	disco := &failingDiscovery{DiscoveryInterface: discoveryServing(GroupVersionV1beta1)}
+	disco.remaining.Store(2)
+
+	WaitForServedVersion(context.Background(), disco)
+	if got := ServedVersion(); got != GroupVersionV1beta1 {
+		t.Fatalf("ServedVersion() = %v, want %v", got, GroupVersionV1beta1)
+	}
+	if got := disco.attempts.Load(); got < 3 {
+		t.Errorf("discovery attempts = %d, want at least 3", got)
+	}
+}
+
+func restoreServedVersion(t *testing.T) func() {
+	t.Helper()
+	original := ServedVersion()
+	return func() {
+		servedMutex.Lock()
+		defer servedMutex.Unlock()
+		servedVersion = original
 	}
 }

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -98,9 +98,7 @@ var (
 // ContextLoggerForResource provides a logger instance with context set for the provided object.
 func ContextLoggerForResource(log logr.Logger, obj client.Object) logr.Logger {
 	gvk := obj.GetObjectKind().GroupVersionKind()
-	name := obj.(metav1.ObjectMetaAccessor).GetObjectMeta().GetName()
-	namespace := obj.(metav1.ObjectMetaAccessor).GetObjectMeta().GetNamespace()
-	return log.WithValues("name", name, "namespace", namespace, "kind", gvk.Kind)
+	return log.WithValues("name", obj.GetName(), "namespace", obj.GetNamespace(), "kind", gvk.Kind)
 }
 
 // IgnoreObject returns true if the object has been marked as ignored by the user,

--- a/pkg/controller/utils/utils_test.go
+++ b/pkg/controller/utils/utils_test.go
@@ -32,6 +32,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
@@ -581,6 +582,22 @@ var _ = Describe("WaitToAddResourceWatch with custom predicates", func() {
 		// generation-based one). The custom predicate is wrapped via predicate.And(), so we
 		// just verify it was called and fires on resource version changes.
 		ctrl.AssertCalled(GinkgoT(), "WatchObject", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	It("should watch an unstructured object", func() {
+		u := &unstructured.Unstructured{}
+		u.SetGroupVersionKind(schema.GroupVersionKind{Group: "test.example.com", Version: "v1", Kind: "TestResource"})
+		u.SetName("default")
+
+		disc.On("ServerResourcesForGroupVersion", testGV).Return(&metav1.APIResourceList{
+			APIResources: []metav1.APIResource{{Kind: "TestResource"}},
+		})
+		ctrl.On("WatchObject", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+		flag := &ReadyFlag{}
+		WaitToAddResourceWatch(ctrl, k8sClient, log, flag, []client.Object{u}, predicate.ResourceVersionChangedPredicate{})
+
+		Expect(flag.IsReady()).To(BeTrue())
 	})
 
 	It("should work with a nil flag", func() {

--- a/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_felixconfigurations.yaml
@@ -302,17 +302,13 @@ spec:
                     packets from external sources are dropped. [Default: true]
                   type: boolean
                 bpfJITHardening:
-                  allOf:
-                    - enum:
-                        - Auto
-                        - Strict
-                    - enum:
-                        - Auto
-                        - Strict
                   description: |-
                     BPFJITHardening controls BPF JIT hardening. When set to "Auto", Felix will set JIT hardening to 1
                     if it detects the current value is 2 (strict mode that hurts performance). When set to "Strict",
                     Felix will not modify the JIT hardening setting. [Default: Auto]
+                  enum:
+                    - Auto
+                    - Strict
                   type: string
                 bpfKubeProxyHealthzPort:
                   description: |-
@@ -1223,6 +1219,11 @@ spec:
                   description: |-
                     PrometheusMetricsClientAuth specifies the client authentication type for the /metrics endpoint.
                     This determines how the server validates client certificates. Default is "NoClientCert".
+                  enum:
+                    - RequireAndVerifyClientCert
+                    - RequireAnyClientCert
+                    - VerifyClientCertIfGiven
+                    - NoClientCert
                   type: string
                 prometheusMetricsEnabled:
                   description:

--- a/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_felixconfigurations.yaml
+++ b/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_felixconfigurations.yaml
@@ -301,17 +301,13 @@ spec:
                     packets from external sources are dropped. [Default: true]
                   type: boolean
                 bpfJITHardening:
-                  allOf:
-                    - enum:
-                        - Auto
-                        - Strict
-                    - enum:
-                        - Auto
-                        - Strict
                   description: |-
                     BPFJITHardening controls BPF JIT hardening. When set to "Auto", Felix will set JIT hardening to 1
                     if it detects the current value is 2 (strict mode that hurts performance). When set to "Strict",
                     Felix will not modify the JIT hardening setting. [Default: Auto]
+                  enum:
+                    - Auto
+                    - Strict
                   type: string
                 bpfKubeProxyHealthzPort:
                   description: |-
@@ -1222,6 +1218,11 @@ spec:
                   description: |-
                     PrometheusMetricsClientAuth specifies the client authentication type for the /metrics endpoint.
                     This determines how the server validates client certificates. Default is "NoClientCert".
+                  enum:
+                    - RequireAndVerifyClientCert
+                    - RequireAnyClientCert
+                    - VerifyClientCertIfGiven
+                    - NoClientCert
                   type: string
                 prometheusMetricsEnabled:
                   description:

--- a/pkg/imports/crds/enterprise/v1.crd.projectcalico.org/crd.projectcalico.org_globalthreatfeeds.yaml
+++ b/pkg/imports/crds/enterprise/v1.crd.projectcalico.org/crd.projectcalico.org_globalthreatfeeds.yaml
@@ -192,6 +192,10 @@ spec:
                           type: array
                           x-kubernetes-list-type: atomic
                         url:
+                          description: |-
+                            URL is the location of the threat feed. Only the http and https schemes
+                            are permitted; other schemes (e.g. javascript:, data:, file:) are rejected.
+                          pattern: ^https?://
                           type: string
                       required:
                         - url

--- a/pkg/imports/crds/enterprise/v3.projectcalico.org/projectcalico.org_globalthreatfeeds.yaml
+++ b/pkg/imports/crds/enterprise/v3.projectcalico.org/projectcalico.org_globalthreatfeeds.yaml
@@ -196,6 +196,10 @@ spec:
                           type: array
                           x-kubernetes-list-type: atomic
                         url:
+                          description: |-
+                            URL is the location of the threat feed. Only the http and https schemes
+                            are permitted; other schemes (e.g. javascript:, data:, file:) are rejected.
+                          pattern: ^https?://
                           type: string
                       required:
                         - url

--- a/pkg/render/kubecontrollers/migration_rbac.go
+++ b/pkg/render/kubecontrollers/migration_rbac.go
@@ -60,6 +60,13 @@ func migrationRBACObjects() []client.Object {
 					Resources: []string{"daemonsets", "deployments"},
 					Verbs:     []string{"get", "list", "watch"},
 				},
+				{
+					// Without this the migration controller reads the cluster as manifest
+					// managed and tells the user to do the cutover by hand.
+					APIGroups: []string{"operator.tigera.io"},
+					Resources: []string{"installations"},
+					Verbs:     []string{"get", "list", "watch"},
+				},
 			},
 		},
 		&rbacv1.ClusterRoleBinding{

--- a/pkg/render/kubecontrollers/migration_rbac_test.go
+++ b/pkg/render/kubecontrollers/migration_rbac_test.go
@@ -79,6 +79,15 @@ var _ = Describe("MigrationRBACComponent", func() {
 			}))
 		})
 
+		It("should grant access to Installations", func() {
+			cr := rtest.GetResource(toCreate, "calico-kube-controllers-migration", "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
+			Expect(cr.Rules).To(ContainElement(rbacv1.PolicyRule{
+				APIGroups: []string{"operator.tigera.io"},
+				Resources: []string{"installations"},
+				Verbs:     []string{"get", "list", "watch"},
+			}))
+		})
+
 		It("should bind to the calico-kube-controllers service account", func() {
 			crb := rtest.GetResource(toCreate, "calico-kube-controllers-migration", "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding").(*rbacv1.ClusterRoleBinding)
 			Expect(crb.RoleRef).To(Equal(rbacv1.RoleRef{


### PR DESCRIPTION
## Description

The DatastoreMigration CRD moves to `migration.projectcalico.org/v1` in Calico v3.33, and the v3.33 CRD serves v1beta1 (deprecated) alongside v1 (storage). There's no single version the operator can hardcode and be right on every cluster, so it now resolves the served version from discovery at startup, preferring v1 and falling back to v1beta1. That version is used for:

- scheme registration
- the startup check for an already-migrated cluster
- both controller watches

Get it wrong and the watch never becomes ready, the migration phase reads as empty, and the apiserver controller re-creates the aggregated APIService while the migration is deleting it.

An earlier version of this PR assumed an upgraded v3.32 cluster had no CR left to watch, since applying the new CRD meant deleting the old one. Deleting the CRD runs the migration finalizer for real, which is why the new CRD serves both versions instead.

Related: [CORE-12573](https://tigera.atlassian.net/browse/CORE-12573)

```release-note
None
```

[CORE-12573]: https://tigera.atlassian.net/browse/CORE-12573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ