### PR TITLE
Release held workflow runs on auto-sync PRs

### DIFF
--- a/.github/workflows/sync-versions.yml
+++ b/.github/workflows/sync-versions.yml
@@ -93,3 +93,28 @@ jobs:
             exit 0
           fi
           gh pr review "$PR" -R "$REPO" --approve
+
+      # GitHub holds Actions runs on a PR pushed by github-actions[bot] in the
+      # action_required state, which leaves the PR permanently unmergeable.
+      # Release them as marvin-tigera.
+      - name: Approve held workflow runs
+        if: steps.cpr.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ secrets.MARVIN_PAT }}
+          PR: ${{ steps.cpr.outputs.pull-request-number }}
+          REPO: ${{ github.repository }}
+        run: |
+          sha=$(gh pr view "$PR" -R "$REPO" --json headRefOid -q .headRefOid)
+          for _ in $(seq 1 6); do
+            runs=$(gh api "repos/$REPO/actions/runs?head_sha=$sha" \
+              --jq '.workflow_runs[] | select(.conclusion == "action_required") | .id')
+            if [ -n "$runs" ]; then
+              for id in $runs; do
+                echo "Approving held run $id"
+                gh api -X POST "repos/$REPO/actions/runs/$id/approve"
+              done
+              break
+            fi
+            echo "No held runs for $sha yet; waiting."
+            sleep 10
+          done


### PR DESCRIPTION
## Description

The hourly version sync PRs stopped auto-merging. GitHub holds Actions runs on a PR whose head was pushed by `github-actions[bot]` in the `action_required` state, waiting for someone to click "Approve and run". Nobody clicks it, so the CodeQL run never reaches a conclusion, the PR stays `UNSTABLE`, and Marvin won't merge it. https://github.com/tigera/operator/pull/5136 sat like that. This adds a step that releases those held runs as marvin-tigera.

The step keys off the PR number rather than the create-pull-request operation, so a run held during an earlier hour still gets released on a later tick when there's nothing new to sync. The poll covers the gap between the branch push and GitHub creating the run.

Verified the mechanism by hand on #5136: approving run 30894181176 through the same API moved CodeQL from `action_required` to running.

Affects CI only.

## Release Note

```release-note
NONE
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`
