### PR TITLE
[CVE] bump ES/Kibana to 8.19.19 and ECK operator to 3.4.1 (release-v1.40)

### DIFF
--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -46,12 +46,12 @@ components:
     image: tigera/dex
     version: v3.22.6
   eck-kibana:
-    version: 8.19.16
+    version: 8.19.19
   kibana:
     image: tigera/kibana
     version: v3.22.6
   eck-elasticsearch:
-    version: 8.19.16
+    version: 8.19.19
   elasticsearch:
     image: tigera/elasticsearch
     version: v3.22.6
@@ -138,7 +138,7 @@ components:
     image: tigera/eck-operator
     version: v3.22.6
   eck-elasticsearch-operator:
-    version: 3.4.0
+    version: 3.4.1
   l7-collector:
     image: tigera/l7-collector
     version: v3.22.6

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -69,12 +69,12 @@ var (
 	}
 
 	ComponentEckElasticsearch = Component{
-		Version:  "8.19.16",
+		Version:  "8.19.19",
 		Registry: "",
 	}
 
 	ComponentEckKibana = Component{
-		Version:  "8.19.16",
+		Version:  "8.19.19",
 		Registry: "",
 	}
 
@@ -91,7 +91,7 @@ var (
 	}
 
 	ComponentECKElasticsearchOperator = Component{
-		Version:  "3.4.0",
+		Version:  "3.4.1",
 		Registry: "",
 	}
 

--- a/pkg/crds/enterprise/01-crd-eck-bundle.yaml
+++ b/pkg/crds/enterprise/01-crd-eck-bundle.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.0'
+    app.kubernetes.io/version: '3.4.1'
   name: agents.agent.k8s.elastic.co
 spec:
   group: agent.k8s.elastic.co
@@ -502,7 +502,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.0'
+    app.kubernetes.io/version: '3.4.1'
   name: apmservers.apm.k8s.elastic.co
 spec:
   group: apm.k8s.elastic.co
@@ -1024,7 +1024,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.0'
+    app.kubernetes.io/version: '3.4.1'
   name: autoopsagentpolicies.autoops.k8s.elastic.co
 spec:
   group: autoops.k8s.elastic.co
@@ -1184,7 +1184,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.0'
+    app.kubernetes.io/version: '3.4.1'
   name: beats.beat.k8s.elastic.co
 spec:
   group: beat.k8s.elastic.co
@@ -1423,7 +1423,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.0'
+    app.kubernetes.io/version: '3.4.1'
   name: elasticmapsservers.maps.k8s.elastic.co
 spec:
   group: maps.k8s.elastic.co
@@ -1680,7 +1680,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.0'
+    app.kubernetes.io/version: '3.4.1'
   name: elasticsearchautoscalers.autoscaling.k8s.elastic.co
 spec:
   group: autoscaling.k8s.elastic.co
@@ -1937,7 +1937,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.0'
+    app.kubernetes.io/version: '3.4.1'
   name: elasticsearches.elasticsearch.k8s.elastic.co
 spec:
   group: elasticsearch.k8s.elastic.co
@@ -3322,7 +3322,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.0'
+    app.kubernetes.io/version: '3.4.1'
   name: enterprisesearches.enterprisesearch.k8s.elastic.co
 spec:
   group: enterprisesearch.k8s.elastic.co
@@ -3800,7 +3800,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.0'
+    app.kubernetes.io/version: '3.4.1'
   name: kibanas.kibana.k8s.elastic.co
 spec:
   group: kibana.k8s.elastic.co
@@ -4368,7 +4368,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.0'
+    app.kubernetes.io/version: '3.4.1'
   name: logstashes.logstash.k8s.elastic.co
 spec:
   group: logstash.k8s.elastic.co
@@ -4911,7 +4911,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.0'
+    app.kubernetes.io/version: '3.4.1'
   name: packageregistries.packageregistry.k8s.elastic.co
 spec:
   group: packageregistry.k8s.elastic.co
@@ -5153,7 +5153,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.0'
+    app.kubernetes.io/version: '3.4.1'
   name: stackconfigpolicies.stackconfigpolicy.k8s.elastic.co
 spec:
   group: stackconfigpolicy.k8s.elastic.co


### PR DESCRIPTION
## Companion to calico-private #13094 (v3.22.7 CVE round)

Bumps the enterprise version pins the operator renders into the ECK CR, and regenerates the committed CRD bundle to match calico-private `release-calient-v3.22` (#13094, merged). This is the versions/CRD half of that round's `needs-operator-pr`; #5145 covered the operator-binary CVE (oras/grpc) half.

### Changes
- **`eck-elasticsearch` / `eck-kibana`: 8.19.16 → 8.19.19** — matches the ES/Kibana image content #13094 ships. Without it the operator declares 8.19.16 to ECK while CE v3.22.7 runs 8.19.19.
- **`eck-elasticsearch-operator`: 3.4.0 → 3.4.1** — matches #13094's ECK operator bump.
- Regenerated `pkg/components/enterprise.go` + `pkg/crds/enterprise/01-crd-eck-bundle.yaml` via `make gen-versions`. The CRD bundle delta is **label-only** (`app.kubernetes.io/version` 3.4.0 → 3.4.1, 12 occurrences) — no schema or RBAC changes.

### Why now / why separate from #5145
`gen-versions` clones calico-private at the `release-calient-v3.22` **branch tip** for the ECK CRDs. Now that #13094 merged, that tip is 3.4.1-labeled, so operator `release-v1.40` CI's `validate-gen-versions` dirty-check goes **red** until this lands. Kept separate from #5145 (correctly a go.mod-only CVE PR) per the repo pair's convention (#4889 / #4967) and for clean revert/cherry-pick semantics.

### Not included (deliberate)
`coreos-alertmanager` is left at `v0.32.1`. The built-vs-declared alertmanager mismatch is pre-existing, not forced by this dirty-check, and calico-private's own template also declares v0.32.1 — correcting only the operator would create a new cross-repo mismatch. Flagged for a separate coordinated change.

### Release Note
```release-note
Update bundled Elasticsearch/Kibana to 8.19.19 and the ECK operator to 3.4.1 for Calico Enterprise v3.22.7.
```
