### PR TITLE
cloud: let the environment override the cloud image and registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,13 +155,33 @@ CONTAINERIZED= mkdir -p .go-pkg-cache $(GOMOD_CACHE) && \
 
 DOCKER_RUN := $(CONTAINERIZED) $(CALICO_BUILD)
 
+# Calico Cloud build variant. `make <target> VARIANT=cloud` builds and pushes the operator-cloud
+# image to GCR (gcr.io/tigera-tesla/operator-cloud), amd64 only.
+# These sit before the enterprise defaults and use `?=` so the environment still wins: hashreleases
+# push the cloud image to the hashrelease registry instead (see hack/release/README.md).
+CLOUD_LDFLAGS=
+ifeq ($(VARIANT),cloud)
+BUILD_IMAGE?=tigera-tesla/operator-cloud
+BINARY_NAME?=operator-cloud
+IMAGE_REGISTRY?=gcr.io
+PUSH_IMAGE_PREFIXES?=gcr.io/
+EXCLUDE_MANIFEST_REGISTRIES?=gcr.io/
+# amd64 only. Constrain ARCHES (not just VALIDARCHES) so push-all, which iterates ARCHES, does not
+# try to push arches that were never built.
+ARCHES:=amd64
+# Bake cloud mode into the operator binary so it cannot be disabled at runtime (see isCloudBuild in
+# cmd/cloud.go). buildVariant lives in package main, which the linker addresses as "main" (not by its
+# import path), so this -X target is "main.buildVariant" rather than a $(PACKAGE_NAME)-prefixed path.
+CLOUD_LDFLAGS=-X main.buildVariant=cloud
+endif
+
 BUILD_IMAGE?=tigera/operator
 
 BUILD_DIR?=build/_output
 BINDIR?=$(BUILD_DIR)/bin
 
 # Name of the built operator binary. The Calico Cloud variant suffixes it with -cloud
-# (see VARIANT=cloud below) so the cloud artifact is easy to tell apart from the enterprise one.
+# (see VARIANT=cloud above) so the cloud artifact is easy to tell apart from the enterprise one.
 BINARY_NAME?=operator
 
 $(BUILD_DIR):
@@ -179,25 +199,6 @@ endif
 EXCLUDE_MANIFEST_REGISTRIES?=""
 PUSH_MANIFEST_IMAGE_PREFIXES=$(PUSH_IMAGE_PREFIXES:$(EXCLUDE_MANIFEST_REGISTRIES)%=)
 PUSH_NONMANIFEST_IMAGE_PREFIXES=$(filter-out $(PUSH_MANIFEST_IMAGE_PREFIXES),$(PUSH_IMAGE_PREFIXES))
-
-# Calico Cloud build variant. `make <target> VARIANT=cloud` builds and pushes the operator-cloud
-# image to GCR (gcr.io/tigera-tesla/operator-cloud), amd64 only.
-CLOUD_LDFLAGS=
-ifeq ($(VARIANT),cloud)
-BUILD_IMAGE:=tigera-tesla/operator-cloud
-BINARY_NAME:=operator-cloud
-IMAGE_REGISTRY:=gcr.io
-PUSH_IMAGE_PREFIXES:=gcr.io/
-EXCLUDE_MANIFEST_REGISTRIES:=gcr.io/
-# amd64 only. Constrain ARCHES (not just VALIDARCHES) so push-all, which iterates ARCHES, does not
-# try to push arches that were never built.
-ARCHES:=amd64
-# Bake cloud mode into the operator binary so it cannot be disabled at runtime (see isCloudBuild in
-# cmd/cloud.go). buildVariant lives in package main, which the linker addresses as "main" (not by its
-# import path), so this -X target is "main.buildVariant" rather than a $(PACKAGE_NAME)-prefixed path.
-CLOUD_LDFLAGS=-X main.buildVariant=cloud
-endif
-
 
 imagetag:
 ifndef IMAGETAG

--- a/hack/release/README.md
+++ b/hack/release/README.md
@@ -95,6 +95,12 @@ binary and the same targets — only a few defaults change (publish to `gcr.io/t
 a `-cloud`-suffixed version, no GitHub release). Those variant-dependent defaults are resolved at
 startup in `internal/setup`; see that package's doc comment for how and why.
 
+The cloud defaults for the published image (`BUILD_IMAGE`, `IMAGE_REGISTRY`, `PUSH_IMAGE_PREFIXES`)
+are set with `?=` in the Makefile, so the environment still wins. Calico Enterprise hashreleases use
+that: calico-private's release tool builds the cloud variant with `IMAGE_NAME=tigera/operator-cloud`
+and the hashrelease registry, so hashrelease images land next to the enterprise operator instead of
+in `gcr.io/tigera-tesla`.
+
 Here `RELEASE_TAG` is the operator version, which for cloud carries the `-cloud` suffix — not a
 separate git tag. CI never pushes a `-cloud` git tag: pushing a plain `vA.B.C` git tag builds both
 the enterprise image and, from the same commit with `VARIANT=cloud`, the `vA.B.C-cloud` image as


### PR DESCRIPTION
## Description

Type of fix: build system change, no runtime behaviour change.

The `VARIANT=cloud` block pinned `BUILD_IMAGE`, `IMAGE_REGISTRY` and `PUSH_IMAGE_PREFIXES` with
`:=`, and a Makefile assignment overrides the environment. That is what we want for a cloud release
— it should always land in `gcr.io/tigera-tesla/operator-cloud` — but it left no way to build the
cloud variant into a different registry. A Calico Enterprise hashrelease passes the hashrelease
registry and image name through the environment (`REGISTRY` / `IMAGE_NAME`, which the release tool
turns into `IMAGE_REGISTRY` / `BUILD_IMAGE`), and those were silently replaced with the tigera-tesla
values.

This moves the cloud block above the enterprise defaults and switches those three to `?=`, so:

- an environment override wins (hashreleases can target their own registry),
- the cloud values still apply when there is no override (`make release-tag VARIANT=cloud` is
  unchanged),
- enterprise/OSS builds are untouched.

`ARCHES` deliberately stays `:=` — the cloud variant is amd64 only by construction, and `push-all`
iterates `ARCHES`, so it must not pick up arches that were never built.

Why now: tigera/calico-private is adding the cloud operator image to enterprise hashreleases. It
needs the image to land next to the enterprise operator in the hashrelease registry, both to keep
dev artifacts out of the cloud release registry and because the hashrelease CI job's OIDC service
account is scoped to the hashrelease project, not tigera-tesla.

### Testing

Verified variable resolution for all three paths by evaluating the Makefile directly:

| | `BUILD_IMAGE` | `IMAGE_REGISTRY` | `ARCHES` | `CLOUD_LDFLAGS` |
|---|---|---|---|---|
| enterprise (no `VARIANT`) | `tigera/operator` | `quay.io` | all four | empty |
| `VARIANT=cloud` | `tigera-tesla/operator-cloud` | `gcr.io` | `amd64` | set |
| `VARIANT=cloud` + env override | `tigera/operator-cloud` | `gcr.io/unique-caldron-775/cnx` | `amd64` | set |

`hack/release` unit tests pass.

## Release Note

```release-note
None
```

## For PR author

- [x] Tests for change. (Makefile change; verified by evaluating all three variable-resolution paths, see above. No Go code changed.)
- [x] If changing pkg/apis/, run `make gen-files` (n/a)
- [x] If changing versions, run `make gen-versions` (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
