### PR TITLE
fix(apiserver): hold the cutover until the new API server is ready

### DIFF
--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -166,6 +166,12 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 		return fmt.Errorf("apiserver-controller failed to watch Deployment: %w", err)
 	}
 
+	// The cutover is gated on this Deployment's readiness, so react to it rather than waiting for the
+	// next periodic reconcile.
+	if err = utils.AddDeploymentWatch(c, render.APIServerName, render.APIServerNamespace); err != nil {
+		return fmt.Errorf("apiserver-controller failed to watch Deployment: %w", err)
+	}
+
 	if err = utils.AddDeploymentWatch(c, webhooks.WebhooksName, common.CalicoNamespace); err != nil {
 		return fmt.Errorf("apiserver-controller failed to watch webhooks Deployment: %w", err)
 	}
@@ -501,6 +507,15 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 		}
 	}
 
+	var holdCutover bool
+	if !r.opts.UseV3CRDs {
+		holdCutover, err = holdAPIServiceCutover(ctx, r.client)
+		if err != nil {
+			r.status.SetDegraded(operatorv1.ResourceReadError, "Error querying the projectcalico.org/v3 APIService", err, reqLogger)
+			return reconcile.Result{}, err
+		}
+	}
+
 	// Render the desired objects from the CRD and create or update them.
 	reqLogger.V(3).Info("rendering components")
 
@@ -523,6 +538,7 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 		KubernetesVersion:            r.opts.KubernetesVersion,
 		ClusterDomain:                r.opts.ClusterDomain,
 		RequiresAggregationServer:    !r.opts.UseV3CRDs,
+		HoldAPIServiceCutover:        holdCutover,
 		QueryServerTLSKeyPairCertificateManagementOnly: queryServerTLSSecretCertificateManagementOnly,
 	}
 
@@ -594,8 +610,16 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 	// dependency on the API server deployment.
 	//
 	// We do this last to avoid transient errors with policy preventing progression of the controller.
+	//
+	// While the cutover is held the previous API server is still serving, so the policy can go first
+	// instead, closing the window in which the new workload runs with no policy of its own.
 	if r.opts.UseV3CRDs || includeV3NetworkPolicy {
-		components = append(components, render.APIServerPolicy(&apiServerCfg))
+		policy := render.APIServerPolicy(&apiServerCfg)
+		if holdCutover {
+			components = append([]render.Component{policy}, components...)
+		} else {
+			components = append(components, policy)
+		}
 	}
 
 	if err = imageset.ApplyImageSet(ctx, r.client, installationSpec.Variant, components...); err != nil {
@@ -615,6 +639,11 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 		render.CalicoAPIServerTLSSecretName: tlsSecret,
 		webhooks.WebhooksTLSSecretName:      webhooksTLS,
 	}, r.status)
+
+	if holdCutover {
+		r.status.SetDegraded(operatorv1.ResourceNotReady, "Waiting for the Calico API server to become ready before repointing the projectcalico.org/v3 APIService", nil, reqLogger)
+		return reconcile.Result{RequeueAfter: utils.StandardRetry}, nil
+	}
 
 	// Clear the degraded bit if we've reached this far.
 	r.status.ClearDegraded()

--- a/pkg/controller/apiserver/apiserver_controller_test.go
+++ b/pkg/controller/apiserver/apiserver_controller_test.go
@@ -32,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -1030,4 +1031,111 @@ var _ = Describe("apiserver controller tests", func() {
 			Expect(err.Error()).To(ContainSubstring("CalicoWebhooksDeployment"))
 		})
 	})
+
+	Context("API server cutover", func() {
+		var r ReconcileAPIServer
+
+		BeforeEach(func() {
+			Expect(cli.Create(ctx, installation)).To(BeNil())
+			Expect(cli.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tigera-system"}})).NotTo(HaveOccurred())
+			Expect(cli.Create(ctx, &apiregv1.APIService{
+				ObjectMeta: metav1.ObjectMeta{Name: render.APIServiceName},
+				Spec: apiregv1.APIServiceSpec{
+					Group:   "projectcalico.org",
+					Version: "v3",
+					Service: &apiregv1.ServiceReference{Name: "tigera-api", Namespace: "tigera-system"},
+				},
+			})).NotTo(HaveOccurred())
+
+			r = ReconcileAPIServer{
+				client:              cli,
+				scheme:              scheme,
+				status:              mockStatus,
+				tierWatchReady:      ready,
+				migrationWatchReady: &utils.ReadyFlag{},
+				opts: options.ControllerOptions{
+					Variant:          operatorv1.CalicoEnterprise,
+					DetectedProvider: operatorv1.ProviderNone,
+				},
+			}
+		})
+
+		apiService := func() *apiregv1.APIService {
+			s := &apiregv1.APIService{}
+			Expect(cli.Get(ctx, types.NamespacedName{Name: render.APIServiceName}, s)).NotTo(HaveOccurred())
+			return s
+		}
+
+		It("leaves the previous API server in service while the new one is not ready", func() {
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Expect(apiService().Spec.Service.Namespace).To(Equal("tigera-system"))
+			Expect(cli.Get(ctx, types.NamespacedName{Name: "tigera-system"}, &corev1.Namespace{})).NotTo(HaveOccurred())
+
+			// The workload it will hand over to is still created, so it has a chance to become ready.
+			d := &appsv1.Deployment{}
+			Expect(cli.Get(ctx, types.NamespacedName{Name: render.APIServerName, Namespace: render.APIServerNamespace}, d)).NotTo(HaveOccurred())
+		})
+
+		It("repoints the APIService once the new API server is ready", func() {
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			d := &appsv1.Deployment{}
+			Expect(cli.Get(ctx, types.NamespacedName{Name: render.APIServerName, Namespace: render.APIServerNamespace}, d)).NotTo(HaveOccurred())
+			d.Status.ReadyReplicas = 2
+			Expect(cli.Status().Update(ctx, d)).NotTo(HaveOccurred())
+
+			_, err = r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Expect(apiService().Spec.Service.Namespace).To(Equal(render.APIServerNamespace))
+			err = cli.Get(ctx, types.NamespacedName{Name: "tigera-system"}, &corev1.Namespace{})
+			Expect(kerror.IsNotFound(err)).To(BeTrue())
+		})
+
+		It("writes the API server's own policy before the workload while holding", func() {
+			r.client = &orderRecordingClient{Client: cli}
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			recorder, ok := r.client.(*orderRecordingClient)
+			Expect(ok).To(BeTrue())
+			Expect(recorder.created).To(ContainElement(render.APIServerPolicyName))
+			Expect(recorder.created).To(ContainElement(render.APIServerName))
+			Expect(indexOf(recorder.created, render.APIServerPolicyName)).To(BeNumerically("<", indexOf(recorder.created, render.APIServerName)))
+		})
+
+		It("does not hold on a cluster that has already migrated", func() {
+			s := apiService()
+			s.Spec.Service.Namespace = render.APIServerNamespace
+			Expect(cli.Update(ctx, s)).NotTo(HaveOccurred())
+
+			hold, err := holdAPIServiceCutover(ctx, cli)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(hold).To(BeFalse())
+		})
+	})
 })
+
+// orderRecordingClient records the names of objects created through it, in order.
+type orderRecordingClient struct {
+	client.Client
+
+	created []string
+}
+
+func (c *orderRecordingClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	c.created = append(c.created, obj.GetName())
+	return c.Client.Create(ctx, obj, opts...)
+}
+
+func indexOf(names []string, name string) int {
+	for i, n := range names {
+		if n == name {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/controller/apiserver/apiserver_controller_test.go
+++ b/pkg/controller/apiserver/apiserver_controller_test.go
@@ -1054,8 +1054,8 @@ var _ = Describe("apiserver controller tests", func() {
 				tierWatchReady:      ready,
 				migrationWatchReady: &utils.ReadyFlag{},
 				opts: options.ControllerOptions{
-					Variant:          operatorv1.CalicoEnterprise,
-					DetectedProvider: operatorv1.ProviderNone,
+					EnterpriseCRDExists: true,
+					DetectedProvider:    operatorv1.ProviderNone,
 				},
 			}
 		})

--- a/pkg/controller/apiserver/cutover.go
+++ b/pkg/controller/apiserver/cutover.go
@@ -27,8 +27,7 @@ import (
 
 // holdAPIServiceCutover reports whether the projectcalico.org/v3 APIService is still served from a
 // previous location whose API server has to keep serving, because the one that would replace it is
-// not ready. Repointing early retires a working API server for one that may never come up, and the
-// fix for that then needs the v3 API that was just taken away.
+// not ready. Errors hold too, since failing to read the state is not evidence the cutover is safe.
 func holdAPIServiceCutover(ctx context.Context, reader client.Reader) (bool, error) {
 	apiService := &apiregv1.APIService{}
 	if err := reader.Get(ctx, client.ObjectKey{Name: render.APIServiceName}, apiService); err != nil {
@@ -36,7 +35,7 @@ func holdAPIServiceCutover(ctx context.Context, reader client.Reader) (bool, err
 			// A fresh install. There is no API server in service to protect.
 			return false, nil
 		}
-		return false, err
+		return true, err
 	}
 
 	if apiService.Spec.Service == nil || apiService.Spec.Service.Namespace == render.APIServerNamespace {
@@ -49,7 +48,7 @@ func holdAPIServiceCutover(ctx context.Context, reader client.Reader) (bool, err
 		if errors.IsNotFound(err) {
 			return true, nil
 		}
-		return false, err
+		return true, err
 	}
 
 	// /readyz is deliberately excluded from the API server's always-allow paths, so a passing probe

--- a/pkg/controller/apiserver/cutover.go
+++ b/pkg/controller/apiserver/cutover.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver
+
+import (
+	"context"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/tigera/operator/pkg/render"
+)
+
+// holdAPIServiceCutover reports whether the projectcalico.org/v3 APIService is still served from a
+// previous location whose API server has to keep serving, because the one that would replace it is
+// not ready. Repointing early retires a working API server for one that may never come up, and the
+// fix for that then needs the v3 API that was just taken away.
+func holdAPIServiceCutover(ctx context.Context, reader client.Reader) (bool, error) {
+	apiService := &apiregv1.APIService{}
+	if err := reader.Get(ctx, client.ObjectKey{Name: render.APIServiceName}, apiService); err != nil {
+		if errors.IsNotFound(err) {
+			// A fresh install. There is no API server in service to protect.
+			return false, nil
+		}
+		return false, err
+	}
+
+	if apiService.Spec.Service == nil || apiService.Spec.Service.Namespace == render.APIServerNamespace {
+		return false, nil
+	}
+
+	deployment := &appsv1.Deployment{}
+	key := client.ObjectKey{Name: render.APIServerName, Namespace: render.APIServerNamespace}
+	if err := reader.Get(ctx, key, deployment); err != nil {
+		if errors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	}
+
+	// /readyz is deliberately excluded from the API server's always-allow paths, so a passing probe
+	// means the pod authorized a request against the kube-apiserver - the connectivity the cutover
+	// depends on, and exactly what a leftover deny policy takes away.
+	return deployment.Status.ReadyReplicas == 0, nil
+}

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -81,6 +81,11 @@ const (
 	APIServerServiceName         = "calico-api"
 	APIServerServiceAccountName  = "calico-apiserver"
 
+	// The API server this one replaces. It shares the calico-apiserver-access-calico-crds binding,
+	// so while the cutover is held both service accounts must be subjects of it.
+	deprecatedAPIServerServiceAccountName = "tigera-apiserver"
+	deprecatedAPIServerNamespace          = "tigera-system"
+
 	APIServerSecretsRBACName                                      = "calico-extension-apiserver-secrets-access"
 	APIServerLinseedAccessClusterRoleName                         = "calico-apiserver-linseed-access"
 	MultiTenantManagedClustersAccessClusterRoleName               = "calico-managed-cluster-access"
@@ -776,18 +781,25 @@ func (c *apiServerComponent) calicoCustomResourcesClusterRole() *rbacv1.ClusterR
 //
 // Both Calico and Calico Enterprise, with the same name.
 func (c *apiServerComponent) calicoCustomResourcesClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+	subjects := []rbacv1.Subject{
+		{Kind: "ServiceAccount", Name: APIServerServiceAccountName, Namespace: APIServerNamespace},
+	}
+	// The previous API server is still serving while the cutover is held, and it reads its own
+	// storage through this binding, so dropping it here would take the API down.
+	if c.cfg.HoldAPIServiceCutover {
+		subjects = append(subjects, rbacv1.Subject{
+			Kind:      "ServiceAccount",
+			Name:      deprecatedAPIServerServiceAccountName,
+			Namespace: deprecatedAPIServerNamespace,
+		})
+	}
+
 	return &rbacv1.ClusterRoleBinding{
 		TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "calico-apiserver-access-calico-crds",
 		},
-		Subjects: []rbacv1.Subject{
-			{
-				Kind:      "ServiceAccount",
-				Name:      APIServerServiceAccountName,
-				Namespace: APIServerNamespace,
-			},
-		},
+		Subjects: subjects,
 		RoleRef: rbacv1.RoleRef{
 			Kind:     "ClusterRole",
 			Name:     "calico-crds",

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -57,6 +57,9 @@ const (
 	APIServerPortName   = "apiserver"
 	APIServerPolicyName = networkpolicy.CalicoComponentPolicyPrefix + "apiserver-access"
 
+	// APIServiceName is the aggregated APIService that fronts the projectcalico.org/v3 API group.
+	APIServiceName = "v3.projectcalico.org"
+
 	auditLogsVolumeName   = "calico-audit-logs"
 	auditPolicyVolumeName = "calico-audit-policy"
 )
@@ -155,6 +158,11 @@ type APIServerConfiguration struct {
 	// Whether or not we should run the aggregation API server for projectcalico.org/v3 APIs
 	// as part of this component.
 	RequiresAggregationServer bool
+
+	// HoldAPIServiceCutover leaves the previous API server in service: the v3.projectcalico.org
+	// APIService keeps pointing at it and none of the resources it needs are removed. Set while the
+	// API server that would take over is not yet ready to serve.
+	HoldAPIServiceCutover bool
 
 	// When certificate management is enabled, we need a separate init container to create a cert, running
 	// with the same permissions as query server.
@@ -286,10 +294,12 @@ func (c *apiServerComponent) Objects() ([]client.Object, []client.Object) {
 	}
 
 	// Add in certificates for API server TLS.
-	if !c.cfg.TLSKeyPair.UseCertificateManagement() {
-		aggregationAPIServerObjects = append(aggregationAPIServerObjects, c.apiServiceRegistration(c.cfg.TLSKeyPair.GetCertificatePEM()))
-	} else {
-		aggregationAPIServerObjects = append(aggregationAPIServerObjects, c.apiServiceRegistration(c.cfg.Installation.CertificateManagement.CACert))
+	if !c.cfg.HoldAPIServiceCutover {
+		if !c.cfg.TLSKeyPair.UseCertificateManagement() {
+			aggregationAPIServerObjects = append(aggregationAPIServerObjects, c.apiServiceRegistration(c.cfg.TLSKeyPair.GetCertificatePEM()))
+		} else {
+			aggregationAPIServerObjects = append(aggregationAPIServerObjects, c.apiServiceRegistration(c.cfg.Installation.CertificateManagement.CACert))
+		}
 	}
 
 	// Global enterprise-only objects.
@@ -366,7 +376,9 @@ func (c *apiServerComponent) Objects() ([]client.Object, []client.Object) {
 
 		// Clean up cluster-scoped resources that were created with the 'tigera' prefix.
 		// The apiserver now uses consistent resource names with 'calico' prefix across both EE and OSS variants.
-		objsToDelete = append(objsToDelete, c.deprecatedResources()...)
+		if !c.cfg.HoldAPIServiceCutover {
+			objsToDelete = append(objsToDelete, c.deprecatedResources()...)
+		}
 	} else {
 		// Explicitly delete any global enterprise objects.
 		// Namespaced objects will be handled by namespace deletion.
@@ -390,7 +402,9 @@ func (c *apiServerComponent) Objects() ([]client.Object, []client.Object) {
 	}
 
 	// Explicitly delete any renamed/deprecated objects.
-	objsToDelete = append(objsToDelete, c.getDeprecatedResources()...)
+	if !c.cfg.HoldAPIServiceCutover {
+		objsToDelete = append(objsToDelete, c.getDeprecatedResources()...)
+	}
 	objsToCreate := append(globalObjects, namespacedObjects...)
 
 	return objsToCreate, objsToDelete
@@ -434,7 +448,7 @@ func (c *apiServerComponent) apiServiceRegistration(cert []byte) *apiregv1.APISe
 	s := &apiregv1.APIService{
 		TypeMeta: metav1.TypeMeta{Kind: "APIService", APIVersion: "apiregistration.k8s.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "v3.projectcalico.org",
+			Name: APIServiceName,
 		},
 		Spec: apiregv1.APIServiceSpec{
 			Group:                "projectcalico.org",

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -294,6 +294,9 @@ func (c *apiServerComponent) Objects() ([]client.Object, []client.Object) {
 	}
 
 	// Add in certificates for API server TLS.
+	//
+	// Leaving the APIService unrendered is what holds the cutover, since the component handler only
+	// writes what it is given and so leaves the one pointing at the previous API server alone.
 	if !c.cfg.HoldAPIServiceCutover {
 		if !c.cfg.TLSKeyPair.UseCertificateManagement() {
 			aggregationAPIServerObjects = append(aggregationAPIServerObjects, c.apiServiceRegistration(c.cfg.TLSKeyPair.GetCertificatePEM()))

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -424,6 +424,28 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 		}))
 	})
 
+	It("binds the previous API server to the CRD role while the cutover is held", func() {
+		// v1.38 created calico-apiserver-access-calico-crds with the previous service account, so
+		// narrowing it to one subject mid-migration stops the API server that is still serving.
+		subjectsFor := func(hold bool) []rbacv1.Subject {
+			cfg.HoldAPIServiceCutover = hold
+			component, err := render.APIServer(cfg)
+			Expect(err).To(BeNil())
+			resources, _ := component.Objects()
+			crb := rtest.GetResource(resources, "calico-apiserver-access-calico-crds", "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding")
+			Expect(crb).NotTo(BeNil())
+			return crb.(*rbacv1.ClusterRoleBinding).Subjects
+		}
+
+		held := subjectsFor(true)
+		Expect(held).To(ContainElement(rbacv1.Subject{Kind: "ServiceAccount", Name: "calico-apiserver", Namespace: "calico-system"}))
+		Expect(held).To(ContainElement(rbacv1.Subject{Kind: "ServiceAccount", Name: "tigera-apiserver", Namespace: "tigera-system"}))
+
+		done := subjectsFor(false)
+		Expect(done).To(HaveLen(1))
+		Expect(done).To(ContainElement(rbacv1.Subject{Kind: "ServiceAccount", Name: "calico-apiserver", Namespace: "calico-system"}))
+	})
+
 	It("should grant the calico-apiserver SA write access to globalreports/status", func() {
 		component, err := render.APIServer(cfg)
 		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)


### PR DESCRIPTION
## Description

Cherry-pick of the master change to `release-v1.42`, which ships CE 3.23. This is the build the live validation below was run on.

Takes over #5139 and adds the change it needed to work on a live cluster. Casey's two commits are unchanged; the fourth is the fix, and the third only adapts his tests to this branch, which has no `ControllerOptions.Variant`.

#5139 holds the APIService repoint, and the removal of the old API server's namespace and RBAC, until the new API server reports ready, so the old one keeps serving and the installation controller's existing delete of the deprecated policy lands. On a direct upgrade that did not happen: `ClusterRoleBinding/calico-apiserver-access-calico-crds` is how an API server reads its own CRD-backed storage, v1.38 creates it under that same name with the previous service account, and v1.42 renders it with only the new one. The reconcile re-points it, the previous API server loses access while it is still the one in service, and the API goes down. Because the name never changes this is a subject rewrite rather than a rename, so holding deprecated resources by name cannot see it.

That binding now carries both service accounts while the cutover is held, and narrows to one when it clears.

Background, including the failing run and the root cause: https://claude.ai/code/artifact/bba535da-e439-4edf-a5cd-93ec7d336247

Validated on this build: a direct CE 3.21.4 to 3.23.1 upgrade with the aggregated API probed every two seconds throughout, 158 of 158 samples up and no unavailability window. The same code without the binding fix was 371 of 388 samples down and never recovered.

## Release Note

```release-note
Fixed a deadlock on upgrade where the Calico API server was moved before a deprecated policy blocking it was removed, leaving the projectcalico.org/v3 API permanently unavailable.
```

## For PR author

- [x] Tests for change.
- [x] If changing pkg/apis/, run `make gen-files` - no API changes.
- [x] If changing versions, run `make gen-versions` - no version changes.
