### PR TITLE
Create the node metrics service for Calico

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1256,6 +1256,9 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 	calicoVersion := components.CalicoRelease
 
 	felixPrometheusMetricsPort := defaultFelixMetricsDefaultPort
+	if felixConfiguration.Spec.PrometheusMetricsPort != nil {
+		felixPrometheusMetricsPort = *felixConfiguration.Spec.PrometheusMetricsPort
+	}
 
 	if instance.Spec.Variant.IsEnterprise() {
 
@@ -1267,10 +1270,6 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 			err := errors.New("felixConfiguration prometheusReporterPort=0 not supported")
 			r.status.SetDegraded(operatorv1.InvalidConfigurationError, "invalid metrics port", err, reqLogger)
 			return reconcile.Result{}, err
-		}
-
-		if felixConfiguration.Spec.PrometheusMetricsPort != nil {
-			felixPrometheusMetricsPort = *felixConfiguration.Spec.PrometheusMetricsPort
 		}
 
 		nodePrometheusTLS, err = certificateManager.GetOrCreateKeyPair(r.client, render.NodePrometheusTLSServerSecret, common.OperatorNamespace(), dns.GetServiceDNSNames(render.CalicoNodeMetricsService, common.CalicoNamespace, r.clusterDomain))

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -234,9 +234,12 @@ func (c *nodeComponent) Objects() ([]client.Object, []client.Object) {
 
 	var objsToDelete []client.Object
 
-	if c.cfg.Installation.Variant.IsEnterprise() {
-		// Include Service for exposing node metrics.
+	// Enterprise always has its reporter ports to expose. Calico only has Felix's port, so there is
+	// nothing to expose until Felix metrics are turned on.
+	if c.cfg.Installation.Variant.IsEnterprise() || c.cfg.FelixPrometheusMetricsEnabled {
 		objs = append(objs, c.nodeMetricsService())
+	} else {
+		objsToDelete = append(objsToDelete, c.nodeMetricsService())
 	}
 
 	cniConfig := c.nodeCNIConfigMap()
@@ -1829,24 +1832,27 @@ func (c *nodeComponent) nodeLivenessReadinessProbes() (*corev1.Probe, *corev1.Pr
 	return lp, rp
 }
 
-// nodeMetricsService creates a Service which exposes two endpoints on calico/node for
-// reporting Prometheus metrics (for policy enforcement activity and BGP stats).
-// This service is used internally by Calico Enterprise and is separate from general
-// Prometheus metrics which are user-configurable.
+// nodeMetricsService creates a Service for scraping Prometheus metrics from calico/node.
 func (c *nodeComponent) nodeMetricsService() *corev1.Service {
-	ports := []corev1.ServicePort{
-		{
-			Name:       "calico-metrics-port",
-			Port:       int32(c.cfg.NodeReporterMetricsPort),
-			TargetPort: intstr.FromInt(c.cfg.NodeReporterMetricsPort),
-			Protocol:   corev1.ProtocolTCP,
-		},
-		{
-			Name:       "calico-bgp-metrics-port",
-			Port:       nodeBGPReporterPort,
-			TargetPort: intstr.FromInt(int(nodeBGPReporterPort)),
-			Protocol:   corev1.ProtocolTCP,
-		},
+	var ports []corev1.ServicePort
+
+	if c.cfg.Installation.Variant.IsEnterprise() {
+		// Enterprise reports policy enforcement activity and BGP stats of its own, separately from
+		// the general Prometheus metrics the user configures through Felix.
+		ports = append(ports,
+			corev1.ServicePort{
+				Name:       "calico-metrics-port",
+				Port:       int32(c.cfg.NodeReporterMetricsPort),
+				TargetPort: intstr.FromInt(c.cfg.NodeReporterMetricsPort),
+				Protocol:   corev1.ProtocolTCP,
+			},
+			corev1.ServicePort{
+				Name:       "calico-bgp-metrics-port",
+				Port:       nodeBGPReporterPort,
+				TargetPort: intstr.FromInt(int(nodeBGPReporterPort)),
+				Protocol:   corev1.ProtocolTCP,
+			},
+		)
 	}
 
 	if c.cfg.FelixPrometheusMetricsEnabled {

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -373,6 +373,35 @@ var _ = Describe("Node rendering tests", func() {
 				verifyProbesAndLifecycle(ds, false, false)
 			})
 
+			It("should render a metrics service with only Felix's port when Felix metrics are enabled", func() {
+				cfg.FelixPrometheusMetricsEnabled = true
+				cfg.FelixPrometheusMetricsPort = 9091
+
+				component := render.Node(&cfg)
+				Expect(component.ResolveImages(nil)).To(BeNil())
+				resources, _ := component.Objects()
+
+				ms := rtest.GetResource(resources, "calico-node-metrics", "calico-system", "", "v1", "Service").(*corev1.Service)
+				Expect(ms.Spec.Ports).To(Equal([]corev1.ServicePort{
+					{
+						Name:       "felix-metrics-port",
+						Port:       9091,
+						TargetPort: intstr.FromInt(9091),
+						Protocol:   corev1.ProtocolTCP,
+					},
+				}))
+				Expect(ms.Spec.ClusterIP).To(Equal("None"))
+			})
+
+			It("should delete the metrics service when Felix metrics are disabled", func() {
+				component := render.Node(&cfg)
+				Expect(component.ResolveImages(nil)).To(BeNil())
+				resources, objsToDelete := component.Objects()
+
+				Expect(rtest.GetResource(resources, "calico-node-metrics", "calico-system", "", "v1", "Service")).To(BeNil())
+				Expect(rtest.GetResource(objsToDelete, "calico-node-metrics", "calico-system", "", "v1", "Service")).ToNot(BeNil())
+			})
+
 			It("should render node correctly for BPF dataplane", func() {
 				expectedResources := []struct {
 					name    string


### PR DESCRIPTION
## Description

The operator already creates metrics Services for Typha and kube-controllers, but not for Felix, so Calico users following the [component metrics guide](https://docs.tigera.io/calico/latest/operations/monitor/monitor-component-metrics) have to hand-roll one. This renders the existing `calico-node-metrics` Service for Calico too, carrying only Felix's port, and removes it again if Felix metrics are turned back off. Enterprise keeps its reporter and BGP ports, unchanged.

Also fixes the Felix metrics port being read out of FelixConfiguration only for Enterprise. Nothing consumed it in a Calico install before this change, but with the Service rendered it would have pointed at the default port no matter what the user configured.

Windows is not covered here. The Windows metrics Service has never carried Felix's port, even in Enterprise, and getting one to work needs a firewall rule, so it wants its own change.

Related: https://github.com/projectcalico/calico/issues/10755, [CORE-13310](https://tigera.atlassian.net/browse/CORE-13310)

## Release Note

```release-note
Calico installations now get a Service for scraping Felix Prometheus metrics when Felix metrics are enabled, so one no longer has to be created by hand.
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`



[CORE-13310]: https://tigera.atlassian.net/browse/CORE-13310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ