### PR TITLE
cloud: push only amd64 for the operator-cloud image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,11 +181,7 @@ PUSH_MANIFEST_IMAGE_PREFIXES=$(PUSH_IMAGE_PREFIXES:$(EXCLUDE_MANIFEST_REGISTRIES
 PUSH_NONMANIFEST_IMAGE_PREFIXES=$(filter-out $(PUSH_MANIFEST_IMAGE_PREFIXES),$(PUSH_IMAGE_PREFIXES))
 
 # Calico Cloud build variant. `make <target> VARIANT=cloud` builds and pushes the operator-cloud
-# image to GCR (gcr.io/tigera-tesla/operator-cloud), amd64 only, instead of the enterprise quay
-# image, and bakes cloud mode into the binary via CLOUD_LDFLAGS (see the operator build below).
-# Enterprise/OSS builds (VARIANT unset) are completely unaffected. PUSH_MANIFEST_IMAGE_PREFIXES and
-# PUSH_NONMANIFEST_IMAGE_PREFIXES above use recursive `=`, so they pick up these overrides.
-# Note: this is the same tigera/operator repo — only the published image differs (operator-cloud).
+# image to GCR (gcr.io/tigera-tesla/operator-cloud), amd64 only.
 CLOUD_LDFLAGS=
 ifeq ($(VARIANT),cloud)
 BUILD_IMAGE:=tigera-tesla/operator-cloud
@@ -193,7 +189,9 @@ BINARY_NAME:=operator-cloud
 IMAGE_REGISTRY:=gcr.io
 PUSH_IMAGE_PREFIXES:=gcr.io/
 EXCLUDE_MANIFEST_REGISTRIES:=gcr.io/
-VALIDARCHES:=amd64
+# amd64 only. Constrain ARCHES (not just VALIDARCHES) so push-all, which iterates ARCHES, does not
+# try to push arches that were never built.
+ARCHES:=amd64
 # Bake cloud mode into the operator binary so it cannot be disabled at runtime (see isCloudBuild in
 # cmd/cloud.go). buildVariant lives in package main, which the linker addresses as "main" (not by its
 # import path), so this -X target is "main.buildVariant" rather than a $(PACKAGE_NAME)-prefixed path.


### PR DESCRIPTION
## Description

Bug fix for the Calico Cloud release/CD tooling.

The cloud variant (`VARIANT=cloud`) builds and tags the `operator-cloud` image for **amd64 only**:
`image-all`, `tag-images-all`, and manifest creation all iterate `$(VALIDARCHES)`, which the cloud
block pinned to `amd64`. But `push-all` iterates `$(ARCHES)`, which was left at all four arches
(`amd64 arm64 ppc64le s390x`). So the post-merge CD `push-all` tried to push arches that were never
built, and failed:

```
docker push gcr.io/tigera-tesla/operator-cloud:master-arm64
tag does not exist: gcr.io/tigera-tesla/operator-cloud:master-arm64
make: *** [Makefile:213: sub-single-push-gcr.io___] Error 1
```

Fix: constrain `ARCHES:=amd64` in the cloud block instead of only `VALIDARCHES`. `VALIDARCHES`
derives from `ARCHES`, so every image target — build, tag, push, manifest — now agrees on amd64.
The change is inside the `ifeq ($(VARIANT),cloud)` block, so enterprise/OSS builds are unaffected.

**Testing** — verified target expansion with `make -pn`:

| Target | Enterprise | Cloud |
|---|---|---|
| `push-all` | `sub-push-amd64 sub-push-arm64 sub-push-ppc64le sub-push-s390x` | `sub-push-amd64` |
| `tag-images-all` | all four | `sub-tag-images-amd64` |

Enterprise expansion is unchanged; cloud `push-all` now matches what actually gets built.

**Components affected:** build/release tooling (`Makefile`) for the Calico Cloud operator image only.

Follow-up to #4980 (the cloud un-fork), which introduced the cloud variant.

## Release Note

```release-note
NONE
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
