### PR TITLE
Correct the Variant doc comment on Installation

### DIFF
--- a/api/v1/installation_types.go
+++ b/api/v1/installation_types.go
@@ -48,7 +48,7 @@ type Installation struct {
 type InstallationSpec struct {
 	// Variant is the product to install - one of Calico or CalicoEnterprise.
 	// TigeraSecureEnterprise is also accepted as a deprecated alias for CalicoEnterprise.
-	// Default: Calico
+	// If left unset, the operator fills in the variant it is running as.
 	// +optional
 	// +kubebuilder:validation:Enum=Calico;CalicoEnterprise;TigeraSecureEnterprise
 	Variant ProductVariant `json:"variant,omitempty"`

--- a/pkg/imports/crds/operator/operator.tigera.io_installations.yaml
+++ b/pkg/imports/crds/operator/operator.tigera.io_installations.yaml
@@ -9318,7 +9318,7 @@ spec:
                   description: |-
                     Variant is the product to install - one of Calico or CalicoEnterprise.
                     TigeraSecureEnterprise is also accepted as a deprecated alias for CalicoEnterprise.
-                    Default: Calico
+                    If left unset, the operator fills in the variant it is running as.
                   enum:
                     - Calico
                     - CalicoEnterprise
@@ -18807,7 +18807,7 @@ spec:
                       description: |-
                         Variant is the product to install - one of Calico or CalicoEnterprise.
                         TigeraSecureEnterprise is also accepted as a deprecated alias for CalicoEnterprise.
-                        Default: Calico
+                        If left unset, the operator fills in the variant it is running as.
                       enum:
                         - Calico
                         - CalicoEnterprise


### PR DESCRIPTION
The variant field on Installation documents itself as defaulting to Calico, which reads like an API guarantee. There is no CRD-level default on the field, and the operator now fills in whichever variant it booted as, so the comment is wrong either way.

Deliberately not adding a schema default to fix it: the overlay merge treats the empty value as "not specified", so a default would be written into the overlay object too and would win the merge, silently changing the variant for Enterprise clusters that use an overlay for something unrelated. Defaults can't be scoped to a single object name.

CORE-13244

```release-note
None
```
