### PR TITLE
Give the manager its own trusted bundle for the Tigera OIDC type

### DIFF
--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -446,8 +446,16 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 		trustedSecretNames = append(trustedSecretNames, render.DexTLSSecretName)
 	}
 
+	// Voltron has to validate a public OIDC issuer for the Tigera OIDC type, so that configuration also
+	// needs the system root certificates in its trusted bundle. Either way this stays a bundle named
+	// for this component: the default-named tigera-ca-bundle belongs to the core controller, which
+	// renders it into the same namespace with a different set of certificates, and two controllers
+	// writing one ConfigMap with different contents overwrite each other on every reconcile.
+	includeSystemRoots := authenticationCR != nil && authenticationCR.Spec.OIDC != nil &&
+		authenticationCR.Spec.OIDC.Type == operatorv1.OIDCTypeTigera
+
 	bundleMaker, err := certificateManager.CreateNamedTrustedBundleFromSecrets(TrustedBundlePrefix, r.client,
-		helper.TruthNamespace(), false, trustedSecretNames...)
+		helper.TruthNamespace(), includeSystemRoots, trustedSecretNames...)
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceCreateError, "Error creating trusted bundle for manager", err, logc)
 	}
@@ -462,7 +470,6 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 			logc,
 			helper,
 			tenant,
-			authenticationCR,
 			certificateManager,
 			bundleMaker,
 			trustedSecretNames,

--- a/pkg/controller/manager/manager_controller_cloud.go
+++ b/pkg/controller/manager/manager_controller_cloud.go
@@ -70,22 +70,15 @@ func (r *ReconcileManager) handleCloudReconcile(
 	reqLogger logr.Logger,
 	helper utils.NamespaceHelper,
 	tenant *operatorv1.Tenant,
-	authenticationCR *operatorv1.Authentication,
 	certificateManager certificatemanager.CertificateManager,
 	bundleMaker certificatemanagement.TrustedBundle,
 	trustedSecretNames []string,
 	requestNamespace string,
 ) (certificatemanagement.TrustedBundle, render.ManagerCloudResources, *operatorv1.Tenant, *reconcile.Result, error) {
 
-	if authenticationCR != nil && authenticationCR.Spec.OIDC != nil && authenticationCR.Spec.OIDC.Type == operatorv1.OIDCTypeTigera {
-		var err error
-		bundleMaker, err = certificateManager.CreateTrustedBundleWithSystemRootCertificates()
-		if err != nil {
-			r.status.SetDegraded(operatorv1.ResourceCreateError, "failed to create trusted bundle with system root certs", err, reqLogger)
-			return nil, render.ManagerCloudResources{}, nil, nil, err
-		}
-	}
-
+	// The trusted bundle is built by the caller, which decides both its name and whether it carries the
+	// system root certificates. All that is left to do here is confirm the certificates it trusts are
+	// available before the manager is rendered.
 	for _, secret := range trustedSecretNames {
 		certificate, err := certificateManager.GetCertificate(r.client, secret, helper.TruthNamespace())
 		if err != nil {
@@ -96,10 +89,6 @@ func (r *ReconcileManager) handleCloudReconcile(
 			r.status.SetDegraded(operatorv1.ResourceNotReady, fmt.Sprintf("Waiting for secret '%s' to become available", secret), nil, reqLogger)
 			// stop reconciler iteration with no error as it is waiting for a resource to become available
 			return nil, render.ManagerCloudResources{}, nil, &reconcile.Result{}, nil
-		}
-
-		if bundleMaker != nil {
-			bundleMaker.AddCertificates(certificate)
 		}
 	}
 

--- a/pkg/controller/manager/manager_controller_test.go
+++ b/pkg/controller/manager/manager_controller_test.go
@@ -578,6 +578,34 @@ var _ = Describe("Manager controller tests", func() {
 				Expect(namespace.Labels["pod-security.kubernetes.io/enforce-version"]).To(Equal("latest"))
 			})
 
+			It("should leave the manager's trusted bundle alone on the cloud path", func() {
+				// The default-named tigera-ca-bundle belongs to the core controller, which renders it
+				// into the same namespace with a different set of certificates. If the manager writes
+				// that same ConfigMap the two controllers overwrite each other on every reconcile,
+				// which rolls every workload that mounts or inherits the bundle. The cloud path must
+				// therefore hand back the component-named bundle it was given, not substitute its own.
+				helper := utils.NewNamespaceHelper(false, render.ManagerNamespace, "")
+
+				// handleCloudReconcile resolves the tenant from this ConfigMap.
+				Expect(c.Create(ctx, &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: utils.CloudAuthConfig, Namespace: common.OperatorNamespace()},
+					Data:       map[string]string{"tenantID": "Auth0ID"},
+				})).NotTo(HaveOccurred())
+
+				in, err := certificateManager.CreateNamedTrustedBundleFromSecrets(TrustedBundlePrefix, c, helper.TruthNamespace(), true)
+				Expect(err).NotTo(HaveOccurred())
+
+				out, _, _, res, err := r.handleCloudReconcile(ctx, log, helper, nil, certificateManager, in, nil, "")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(res).To(BeNil())
+
+				Expect(out).NotTo(BeNil())
+				Expect(out.ConfigMap(helper.InstallNamespace()).Name).
+					To(Equal(certificatemanagement.TrustedBundleName(render.ManagerName, true)))
+				Expect(out.ConfigMap(helper.InstallNamespace()).Name).
+					NotTo(Equal(certificatemanagement.TrustedCertConfigMapName))
+			})
+
 			Context("image reconciliation", func() {
 				It("should use builtin images", func() {
 					mockStatus.On("RemoveCertificateSigningRequests", mock.Anything).Return()


### PR DESCRIPTION
## Description

**Bug fix.** On clusters configured with the Tigera OIDC type, `calico-manager` and `es-calico-kube-controllers` repeatedly roll their pods, alternating between two pod templates.

### Impact

This is not a steady loop. Neither controller rewrites the bundle on every reconcile — the 5 minute periodic resync does not re-trigger it — so rollouts arrive in bursts, each set off by something that makes one of the controllers rebuild the bundle from cold: an upgrade, a manager restart, or a certificate rotation. Within a burst, replacements follow one another within seconds; between bursts the deployments can sit quiet for hours.

Both deployments stay available the whole time, since each flip is an ordinary rolling update. The cost is repeated unnecessary restarts, log and event noise, write contention on the shared ConfigMap (`Operation cannot be fulfilled on configmaps "tigera-ca-bundle"`), and a revision history that grows without bound — not downtime.

### Root cause

For `Authentication.spec.oidc.type: Tigera`, `handleCloudReconcile` discards the manager's component-named trusted bundle and replaces it with one from `CreateTrustedBundleWithSystemRootCertificates()`, which renders the **default-named** `tigera-ca-bundle` (`manager_controller_cloud.go:80-87`):

```go
if authenticationCR != nil && authenticationCR.Spec.OIDC != nil && authenticationCR.Spec.OIDC.Type == operatorv1.OIDCTypeTigera {
	bundleMaker, err = certificateManager.CreateTrustedBundleWithSystemRootCertificates()
}
```

That ConfigMap is owned by the **core controller**, which renders it with a *different* set of certificates — the `node` and `typha` key pairs, plus the legacy `tigera-operator/typha-ca` ConfigMap on clusters old enough to still carry one (`core_controller.go:1978-1990`). Both land in the same namespace, since `render.ManagerNamespace` is `common.CalicoNamespace`.

Two controllers writing one ConfigMap with different contents overwrite each other, so `calico-system/tigera-ca-bundle` alternates between exactly two values. Both consumers flip with it:

- `calico-manager` mounts the bundle and hashes its data keys, so its pod-template annotations flip.
- `es-calico-kube-controllers` obtains it via `cm.LoadTrustedBundle()`, which copies the ConfigMap's `hash.operator.tigera.io/*` annotations onto the dependent workload — including the namespace-prefixed `calico-system.hash.operator.tigera.io/typha-ca` key, which appears and disappears.

Each deployment therefore oscillates between two pod templates. Kubernetes reuses the two ReplicaSets rather than creating new ones and simply bumps `deployment.kubernetes.io/revision` on each switch back, so a deployment can reach a revision number in the hundreds or thousands while only ever having created a handful of ReplicaSets. Diffing the two ReplicaSets of either deployment shows the `typha-ca` annotation and the bundle content hash as the *only* pod-template differences.

### Which clusters this affects

The extra certificate comes from the legacy `typha-ca` ConfigMap, which only exists on clusters installed by an operator older than v1.29: `b0fce5783` (2022-03-04) replaced the dedicated Typha/Felix CA with the central CA, and nothing has ever deleted the old ConfigMap. Where one is present the two writers' bundles differ and the deployments flip. On a cluster installed after that change neither bundle contains it, both writers produce identical content, the second write is a no-op, and nothing flaps.

Deleting the stale ConfigMap therefore stops the churn, but that is a mitigation rather than a fix — the two-writer conflict remains latent and resurfaces wherever the two controllers' inputs diverge for any other reason.

### The change

The only thing the Tigera OIDC type actually needs is the system root certificates, so pass that as a flag to the one call that already builds the manager's bundle, rather than rebuilding it:

```go
includeSystemRoots := authenticationCR != nil && authenticationCR.Spec.OIDC != nil &&
	authenticationCR.Spec.OIDC.Type == operatorv1.OIDCTypeTigera

bundleMaker, err := certificateManager.CreateNamedTrustedBundleFromSecrets(TrustedBundlePrefix, r.client,
	helper.TruthNamespace(), includeSystemRoots, trustedSecretNames...)
```

`authenticationCR` is already fetched above this point, so the decision can be made here. The manager is then *always* backed by a bundle named for itself, and `handleCloudReconcile` no longer takes part in building it — it only checks that the certificates the bundle trusts are available, and its `authenticationCR` parameter is gone.

That also removes a redundant `AddCertificates` loop. `AddCertificates` appends rather than deduplicating by name (it skips only nil entries and certificates signed by our own CA), so on the cloud path every trusted secret was added a second time and any certificate *not* signed by our CA — a BYO cert — ended up duplicated in the bundle. Certificates are now added exactly once, by the single constructor call.

### Upgrade impact

The manager now creates and mounts `calico-manager-ca-bundle-system-certs` instead of the shared `tigera-ca-bundle`. Worth a reviewer's attention:

- Nothing is orphaned — the core controller continues to own and maintain `tigera-ca-bundle` for its other consumers.
- In-container certificate paths are **unchanged**: `VolumeMounts()` uses the constant `TrustedCertVolumeMountPath`, and only the ConfigMap and volume names derive from the bundle name. Voltron and manager keep reading the same files.
- `calico-manager` rolls once on upgrade as the new volume is mounted.

### Testing

- New unit test `should leave the manager's trusted bundle alone on the cloud path` passes a component-named bundle into `handleCloudReconcile` and asserts the bundle handed back is still that one, and is not `tigera-ca-bundle`. Verified it **fails if the override is reintroduced**, producing `tigera-ca-bundle`.
- The test drives `handleCloudReconcile` rather than `Reconcile`, because reaching this code through `Reconcile` requires `utils.GetKeyValidatorConfig` → `tigerakvc.New`, which performs live OIDC discovery and JWKS fetches against the issuer. That is also why this path had no prior unit coverage at all. It does mean the `includeSystemRoots` expression itself is not unit-covered; a fake-issuer harness would let a future test cover it, and would be a worthwhile follow-up.
- `go test ./pkg/controller/manager/...` passes (29 specs).
- `gofmt` clean; the repo pre-commit hook passes.

### Components affected

The manager controller on the Tigera OIDC path. Multi-tenant and other OIDC types already used the named bundle and are unaffected.

## Release Note

```release-note
Fixed calico-manager and es-calico-kube-controllers repeatedly rolling their pods, caused by the manager controller and the core controller writing the shared tigera-ca-bundle ConfigMap with different sets of certificates.
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
