### PR TITLE
Only create the dex TLS key pair when dex is enabled

### DIFF
--- a/pkg/controller/authentication/authentication_controller.go
+++ b/pkg/controller/authentication/authentication_controller.go
@@ -278,11 +278,21 @@ func (r *ReconcileAuthentication) Reconcile(ctx context.Context, request reconci
 		return reconcile.Result{}, err
 	}
 
-	dnsNames := dns.GetServiceDNSNames(render.DexObjectName, render.DexNamespace, r.clusterDomain)
-	tlsKeyPair, err := certificateManager.GetOrCreateKeyPair(r.client, render.DexTLSSecretName, common.OperatorNamespace(), dnsNames)
-	if err != nil {
-		r.status.SetDegraded(oprv1.ResourceReadError, "Unable to get or create tls key pair", err, reqLogger)
-		return reconcile.Result{}, err
+	enableDex := utils.DexEnabled(authentication)
+
+	// Only maintain a key pair for dex when dex is actually deployed. GetOrCreateKeyPair generates a
+	// new key pair whenever the existing secret is missing, expired or otherwise unusable, but the
+	// component that persists it is only rendered when dex is enabled. Calling it unconditionally
+	// therefore generates and discards a key pair on every reconcile, indefinitely, on clusters that
+	// do not run dex.
+	var tlsKeyPair certificatemanagement.KeyPairInterface
+	if enableDex {
+		dnsNames := dns.GetServiceDNSNames(render.DexObjectName, render.DexNamespace, r.clusterDomain)
+		tlsKeyPair, err = certificateManager.GetOrCreateKeyPair(r.client, render.DexTLSSecretName, common.OperatorNamespace(), dnsNames)
+		if err != nil {
+			r.status.SetDegraded(oprv1.ResourceReadError, "Unable to get or create tls key pair", err, reqLogger)
+			return reconcile.Result{}, err
+		}
 	}
 
 	// Dex needs to trust a public CA, so we mount all the system certificates.
@@ -377,8 +387,6 @@ func (r *ReconcileAuthentication) Reconcile(ctx context.Context, request reconci
 	}
 	r.lastAvailabilityTransition = currentAvailabilityTransition
 
-	enableDex := utils.DexEnabled(authentication)
-
 	// DexConfig adds convenience methods around dex related objects in k8s and can be used to configure Dex.
 	dexCfg := render.NewDexConfig(installationSpec.CertificateManagement, authentication, idpSecret, secretProviderClass, r.clusterDomain)
 
@@ -431,9 +439,11 @@ func (r *ReconcileAuthentication) Reconcile(ctx context.Context, request reconci
 	}
 
 	// Check BYO certificate expiry warnings.
-	certificatemanagement.CheckKeyPairWarnings(map[string]certificatemanagement.KeyPairInterface{
-		render.DexTLSSecretName: tlsKeyPair,
-	}, r.status)
+	if enableDex {
+		certificatemanagement.CheckKeyPairWarnings(map[string]certificatemanagement.KeyPairInterface{
+			render.DexTLSSecretName: tlsKeyPair,
+		}, r.status)
+	}
 
 	// Clear the degraded bit if we've reached this far.
 	r.status.ClearDegraded()

--- a/pkg/render/dex.go
+++ b/pkg/render/dex.go
@@ -130,17 +130,34 @@ func (*dexComponent) SupportedOSType() rmeta.OSType {
 
 func (c *dexComponent) Objects() ([]client.Object, []client.Object) {
 
+	// c.deployment() and c.configMap() panic on a nil TLSKeyPair, which is what dex being disabled
+	// implies. They are only deleted on that path, so name them instead of rendering them.
+	var dexDeployment, dexConfigMap client.Object
+	if c.cfg.DeleteDex {
+		dexDeployment = &appsv1.Deployment{
+			TypeMeta:   metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+			ObjectMeta: metav1.ObjectMeta{Name: DexObjectName, Namespace: DexNamespace},
+		}
+		dexConfigMap = &corev1.ConfigMap{
+			TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{Name: DexObjectName, Namespace: DexNamespace},
+		}
+	} else {
+		dexDeployment = c.deployment()
+		dexConfigMap = c.configMap()
+	}
+
 	objs := []client.Object{
 		CreateNamespace(DexObjectName, c.cfg.Installation.KubernetesProvider, PSSRestricted, c.cfg.Installation.Azure),
 		c.calicoSystemNetworkPolicy(c.cfg.Installation.Variant),
 		networkpolicy.CalicoSystemDefaultDeny(DexNamespace),
 		CreateOperatorSecretsRoleBinding(DexNamespace),
 		c.serviceAccount(),
-		c.deployment(),
+		dexDeployment,
 		c.service(),
 		c.clusterRole(),
 		c.clusterRoleBinding(),
-		c.configMap(),
+		dexConfigMap,
 	}
 	objectsToDelete := []client.Object{
 		// Delete the secret called tigera-dex which in the past was used to store a client secret.

--- a/pkg/render/dex_test.go
+++ b/pkg/render/dex_test.go
@@ -264,6 +264,20 @@ var _ = Describe("dex rendering tests", func() {
 				"https://example.com/login/oidc/silent-callback"))
 		})
 
+		It("should render the objects to delete without a TLS key pair when dex is disabled", func() {
+			// When dex is disabled no key pair is created for it, so the teardown path must not
+			// depend on one.
+			cfg.DeleteDex = true
+			cfg.TLSKeyPair = nil
+
+			component := render.Dex(cfg)
+			objsToCreate, objsToDelete := component.Objects()
+
+			Expect(objsToCreate).To(BeNil())
+			rtest.ExpectResourceInList(objsToDelete, render.DexObjectName, render.DexNamespace, "apps", "v1", "Deployment")
+			rtest.ExpectResourceInList(objsToDelete, render.DexObjectName, render.DexNamespace, "", "v1", "ConfigMap")
+		})
+
 		It("should render config Map with the HSTS headers", func() {
 			component := render.Dex(cfg)
 			resources, _ := component.Objects()


### PR DESCRIPTION
## Description

**Bug fix.** `utils.DexEnabled()` returns false when `Authentication.spec.oidc.type` is `Tigera`, and dex is not deployed in that case. The authentication controller nonetheless calls `GetOrCreateKeyPair()` for `tigera-dex-tls` unconditionally (`authentication_controller.go:282`), which generates a new key pair whenever the existing secret is missing, expired or otherwise unusable.

The component that persists that key pair — `rcertificatemanagement.CertificateManagement(...)` — is only appended to `components` when `enableDex` is true. So on a cluster that does not run dex, nothing ever writes the newly generated secret. The result is that **every reconcile generates and immediately discards an RSA key pair**, and an expired `tigera-dex-tls` secret is re-detected forever:

```
{"level":"info","logger":"tls","msg":"KeyPair is an expired legacy operator cert, make a new one","name":"tigera-dex-tls"}
```

This never converges: while dex is disabled nothing can replace the expired secret, so the same log line repeats on every reconcile indefinitely. The cost is wasted key generation and signing on a hot controller, plus permanent log noise.

### What changed

- `pkg/controller/authentication/authentication_controller.go` — hoist `enableDex` (it only depends on the already-fetched `Authentication`) above the point where the key pair is built, and only call `GetOrCreateKeyPair()` when dex is enabled. `CheckKeyPairWarnings()` is guarded the same way, since it dereferences the key pair.
- `pkg/render/dex.go` — `Objects()` built `c.deployment()` and `c.configMap()` before checking `DeleteDex`, and both dereference `c.cfg.TLSKeyPair`, so a nil key pair would panic on the teardown path. Those two objects are only ever *deleted* on that path, so they are now identified by name and GVK instead of being fully rendered.

Not changed: when dex *is* enabled the behaviour is identical, and this does not alter the contents of any rendered object.

### Testing

- New unit test in `pkg/render/dex_test.go` covering `DeleteDex: true` with a nil `TLSKeyPair`, asserting nothing is rendered for creation and that the Deployment and ConfigMap are in the delete list. This test panics without the `dex.go` change.
- `go test ./pkg/render` — 516 specs pass.
- `go test ./pkg/controller/authentication/...` — passes.
- `gofmt` clean; `go vet` clean on both changed packages.

### Components affected

The authentication controller and the dex renderer only. Clusters using `oidc.type` other than `Tigera` (i.e. those that actually deploy dex) are unaffected.

## Release Note

```release-note
Stop generating a new tigera-dex-tls key pair on every reconcile when dex is not deployed.
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
