### PR TITLE
Serve whisker over HTTPS

### DIFF
--- a/pkg/controller/whisker/controller.go
+++ b/pkg/controller/whisker/controller.go
@@ -78,6 +78,7 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 
 	for _, secretName := range []string{
 		certificatemanagement.CASecretName,
+		whisker.WhiskerKeyPairSecret,
 		goldmane.GoldmaneKeyPairSecret,
 	} {
 		if err = utils.AddSecretsWatch(c, secretName, common.OperatorNamespace()); err != nil {
@@ -200,11 +201,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 
+	whiskerCertificateNames := dns.GetServiceDNSNames(whisker.WhiskerName, whisker.WhiskerNamespace, r.clusterDomain)
+	whiskerCertificateNames = append(whiskerCertificateNames, "localhost", "127.0.0.1")
+	whiskerKeyPair, err := certificateManager.GetOrCreateKeyPair(r.cli, whisker.WhiskerKeyPairSecret, whisker.WhiskerNamespace, whiskerCertificateNames)
+	if err != nil {
+		r.status.SetDegraded(operatorv1.ResourceCreateError, "Error creating whisker TLS certificate", err, reqLogger)
+		return reconcile.Result{}, err
+	}
+
 	whiskerBackendCertificateNames := dns.GetServiceDNSNames("whisker-backend", whisker.WhiskerNamespace, r.clusterDomain)
 	whiskerBackendCertificateNames = append(whiskerBackendCertificateNames, "localhost", "127.0.0.1")
 	backendKeyPair, err := certificateManager.GetOrCreateKeyPair(r.cli, whisker.WhiskerBackendKeyPairSecret, whisker.WhiskerNamespace, whiskerBackendCertificateNames)
 	if err != nil {
-		r.status.SetDegraded(operatorv1.ResourceCreateError, "Error creating whisker-backend TLS certificate", err, log)
+		r.status.SetDegraded(operatorv1.ResourceCreateError, "Error creating whisker-backend TLS certificate", err, reqLogger)
 		return reconcile.Result{}, err
 	}
 
@@ -242,6 +251,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		OpenShift:             r.provider.IsOpenShift(),
 		Installation:          installationSpec,
 		TrustedCertBundle:     trustedBundle,
+		WhiskerKeyPair:        whiskerKeyPair,
 		WhiskerBackendKeyPair: backendKeyPair,
 		Whisker:               whiskerCR,
 		ClusterDomain:         r.clusterDomain,
@@ -262,6 +272,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		TruthNamespace:  common.OperatorNamespace(),
 		ServiceAccounts: []string{whisker.WhiskerServiceAccountName},
 		KeyPairOptions: []rcertificatemanagement.KeyPairOption{
+			rcertificatemanagement.NewKeyPairOption(whiskerKeyPair, true, true),
 			rcertificatemanagement.NewKeyPairOption(backendKeyPair, true, true),
 		},
 		TrustedBundle: trustedBundle,

--- a/pkg/controller/whisker/controller.go
+++ b/pkg/controller/whisker/controller.go
@@ -202,7 +202,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	whiskerCertificateNames := dns.GetServiceDNSNames(whisker.WhiskerName, whisker.WhiskerNamespace, r.clusterDomain)
-	whiskerCertificateNames = append(whiskerCertificateNames, "localhost", "127.0.0.1")
+	whiskerCertificateNames = append(whiskerCertificateNames, "localhost")
 	whiskerKeyPair, err := certificateManager.GetOrCreateKeyPair(r.cli, whisker.WhiskerKeyPairSecret, whisker.WhiskerNamespace, whiskerCertificateNames)
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceCreateError, "Error creating whisker TLS certificate", err, reqLogger)

--- a/pkg/controller/whisker/controller_test.go
+++ b/pkg/controller/whisker/controller_test.go
@@ -36,8 +36,10 @@ import (
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/apis"
 	"github.com/tigera/operator/pkg/controller/status"
+	"github.com/tigera/operator/pkg/render/whisker"
 	admregv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -136,6 +138,25 @@ var _ = Describe("whisker controller tests", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(cli.Get(ctx, types.NamespacedName{Name: installation.Name}, installation)).ShouldNot(HaveOccurred())
 			_ = installation
+		})
+
+		It("should create the whisker TLS key pairs", func() {
+			Expect(cli.Create(ctx, installation)).To(BeNil())
+			reconciler := Reconciler{
+				cli:      cli,
+				scheme:   scheme,
+				provider: operatorv1.ProviderNone,
+				status:   mockStatus,
+			}
+			_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "default", Namespace: "calico-system"}})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			for _, name := range []string{whisker.WhiskerKeyPairSecret, whisker.WhiskerBackendKeyPairSecret} {
+				secret := &corev1.Secret{}
+				Expect(cli.Get(ctx, types.NamespacedName{Name: name, Namespace: common.OperatorNamespace()}, secret)).ShouldNot(HaveOccurred())
+				Expect(secret.Data).To(HaveKey("tls.crt"))
+				Expect(secret.Data).To(HaveKey("tls.key"))
+			}
 		})
 	})
 })

--- a/pkg/render/whisker/component.go
+++ b/pkg/render/whisker/component.go
@@ -51,7 +51,9 @@ const (
 	WhiskerContainerName        = "whisker"
 	WhiskerBackendContainerName = "whisker-backend"
 
+	WhiskerKeyPairSecret        = "whisker-key-pair"
 	WhiskerBackendKeyPairSecret = "whisker-backend-key-pair"
+	WhiskerServicePort          = 8443
 	GoldmaneDeploymentName      = "goldmane"
 	GoldmaneServicePort         = 7443
 	GoldmaneNamespace           = common.CalicoNamespace
@@ -82,6 +84,7 @@ type Configuration struct {
 	OpenShift             bool
 	Installation          *operatorv1.InstallationSpec
 	TrustedCertBundle     certificatemanagement.TrustedBundleRO
+	WhiskerKeyPair        certificatemanagement.KeyPairInterface
 	WhiskerBackendKeyPair certificatemanagement.KeyPairInterface
 	Whisker               *operatorv1.Whisker
 	ClusterID             string
@@ -173,6 +176,7 @@ func (c *Component) whiskerContainer() corev1.Container {
 				MountPath: configMountPath,
 				ReadOnly:  true,
 			},
+			c.cfg.WhiskerKeyPair.VolumeMount(c.SupportedOSType()),
 		},
 	}
 }
@@ -184,7 +188,7 @@ func (c *Component) whiskerService() *corev1.Service {
 			Namespace: WhiskerNamespace,
 		},
 		Spec: corev1.ServiceSpec{
-			Ports: []corev1.ServicePort{{Port: 8081}},
+			Ports: []corev1.ServicePort{{Port: WhiskerServicePort}},
 			Selector: map[string]string{
 				"k8s-app": WhiskerDeploymentName,
 			},
@@ -203,6 +207,8 @@ func (c *Component) whiskerBackendContainer() corev1.Container {
 			{Name: "GOLDMANE_HOST", Value: fmt.Sprintf("goldmane.%s.svc.%s:7443", GoldmaneNamespace, c.cfg.ClusterDomain)},
 			{Name: "TLS_CERT_PATH", Value: c.cfg.WhiskerBackendKeyPair.VolumeMountCertificateFilePath()},
 			{Name: "TLS_KEY_PATH", Value: c.cfg.WhiskerBackendKeyPair.VolumeMountKeyFilePath()},
+			{Name: "SERVER_TLS_CERT_PATH", Value: c.cfg.WhiskerBackendKeyPair.VolumeMountCertificateFilePath()},
+			{Name: "SERVER_TLS_KEY_PATH", Value: c.cfg.WhiskerBackendKeyPair.VolumeMountKeyFilePath()},
 		},
 		SecurityContext: securitycontext.NewNonRootContext(),
 		VolumeMounts: append(
@@ -223,6 +229,9 @@ func (c *Component) deployment() *appsv1.Deployment {
 		// Add the trusted cert bundle volume to the pod.
 		c.cfg.TrustedCertBundle.Volume(),
 
+		// Add the whisker TLS key pair volume (used by nginx for HTTPS).
+		c.cfg.WhiskerKeyPair.Volume(),
+
 		// Add the whisker backend key pair volume to the pod.
 		c.cfg.WhiskerBackendKeyPair.Volume(),
 
@@ -235,6 +244,14 @@ func (c *Component) deployment() *appsv1.Deployment {
 				},
 			},
 		},
+	}
+
+	// Both key pairs are served at process startup (nginx and the backend), so
+	// rotate the pod when either changes. The trusted bundle is only used by a
+	// client that picks up changes without a restart.
+	annotations := map[string]string{
+		c.cfg.WhiskerKeyPair.HashAnnotationKey():        c.cfg.WhiskerKeyPair.HashAnnotationValue(),
+		c.cfg.WhiskerBackendKeyPair.HashAnnotationKey(): c.cfg.WhiskerBackendKeyPair.HashAnnotationValue(),
 	}
 
 	return &appsv1.Deployment{
@@ -250,7 +267,8 @@ func (c *Component) deployment() *appsv1.Deployment {
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: WhiskerDeploymentName,
+					Name:        WhiskerDeploymentName,
+					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
 					NodeSelector:       c.cfg.Installation.ControlPlaneNodeSelector,

--- a/pkg/render/whisker/component_test.go
+++ b/pkg/render/whisker/component_test.go
@@ -36,6 +36,7 @@ import (
 )
 
 var (
+	defaultWhiskerKeyPair    = certificatemanagement.NewKeyPair(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: whisker.WhiskerKeyPairSecret}}, nil, "")
 	defaultTLSKeyPair        = certificatemanagement.NewKeyPair(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "key-pair"}}, nil, "")
 	defaultTrustedCertBundle = certificatemanagement.CreateTrustedBundle(nil)
 	numExpectedObjects       = 5
@@ -64,6 +65,7 @@ var _ = Describe("ComponentRendering", func() {
 					Variant:            operatorv1.Calico,
 				},
 				TrustedCertBundle:     defaultTrustedCertBundle,
+				WhiskerKeyPair:        defaultWhiskerKeyPair,
 				WhiskerBackendKeyPair: defaultTLSKeyPair,
 				Whisker:               &operatorv1.Whisker{Spec: operatorv1.WhiskerSpec{Notifications: ptr.To(operatorv1.Enabled)}},
 			},
@@ -76,6 +78,7 @@ var _ = Describe("ComponentRendering", func() {
 					Variant:            operatorv1.CalicoEnterprise,
 				},
 				TrustedCertBundle:     defaultTrustedCertBundle,
+				WhiskerKeyPair:        defaultWhiskerKeyPair,
 				WhiskerBackendKeyPair: defaultTLSKeyPair,
 				Whisker:               &operatorv1.Whisker{Spec: operatorv1.WhiskerSpec{Notifications: ptr.To(operatorv1.Enabled)}},
 			},
@@ -99,6 +102,7 @@ var _ = Describe("ComponentRendering", func() {
 					Variant:            operatorv1.Calico,
 				},
 				TrustedCertBundle:     defaultTrustedCertBundle,
+				WhiskerKeyPair:        defaultWhiskerKeyPair,
 				WhiskerBackendKeyPair: defaultTLSKeyPair,
 				Whisker:               &operatorv1.Whisker{Spec: operatorv1.WhiskerSpec{Notifications: ptr.To(operatorv1.Enabled)}},
 				ClusterID:             "test-cluster-id",
@@ -120,6 +124,10 @@ var _ = Describe("ComponentRendering", func() {
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: whisker.WhiskerDeploymentName,
+							Annotations: map[string]string{
+								defaultWhiskerKeyPair.HashAnnotationKey(): defaultWhiskerKeyPair.HashAnnotationValue(),
+								defaultTLSKeyPair.HashAnnotationKey():     defaultTLSKeyPair.HashAnnotationValue(),
+							},
 						},
 						Spec: corev1.PodSpec{
 							ServiceAccountName: whisker.WhiskerServiceAccountName,
@@ -142,6 +150,7 @@ var _ = Describe("ComponentRendering", func() {
 											MountPath: "/etc/nginx/conf.d",
 											ReadOnly:  true,
 										},
+										defaultWhiskerKeyPair.VolumeMount(rmeta.OSTypeLinux),
 									},
 								},
 								{
@@ -154,6 +163,8 @@ var _ = Describe("ComponentRendering", func() {
 										{Name: "GOLDMANE_HOST", Value: "goldmane.calico-system.svc.cluster.domain:7443"},
 										{Name: "TLS_CERT_PATH", Value: defaultTLSKeyPair.VolumeMountCertificateFilePath()},
 										{Name: "TLS_KEY_PATH", Value: defaultTLSKeyPair.VolumeMountKeyFilePath()},
+										{Name: "SERVER_TLS_CERT_PATH", Value: defaultTLSKeyPair.VolumeMountCertificateFilePath()},
+										{Name: "SERVER_TLS_KEY_PATH", Value: defaultTLSKeyPair.VolumeMountKeyFilePath()},
 									},
 									SecurityContext: securitycontext.NewNonRootContext(),
 									VolumeMounts: append(
@@ -163,6 +174,7 @@ var _ = Describe("ComponentRendering", func() {
 							},
 							Volumes: []corev1.Volume{
 								defaultTrustedCertBundle.Volume(),
+								defaultWhiskerKeyPair.Volume(),
 								defaultTLSKeyPair.Volume(),
 								{
 									Name: "nginx-config",
@@ -187,6 +199,7 @@ var _ = Describe("ComponentRendering", func() {
 				Variant:            operatorv1.Calico,
 			},
 			TrustedCertBundle:     defaultTrustedCertBundle,
+			WhiskerKeyPair:        defaultWhiskerKeyPair,
 			WhiskerBackendKeyPair: defaultTLSKeyPair,
 			Whisker:               &operatorv1.Whisker{Spec: operatorv1.WhiskerSpec{Notifications: ptr.To(operatorv1.Enabled)}},
 			ClusterID:             "test-cluster-id",
@@ -217,6 +230,7 @@ var _ = Describe("ComponentRendering", func() {
 				},
 			},
 			TrustedCertBundle:     defaultTrustedCertBundle,
+			WhiskerKeyPair:        defaultWhiskerKeyPair,
 			WhiskerBackendKeyPair: defaultTLSKeyPair,
 			Whisker:               &operatorv1.Whisker{Spec: operatorv1.WhiskerSpec{Notifications: ptr.To(operatorv1.Enabled)}},
 			ClusterID:             "test-cluster-id",
@@ -233,6 +247,26 @@ var _ = Describe("ComponentRendering", func() {
 		actual, ok := config.Data["default.conf"]
 		Expect(ok).To(BeTrue(), "expected default.conf to be present in config map")
 		Expect(actual).To(Equal(whisker.NginxConfigDual))
+	})
+
+	It("should render a service with HTTPS port", func() {
+		cfg := &whisker.Configuration{
+			Installation: &operatorv1.InstallationSpec{
+				KubernetesProvider: operatorv1.ProviderGKE,
+				Variant:            operatorv1.Calico,
+			},
+			TrustedCertBundle:     defaultTrustedCertBundle,
+			WhiskerKeyPair:        defaultWhiskerKeyPair,
+			WhiskerBackendKeyPair: defaultTLSKeyPair,
+			Whisker:               &operatorv1.Whisker{Spec: operatorv1.WhiskerSpec{Notifications: ptr.To(operatorv1.Enabled)}},
+		}
+		component := whisker.Whisker(cfg)
+		objsToCreate, _ := component.Objects()
+
+		svc, err := rtest.GetResourceOfType[*corev1.Service](objsToCreate, "whisker", whisker.WhiskerNamespace)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(svc.Spec.Ports).To(HaveLen(1))
+		Expect(svc.Spec.Ports[0].Port).To(Equal(int32(whisker.WhiskerServicePort)))
 	})
 
 	It("Should apply overrides", func() {
@@ -330,7 +364,15 @@ var _ = Describe("ComponentRendering", func() {
 		deployment, err := GetOverriddenWhiskerDeployment(overrides)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(deployment.Spec.Template.ObjectMeta.Labels).To(Equal(podLabels))
-		Expect(deployment.Spec.Template.ObjectMeta.Annotations).To(Equal(podAnnotations))
+		// Override annotations are merged on top of the rendered key pair hash annotations.
+		expectedAnnotations := map[string]string{
+			defaultWhiskerKeyPair.HashAnnotationKey(): defaultWhiskerKeyPair.HashAnnotationValue(),
+			defaultTLSKeyPair.HashAnnotationKey():     defaultTLSKeyPair.HashAnnotationValue(),
+		}
+		for k, v := range podAnnotations {
+			expectedAnnotations[k] = v
+		}
+		Expect(deployment.Spec.Template.ObjectMeta.Annotations).To(Equal(expectedAnnotations))
 		Expect(deployment.Spec.Template.Spec.Affinity).To(Equal(affinity))
 		Expect(deployment.Spec.Template.Spec.TopologySpreadConstraints).To(Equal(topologyConstraints))
 		Expect(deployment.Spec.Template.Spec.NodeSelector).To(Equal(nodeSelector))
@@ -348,6 +390,7 @@ func GetOverriddenWhiskerDeployment(overrides *operatorv1.WhiskerDeployment) (*a
 			Variant:            operatorv1.Calico,
 		},
 		TrustedCertBundle:     defaultTrustedCertBundle,
+		WhiskerKeyPair:        defaultWhiskerKeyPair,
 		WhiskerBackendKeyPair: defaultTLSKeyPair,
 		Whisker: &operatorv1.Whisker{
 			Spec: operatorv1.WhiskerSpec{

--- a/pkg/render/whisker/nginx-v4.conf
+++ b/pkg/render/whisker/nginx-v4.conf
@@ -1,7 +1,11 @@
 # Nginx configuration for Whisker on systems that do not support Ipv6.
 server {
-    # Listen on all.
-    listen 0.0.0.0:8081;
+    # Listen on all with TLS.
+    listen 0.0.0.0:8443 ssl;
+
+    ssl_certificate /whisker-key-pair/tls.crt;
+    ssl_certificate_key /whisker-key-pair/tls.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
 
     server_tokens off;
 
@@ -26,7 +30,8 @@ server {
 
     location /whisker-backend/ {
         rewrite ^/whisker-backend/(.*)$ /$1 break;
-        proxy_pass http://localhost:3002;
+        proxy_pass https://localhost:3002;
+        proxy_ssl_verify off;
         proxy_buffering off;
         proxy_request_buffering off;
         proxy_cache off;

--- a/pkg/render/whisker/nginx.conf
+++ b/pkg/render/whisker/nginx.conf
@@ -1,8 +1,12 @@
 # Nginx configuration for Whisker on systems that support IPv6.
 server {
-    # Listen on all.
-    listen 0.0.0.0:8081;
-    listen [::]:8081 ipv6only=on;
+    # Listen on all with TLS.
+    listen 0.0.0.0:8443 ssl;
+    listen [::]:8443 ssl ipv6only=on;
+
+    ssl_certificate /whisker-key-pair/tls.crt;
+    ssl_certificate_key /whisker-key-pair/tls.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
 
     server_tokens off;
 
@@ -27,7 +31,8 @@ server {
 
     location /whisker-backend/ {
         rewrite ^/whisker-backend/(.*)$ /$1 break;
-        proxy_pass http://localhost:3002;
+        proxy_pass https://localhost:3002;
+        proxy_ssl_verify off;
         proxy_buffering off;
         proxy_request_buffering off;
         proxy_cache off;


### PR DESCRIPTION
## Description

Feature: whisker's UI and backend are now served over HTTPS.

- New `whisker-key-pair` certificate for nginx; both nginx configs
  serve TLS on 8443 (TLS 1.2/1.3 only) and proxy `/whisker-backend/`
  to the backend over https.
- The whisker service moves from 8081 to 8443. UI access is via
  `kubectl port-forward` at `https://localhost:8443` (self-signed CA).
  No NetworkPolicy changes: port-forward enters through the pod's
  loopback and is not subject to policy. The gateway-scoped ingress
  rule ships with the `spec.gateway` (PMREQ-821) slice.
- whisker-backend gets `SERVER_TLS_CERT_PATH` / `SERVER_TLS_KEY_PATH`
  env vars (from the existing backend key pair). With
  projectcalico/calico#13436 the backend is HTTPS-only and these vars
  are required.
- The pod template carries hash annotations for both key pairs, so
  cert rotation restarts nginx and the backend.

Companion: projectcalico/calico#13436 (backend HTTPS-only + e2e).

**Merge order: this operator PR merges first, then the calico PR.**
This PR is safe to merge alone: the current backend image ignores the
new env vars, so the existing e2e keeps passing; only direct whisker
UI access on master dev clusters is degraded until the calico PR
lands. Once the calico PR merges, the backend requires the env vars —
so image upgrades without this operator change crashloop loudly
rather than serving plain HTTP.

Testing:
- Render unit tests updated and extended (service port, env vars,
  volumes, rotation annotations); controller test asserts both key
  pair secrets are created on reconcile.
- Verified end to end on a kadm cluster: nginx (8443, TLS) ->
  whisker-backend (3002, TLS) -> Goldmane (7443, mTLS), flows visible
  in the UI, plain HTTP on 8443 rejected with 400, TLS 1.1 handshake
  refused, rendered NetworkPolicy identical to master.

## Release Note

```release-note
Whisker is now served over HTTPS on port 8443.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)