### PR TITLE
Add a test for the kube-controllers IPReservations watch permission

### DIFF
--- a/pkg/render/kubecontrollers/kube-controllers_test.go
+++ b/pkg/render/kubecontrollers/kube-controllers_test.go
@@ -128,6 +128,19 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		}
 	})
 
+	It("should let the IPAM syncer watch IPReservations", func() {
+		component := kubecontrollers.NewCalicoKubeControllers(&cfg)
+		Expect(component.ResolveImages(nil)).To(BeNil())
+		resources, _ := component.Objects()
+
+		role := rtest.GetResource(resources, "calico-kube-controllers", "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
+		Expect(role.Rules).To(ContainElement(rbacv1.PolicyRule{
+			APIGroups: []string{"projectcalico.org", "crd.projectcalico.org"},
+			Resources: []string{"ipreservations"},
+			Verbs:     []string{"list", "watch"},
+		}))
+	})
+
 	It("should render SecurityContextConstrains properly when provider is OpenShift", func() {
 		cfg.Installation.KubernetesProvider = operatorv1.ProviderOpenShift
 		component := kubecontrollers.NewCalicoKubeControllers(&cfg)


### PR DESCRIPTION
https://github.com/tigera/operator/pull/5115 landed the same `watch` verb independently, so all that's left here is a test to keep it from regressing. Without the watch, the IPAM syncer retries forever and IPAM stops syncing - which is what a v3-CRD cluster hits once the migration ClusterRole (which grants the whole `projectcalico.org` group) is removed.

```release-note
None
```
