### PR TITLE
Add FelixIPIPOnly cluster routing mode

### DIFF
--- a/api/v1/installation_types.go
+++ b/api/v1/installation_types.go
@@ -577,12 +577,13 @@ func BGPOptionPtr(b BGPOption) *BGPOption {
 }
 
 // ClusterRoutingMode describes the mode of cluster routing.
-// +kubebuilder:validation:Enum=BIRD;Felix
+// +kubebuilder:validation:Enum=BIRD;Felix;FelixIPIPOnly
 type ClusterRoutingMode string
 
 const (
-	ClusterRoutingModeBIRD  ClusterRoutingMode = "BIRD"
-	ClusterRoutingModeFelix ClusterRoutingMode = "Felix"
+	ClusterRoutingModeBIRD          ClusterRoutingMode = "BIRD"
+	ClusterRoutingModeFelix         ClusterRoutingMode = "Felix"
+	ClusterRoutingModeFelixIPIPOnly ClusterRoutingMode = "FelixIPIPOnly"
 )
 
 const (
@@ -662,10 +663,18 @@ type CalicoNetworkSpec struct {
 	// +kubebuilder:validation:Enum=Enabled;Disabled
 	BGP *BGPOption `json:"bgp,omitempty"`
 
-	// ClusterRoutingMode controls how nodes get a route to a workload on another node,
-	// when that workload's IP comes from an IP Pool with vxlanMode: Never. When ClusterRoutingMode is BIRD,
-	// confd and BIRD program that route. When ClusterRoutingMode is Felix, it is expected that Felix will program that route.
-	// Felix always programs such routes for IP Pools with vxlanMode: Always or vxlanMode: CrossSubnet. [Default: BIRD]
+	// ClusterRoutingMode controls which component programs the routes that a node needs in order to reach
+	// workloads on other nodes. It only applies to IP Pools with vxlanMode: Never; the routes for IP Pools
+	// with vxlanMode: Always or vxlanMode: CrossSubnet are always programmed by Felix.
+	// In BIRD mode, confd and BIRD program the routes for both IPIP and unencapsulated IP Pools.
+	// In Felix mode, Felix programs the routes for both IPIP and unencapsulated IP Pools.
+	// In FelixIPIPOnly mode, Felix programs the routes for IPIP IP Pools, and confd and BIRD program them
+	// for unencapsulated IP Pools.
+	// If not specified, the operator writes neither FelixConfiguration.programClusterRoutes nor
+	// BGPConfiguration.programClusterRoutes, so Calico's own defaults apply; as of Calico v3.33 those
+	// defaults are equivalent to FelixIPIPOnly.
+	// Note that BIRD programming of IPIP routes, which the BIRD mode selects, is deprecated as of
+	// Calico v3.33 and is intended for removal in v3.35.
 	// +optional
 	ClusterRoutingMode *ClusterRoutingMode `json:"clusterRoutingMode,omitempty"`
 

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -2195,10 +2195,7 @@ func setClusterRoutingOnFelixConfiguration(
 	}
 
 	updated := false
-	desiredValue := "Disabled"
-	if felixProgramsClusterRoutes(install) {
-		desiredValue = "Enabled"
-	}
+	desiredValue := felixProgramClusterRoutesValue(*install.Spec.CalicoNetwork.ClusterRoutingMode)
 
 	if fc.Spec.ProgramClusterRoutes == nil || *fc.Spec.ProgramClusterRoutes != desiredValue {
 		fc.Spec.ProgramClusterRoutes = &desiredValue
@@ -2221,10 +2218,7 @@ func setClusterRoutingOnBGPConfiguration(
 	}
 
 	updated := false
-	desiredValue := "Enabled"
-	if felixProgramsClusterRoutes(install) {
-		desiredValue = "Disabled"
-	}
+	desiredValue := birdProgramClusterRoutesValue(*install.Spec.CalicoNetwork.ClusterRoutingMode)
 
 	if bgpConfig.Spec.ProgramClusterRoutes == nil || *bgpConfig.Spec.ProgramClusterRoutes != desiredValue {
 		bgpConfig.Spec.ProgramClusterRoutes = &desiredValue
@@ -2235,12 +2229,50 @@ func setClusterRoutingOnBGPConfiguration(
 	return updated, nil
 }
 
-func felixProgramsClusterRoutes(install *operatorv1.Installation) bool {
-	if install.Spec.CalicoNetwork != nil && install.Spec.CalicoNetwork.ClusterRoutingMode != nil &&
-		*install.Spec.CalicoNetwork.ClusterRoutingMode == operatorv1.ClusterRoutingModeFelix {
-		return true
+// felixProgramClusterRoutesValue and birdProgramClusterRoutesValue map a cluster routing mode onto
+// the FelixConfiguration and BGPConfiguration programClusterRoutes values that implement it.  The
+// two must always be complementary: whatever Felix is not programming, BIRD has to, and vice versa.
+func felixProgramClusterRoutesValue(mode operatorv1.ClusterRoutingMode) string {
+	switch mode {
+	case operatorv1.ClusterRoutingModeFelix:
+		return "Enabled"
+	case operatorv1.ClusterRoutingModeFelixIPIPOnly:
+		return "EnabledIPIPOnly"
+	default:
+		return "Disabled"
 	}
-	return false
+}
+
+func birdProgramClusterRoutesValue(mode operatorv1.ClusterRoutingMode) string {
+	switch mode {
+	case operatorv1.ClusterRoutingModeFelix:
+		return "Disabled"
+	case operatorv1.ClusterRoutingModeFelixIPIPOnly:
+		return "EnabledNoEncapOnly"
+	default:
+		return "Enabled"
+	}
+}
+
+// felixProgramsIPIPClusterRoutes and felixProgramsNoEncapClusterRoutes say whether Felix, rather
+// than confd and BIRD, is the configured owner of the cluster routes for IPIP and for
+// unencapsulated IP Pools respectively.  Both return false when the mode is unset: the operator
+// then writes neither field and Calico's own defaults decide, which is not something to encode
+// here -- it varies by Calico version.
+func felixProgramsIPIPClusterRoutes(install *operatorv1.Installation) bool {
+	mode := clusterRoutingMode(install)
+	return mode == operatorv1.ClusterRoutingModeFelix || mode == operatorv1.ClusterRoutingModeFelixIPIPOnly
+}
+
+func felixProgramsNoEncapClusterRoutes(install *operatorv1.Installation) bool {
+	return clusterRoutingMode(install) == operatorv1.ClusterRoutingModeFelix
+}
+
+func clusterRoutingMode(install *operatorv1.Installation) operatorv1.ClusterRoutingMode {
+	if install.Spec.CalicoNetwork == nil || install.Spec.CalicoNetwork.ClusterRoutingMode == nil {
+		return ""
+	}
+	return *install.Spec.CalicoNetwork.ClusterRoutingMode
 }
 
 // setBPFUpdatesOnFelixConfiguration will take the passed in fc and update any BPF properties needed

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -1528,6 +1528,26 @@ var _ = Describe("Testing core-controller installation", func() {
 			Expect(*bgpConfig.Spec.ProgramClusterRoutes).To(Equal("Disabled"))
 		})
 
+		It("should correctly patch FelixConfig and BGPConfig with ClusterRouteMode set to FelixIPIPOnly", func() {
+			felixIPIPOnly := operator.ClusterRoutingModeFelixIPIPOnly
+			cr.Spec.CalicoNetwork = &operator.CalicoNetworkSpec{ClusterRoutingMode: &felixIPIPOnly}
+			Expect(c.Create(ctx, cr)).NotTo(HaveOccurred())
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			fc := &v3.FelixConfiguration{}
+			err = c.Get(ctx, types.NamespacedName{Name: "default"}, fc)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(fc.Spec.ProgramClusterRoutes).NotTo(BeNil())
+			Expect(*fc.Spec.ProgramClusterRoutes).To(Equal("EnabledIPIPOnly"))
+
+			bgpConfig := &v3.BGPConfiguration{}
+			err = c.Get(ctx, types.NamespacedName{Name: "default"}, bgpConfig)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(bgpConfig.Spec.ProgramClusterRoutes).NotTo(BeNil())
+			Expect(*bgpConfig.Spec.ProgramClusterRoutes).To(Equal("EnabledNoEncapOnly"))
+		})
+
 		It("should create the default BGPConfig and FelixConfig with ClusterRoutingMode set", func() {
 			bgpConfig := &v3.BGPConfiguration{}
 			err := c.Get(ctx, types.NamespacedName{Name: "default"}, bgpConfig)

--- a/pkg/controller/installation/validation.go
+++ b/pkg/controller/installation/validation.go
@@ -146,7 +146,8 @@ func validateCustomResource(instance *operatorv1.Installation) error {
 	// Verify Calico settings, if specified.
 	if instance.Spec.CalicoNetwork != nil {
 		bpfDataplane := instance.Spec.CalicoNetwork.LinuxDataplane != nil && *instance.Spec.CalicoNetwork.LinuxDataplane == operatorv1.LinuxDataplaneBPF
-		felixClusterRoutingMode := felixProgramsClusterRoutes(instance)
+		felixOwnsIPIPRoutes := felixProgramsIPIPClusterRoutes(instance)
+		felixOwnsNoEncapRoutes := felixProgramsNoEncapClusterRoutes(instance)
 
 		// Perform validation on non-IPPool fields that rely on IP pool configuration. Validation of the IP pools themselves
 		// happens in the IP pool controller.
@@ -175,15 +176,17 @@ func validateCustomResource(instance *operatorv1.Installation) error {
 					// Verify the specified encapsulation type is valid.
 					switch pool.Encapsulation {
 					case operatorv1.EncapsulationIPIP, operatorv1.EncapsulationIPIPCrossSubnet:
-						// In BIRD cluster routing mode, IPIP currently requires BGP to be running in order to program routes.
-						if !felixClusterRoutingMode &&
+						// Unless Felix is the configured owner of the IPIP cluster routes, they are
+						// BIRD's to program, which requires BGP to be running.
+						if !felixOwnsIPIPRoutes &&
 							(instance.Spec.CalicoNetwork.BGP == nil || *instance.Spec.CalicoNetwork.BGP == operatorv1.BGPDisabled) {
 							return fmt.Errorf("with BIRD cluster routing mode, IPIP encapsulation requires that BGP is enabled")
 						}
 					case operatorv1.EncapsulationVXLAN, operatorv1.EncapsulationVXLANCrossSubnet:
 					case operatorv1.EncapsulationNone:
-						// In BIRD cluster routing mode, Unencapsulated currently requires BGP to be running in order to program routes.
-						if !felixClusterRoutingMode &&
+						// Likewise for unencapsulated pools.  Note that clusterRoutingMode
+						// FelixIPIPOnly leaves these with BIRD, so it still needs BGP.
+						if !felixOwnsNoEncapRoutes &&
 							(instance.Spec.CalicoNetwork.BGP == nil || *instance.Spec.CalicoNetwork.BGP == operatorv1.BGPDisabled) {
 							return fmt.Errorf("with BIRD cluster routing mode, unencapsulated IP pools require that BGP is enabled")
 						}

--- a/pkg/controller/installation/validation_test.go
+++ b/pkg/controller/installation/validation_test.go
@@ -361,6 +361,59 @@ var _ = Describe("Installation validation tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	// FelixIPIPOnly splits the two: Felix takes the IPIP pools, so they no longer need BGP, but
+	// BIRD keeps the unencapsulated ones, so those still do.
+	It("should allow IPIP with BGP disabled in FelixIPIPOnly cluster routing mode", func() {
+		disabled := operator.BGPDisabled
+		instance.Spec.CalicoNetwork.BGP = &disabled
+		clusterRoutingMode := operator.ClusterRoutingModeFelixIPIPOnly
+		instance.Spec.CalicoNetwork.ClusterRoutingMode = &clusterRoutingMode
+		instance.Spec.CalicoNetwork.IPPools = []operator.IPPool{
+			{
+				CIDR:          "192.168.0.0/24",
+				Encapsulation: operator.EncapsulationIPIP,
+				NATOutgoing:   operator.NATOutgoingEnabled,
+				NodeSelector:  "all()",
+			},
+		}
+		err := validateCustomResource(instance)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should allow IPIP cross-subnet with BGP disabled in FelixIPIPOnly cluster routing mode", func() {
+		disabled := operator.BGPDisabled
+		instance.Spec.CalicoNetwork.BGP = &disabled
+		clusterRoutingMode := operator.ClusterRoutingModeFelixIPIPOnly
+		instance.Spec.CalicoNetwork.ClusterRoutingMode = &clusterRoutingMode
+		instance.Spec.CalicoNetwork.IPPools = []operator.IPPool{
+			{
+				CIDR:          "192.168.0.0/24",
+				Encapsulation: operator.EncapsulationIPIPCrossSubnet,
+				NATOutgoing:   operator.NATOutgoingEnabled,
+				NodeSelector:  "all()",
+			},
+		}
+		err := validateCustomResource(instance)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should prevent no-encap with BGP disabled in FelixIPIPOnly cluster routing mode", func() {
+		disabled := operator.BGPDisabled
+		instance.Spec.CalicoNetwork.BGP = &disabled
+		clusterRoutingMode := operator.ClusterRoutingModeFelixIPIPOnly
+		instance.Spec.CalicoNetwork.ClusterRoutingMode = &clusterRoutingMode
+		instance.Spec.CalicoNetwork.IPPools = []operator.IPPool{
+			{
+				CIDR:          "192.168.0.0/24",
+				Encapsulation: operator.EncapsulationNone,
+				NATOutgoing:   operator.NATOutgoingEnabled,
+				NodeSelector:  "all()",
+			},
+		}
+		err := validateCustomResource(instance)
+		Expect(err).To(HaveOccurred())
+	})
+
 	It("should not error if CalicoNetwork is provided on EKS", func() {
 		instance := &operator.Installation{}
 		instance.Spec.CNI = &operator.CNISpec{Type: operator.PluginCalico}

--- a/pkg/imports/crds/operator/operator.tigera.io_installations.yaml
+++ b/pkg/imports/crds/operator/operator.tigera.io_installations.yaml
@@ -1346,13 +1346,22 @@ spec:
                       type: string
                     clusterRoutingMode:
                       description: |-
-                        ClusterRoutingMode controls how nodes get a route to a workload on another node,
-                        when that workload's IP comes from an IP Pool with vxlanMode: Never. When ClusterRoutingMode is BIRD,
-                        confd and BIRD program that route. When ClusterRoutingMode is Felix, it is expected that Felix will program that route.
-                        Felix always programs such routes for IP Pools with vxlanMode: Always or vxlanMode: CrossSubnet. [Default: BIRD]
+                        ClusterRoutingMode controls which component programs the routes that a node needs in order to reach
+                        workloads on other nodes. It only applies to IP Pools with vxlanMode: Never; the routes for IP Pools
+                        with vxlanMode: Always or vxlanMode: CrossSubnet are always programmed by Felix.
+                        In BIRD mode, confd and BIRD program the routes for both IPIP and unencapsulated IP Pools.
+                        In Felix mode, Felix programs the routes for both IPIP and unencapsulated IP Pools.
+                        In FelixIPIPOnly mode, Felix programs the routes for IPIP IP Pools, and confd and BIRD program them
+                        for unencapsulated IP Pools.
+                        If not specified, the operator writes neither FelixConfiguration.programClusterRoutes nor
+                        BGPConfiguration.programClusterRoutes, so Calico's own defaults apply; as of Calico v3.33 those
+                        defaults are equivalent to FelixIPIPOnly.
+                        Note that BIRD programming of IPIP routes, which the BIRD mode selects, is deprecated as of
+                        Calico v3.33 and is intended for removal in v3.35.
                       enum:
                         - BIRD
                         - Felix
+                        - FelixIPIPOnly
                       type: string
                     containerIPForwarding:
                       description: |-
@@ -10705,13 +10714,22 @@ spec:
                           type: string
                         clusterRoutingMode:
                           description: |-
-                            ClusterRoutingMode controls how nodes get a route to a workload on another node,
-                            when that workload's IP comes from an IP Pool with vxlanMode: Never. When ClusterRoutingMode is BIRD,
-                            confd and BIRD program that route. When ClusterRoutingMode is Felix, it is expected that Felix will program that route.
-                            Felix always programs such routes for IP Pools with vxlanMode: Always or vxlanMode: CrossSubnet. [Default: BIRD]
+                            ClusterRoutingMode controls which component programs the routes that a node needs in order to reach
+                            workloads on other nodes. It only applies to IP Pools with vxlanMode: Never; the routes for IP Pools
+                            with vxlanMode: Always or vxlanMode: CrossSubnet are always programmed by Felix.
+                            In BIRD mode, confd and BIRD program the routes for both IPIP and unencapsulated IP Pools.
+                            In Felix mode, Felix programs the routes for both IPIP and unencapsulated IP Pools.
+                            In FelixIPIPOnly mode, Felix programs the routes for IPIP IP Pools, and confd and BIRD program them
+                            for unencapsulated IP Pools.
+                            If not specified, the operator writes neither FelixConfiguration.programClusterRoutes nor
+                            BGPConfiguration.programClusterRoutes, so Calico's own defaults apply; as of Calico v3.33 those
+                            defaults are equivalent to FelixIPIPOnly.
+                            Note that BIRD programming of IPIP routes, which the BIRD mode selects, is deprecated as of
+                            Calico v3.33 and is intended for removal in v3.35.
                           enum:
                             - BIRD
                             - Felix
+                            - FelixIPIPOnly
                           type: string
                         containerIPForwarding:
                           description: |-


### PR DESCRIPTION
## Description

**Type:** new feature. **Depends on** projectcalico/calico#13470 — see "Merge order" below.

Calico is moving ownership of IPIP cluster routes from confd/BIRD to Felix, and
deprecating BIRD's ability to program them at all. Calico expresses that per
encapsulation type: `FelixConfiguration.programClusterRoutes` and
`BGPConfiguration.programClusterRoutes` each now take `Disabled`,
`EnabledIPIPOnly`, `EnabledNoEncapOnly` or `Enabled`, and their defaults move to
the complementary pair that puts IPIP with Felix and unencapsulated pools with
BIRD.

`clusterRoutingMode` was a single `BIRD` / `Felix` choice and could not express
that split. This adds a third value, `FelixIPIPOnly`, and maps the three modes
onto the two Calico fields:

| `clusterRoutingMode` | `FelixConfiguration` | `BGPConfiguration` |
|---|---|---|
| `BIRD` | `Disabled` | `Enabled` |
| `Felix` | `Enabled` | `Disabled` |
| `FelixIPIPOnly` | `EnabledIPIPOnly` | `EnabledNoEncapOnly` |

### Unset `clusterRoutingMode` — no change in operator behaviour

Unset continues to mean "write neither field", so Calico's own defaults decide.
Worth being explicit about, because it means **operator-installed clusters that
have not set `clusterRoutingMode` do pick up Calico's new defaults on upgrade**,
without any operator change — IPIP cluster routes move from BIRD to Felix. This
PR is what lets a user pin or opt into that split explicitly; it is not what
enables it.

The field's doc comment previously said `[Default: BIRD]`. That was only ever an
observation about what Calico defaulted to when the operator wrote nothing, and
it is now wrong, so the comment says what actually happens instead.

### Validation

Validation asked one "does Felix program the cluster routes" question and applied
the answer to both IPIP and unencapsulated pools. That is no longer a single
question, so it is split in two: an IPIP pool requires BGP unless Felix owns the
IPIP routes, and an unencapsulated pool requires BGP unless Felix owns those.

So `FelixIPIPOnly` allows an IPIP pool with BGP disabled — new, and the point of
the value — but still rejects an unencapsulated pool with BGP disabled, correctly,
because in that mode BIRD is the component programming them.

Both predicates deliberately return `false` when `clusterRoutingMode` is unset,
so nothing that was rejected before becomes allowed by default. The alternative —
treating unset as equivalent to Calico's default — would mean encoding which
Calico version defaults which way, and that coupling would go stale silently.
The cost is that unset and `FelixIPIPOnly` behave identically at runtime but
differ in validation, with unset the stricter of the two. **Reviewers: this is
the judgement call in this PR most worth a second opinion.**

## Merge order

The operator writes `EnabledIPIPOnly` / `EnabledNoEncapOnly` as plain strings, so
this compiles and its unit tests pass today. But a real cluster's
FelixConfiguration and BGPConfiguration CRDs only accept those values once
projectcalico/calico#13470 has merged **and** `pkg/imports/crds/calico/` has been
re-imported from Calico master. Until both have happened, selecting
`FelixIPIPOnly` on a live cluster will be rejected by the apiserver. Please hold
this until then; the CRD re-import is not part of this PR.

## Testing

- `pkg/controller/installation`: 310 of 324 specs pass. The 14 failures are the
  pre-existing `cel_validation_test.go` `BeforeEach` failures, which need envtest
  assets — the same 14 fail on an unmodified `master` (306 of 320 there, so all
  four new specs pass and nothing regressed).
- New specs: the `FelixIPIPOnly` reconcile mapping, plus validation cases for
  IPIP, IPIP-cross-subnet and unencapsulated pools with BGP disabled under
  `FelixIPIPOnly`.
- `golangci-lint run`: 0 issues.
- `make gen-files` for the regenerated Installation CRD.
- Not yet exercised on a live cluster — that depends on the merge order above.

Also worth a reviewer's eye: `FelixIPIPOnly` with BGP disabled is now an allowed
combination that has not been run end-to-end. It is structurally the same shape
as VXLAN with BGP disabled (Felix owns the routes, no BIRD), but if you would
rather this PR did not widen validation at all, say so and I will drop that part
and keep the mode purely as a mapping.

## Release Note

```release-note
Added a FelixIPIPOnly value to Installation clusterRoutingMode, selecting Felix for the cluster routes of IPIP IP pools and confd/BIRD for those of unencapsulated IP pools.
```

## For PR author

- [x] Tests for change.
- [x] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
