### PR TITLE
[PMREQ-810] Let kube-controllers watch Networks

### DIFF
--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -592,6 +592,15 @@ func kubeControllersRoleEnterpriseCommonRules(cfg *KubeControllersConfiguration)
 			Verbs:     []string{"update"},
 		},
 		{
+			// The node controller watches Networks so that it can discount an L2
+			// network's subnet edges and gateways from the reserved-IP metric.
+			// The Network resource is only available in Enterprise / Cloud at
+			// this time.
+			APIGroups: []string{"projectcalico.org", "crd.projectcalico.org"},
+			Resources: []string{"networks"},
+			Verbs:     []string{"list", "watch"},
+		},
+		{
 			APIGroups: []string{"projectcalico.org", "crd.projectcalico.org"},
 			Resources: []string{"deeppacketinspections"},
 			Verbs:     []string{"get", "watch", "list"},

--- a/pkg/render/kubecontrollers/kube-controllers_test.go
+++ b/pkg/render/kubecontrollers/kube-controllers_test.go
@@ -327,7 +327,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(len(dp.Spec.Template.Spec.Volumes)).To(Equal(1))
 
 		clusterRole := rtest.GetResource(resources, kubecontrollers.KubeControllerRole, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
-		Expect(clusterRole.Rules).To(HaveLen(38), "cluster role should have 38 rules")
+		Expect(clusterRole.Rules).To(HaveLen(39), "cluster role should have 39 rules")
 
 		// Application-layer reconciler RBAC: WAF CRDs (resources, /status, /finalizers).
 		Expect(clusterRole.Rules).To(ContainElement(rbacv1.PolicyRule{
@@ -552,7 +552,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(dp.Spec.Template.Spec.Volumes[0].ConfigMap.Name).To(Equal("tigera-ca-bundle"))
 
 		clusterRole := rtest.GetResource(resources, kubecontrollers.EsKubeControllerRole, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
-		Expect(clusterRole.Rules).To(HaveLen(36), "cluster role should have 36 rules")
+		Expect(clusterRole.Rules).To(HaveLen(37), "cluster role should have 37 rules")
 		Expect(clusterRole.Rules).To(ContainElement(
 			rbacv1.PolicyRule{
 				APIGroups: []string{""},
@@ -851,7 +851,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(dp.Spec.Template.Spec.Containers[0].Image).To(Equal("test-reg/tigera/calico:" + components.ComponentTigeraCalico.Version))
 
 		clusterRole := rtest.GetResource(resources, kubecontrollers.EsKubeControllerRole, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
-		Expect(clusterRole.Rules).To(HaveLen(36), "cluster role should have 36 rules")
+		Expect(clusterRole.Rules).To(HaveLen(37), "cluster role should have 37 rules")
 		Expect(clusterRole.Rules).To(ContainElement(
 			rbacv1.PolicyRule{
 				APIGroups: []string{""},


### PR DESCRIPTION
## Description

kube-controllers' `ipam_ippool_reserved` metric reports how many addresses in each IP pool cannot be assigned. It already covers `IPReservation`s; a companion calico-private PR extends it to an L2 bridge `Network`'s subnet edges (the network and directed-broadcast address) and gateways, which are unassignable for the same reason. The node controller therefore watches `Network` on its syncer, alongside `IPReservation`.

That needs `list` and `watch` on `networks` in the kube-controllers ClusterRole. `Network` is Enterprise / Cloud only, so the rule goes in `kubeControllersRoleEnterpriseCommonRules`, following the precedent in `pkg/render/node.go`.

**This needs to merge before the calico PR.** Without the verb kube-controllers gets a 403 listing `networks`, and `watcherCache` only treats a *missing CRD* (404) as in-sync — a denied list takes the generic retry path without finishing the resync. The DataFeed then never reaches `InSync`, and every controller on it stalls, including auto host endpoints and the IPAM garbage collector. Calico CI demonstrated it as a `[Feature:AutoHEPs]` e2e failure.

Testing: the existing kube-controllers render tests, whose ClusterRole rule counts move by one.

Calico side: https://github.com/tigera/calico-private/pull/13102

CORE-13146

## Release Note

```release-note
None
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
