### PR TITLE
fix: replace projectcalico.org/name with kubernetes.io/metadata.name in NetworkPolicies

### DIFF
--- a/pkg/controller/policyrecommendation/policyrecommendation_controller.go
+++ b/pkg/controller/policyrecommendation/policyrecommendation_controller.go
@@ -540,10 +540,10 @@ func (r *ReconcilePolicyRecommendation) createDefaultPolicyRecommendationScope(c
 	prs.Name = "default"
 	prs.Spec.NamespaceSpec = &v3.PolicyRecommendationScopeNamespaceSpec{
 		RecStatus: "Disabled",
-		Selector:  "!(projectcalico.org/name starts with 'tigera-') && !(projectcalico.org/name starts with 'calico-') && !(projectcalico.org/name starts with 'kube-')",
+		Selector:  "!(kubernetes.io/metadata.name starts with 'tigera-') && !(kubernetes.io/metadata.name starts with 'calico-') && !(kubernetes.io/metadata.name starts with 'kube-')",
 	}
 	if r.opts.DetectedProvider.IsOpenShift() {
-		prs.Spec.NamespaceSpec.Selector += " && !(projectcalico.org/name starts with 'openshift-')"
+		prs.Spec.NamespaceSpec.Selector += " && !(kubernetes.io/metadata.name starts with 'openshift-')"
 	}
 
 	if err := r.client.Create(ctx, prs); err != nil {

--- a/pkg/controller/policyrecommendation/policyrecommendation_controller_test.go
+++ b/pkg/controller/policyrecommendation/policyrecommendation_controller_test.go
@@ -545,7 +545,7 @@ var _ = Describe("PolicyRecommendation controller tests", func() {
 
 			// Verify the values of the created PolicyRecommendationScope object.
 			Expect(prs.Spec.NamespaceSpec.RecStatus).To(Equal(v3.PolicyRecommendationDisabled))
-			Expect(prs.Spec.NamespaceSpec.Selector).To(Equal("!(projectcalico.org/name starts with 'tigera-') && !(projectcalico.org/name starts with 'calico-') && !(projectcalico.org/name starts with 'kube-')"))
+			Expect(prs.Spec.NamespaceSpec.Selector).To(Equal("!(kubernetes.io/metadata.name starts with 'tigera-') && !(kubernetes.io/metadata.name starts with 'calico-') && !(kubernetes.io/metadata.name starts with 'kube-')"))
 		})
 
 		It("should create default PolicyRecommendationScope for openshift", func() {
@@ -584,7 +584,7 @@ var _ = Describe("PolicyRecommendation controller tests", func() {
 
 			// Verify the values of the created PolicyRecommendationScope object.
 			Expect(prs.Spec.NamespaceSpec.RecStatus).To(Equal(v3.PolicyRecommendationDisabled))
-			Expect(prs.Spec.NamespaceSpec.Selector).To(Equal("!(projectcalico.org/name starts with 'tigera-') && !(projectcalico.org/name starts with 'calico-') && !(projectcalico.org/name starts with 'kube-') && !(projectcalico.org/name starts with 'openshift-')"))
+			Expect(prs.Spec.NamespaceSpec.Selector).To(Equal("!(kubernetes.io/metadata.name starts with 'tigera-') && !(kubernetes.io/metadata.name starts with 'calico-') && !(kubernetes.io/metadata.name starts with 'kube-') && !(kubernetes.io/metadata.name starts with 'openshift-')"))
 		})
 	})
 })

--- a/pkg/render/common/networkpolicy/networkpolicy.go
+++ b/pkg/render/common/networkpolicy/networkpolicy.go
@@ -49,7 +49,7 @@ func AppendDNSEgressRules(egressRules []v3.Rule, openShift bool) []v3.Rule {
 				Action:   v3.Allow,
 				Protocol: &UDPProtocol,
 				Destination: v3.EntityRule{
-					NamespaceSelector: "projectcalico.org/name == 'openshift-dns'",
+					NamespaceSelector: "kubernetes.io/metadata.name == 'openshift-dns'",
 					Selector:          "dns.operator.openshift.io/daemonset-dns == 'default'",
 					Ports:             Ports(5353),
 				},
@@ -58,7 +58,7 @@ func AppendDNSEgressRules(egressRules []v3.Rule, openShift bool) []v3.Rule {
 				Action:   v3.Allow,
 				Protocol: &TCPProtocol,
 				Destination: v3.EntityRule{
-					NamespaceSelector: "projectcalico.org/name == 'openshift-dns'",
+					NamespaceSelector: "kubernetes.io/metadata.name == 'openshift-dns'",
 					Selector:          "dns.operator.openshift.io/daemonset-dns == 'default'",
 					Ports:             Ports(5353),
 				},
@@ -69,7 +69,7 @@ func AppendDNSEgressRules(egressRules []v3.Rule, openShift bool) []v3.Rule {
 			Action:   v3.Allow,
 			Protocol: &UDPProtocol,
 			Destination: v3.EntityRule{
-				NamespaceSelector: "projectcalico.org/name == 'kube-system'",
+				NamespaceSelector: "kubernetes.io/metadata.name == 'kube-system'",
 				// In most Kubernetes distros the label is for kube-dns, but in Canonical it is for coredns.
 				Selector: "k8s-app in { 'kube-dns', 'coredns' }",
 				Ports:    Ports(53),
@@ -83,7 +83,7 @@ func AppendDNSEgressRules(egressRules []v3.Rule, openShift bool) []v3.Rule {
 // CreateEntityRule creates an entity rule that matches traffic using label selectors based on namespace, deployment name, and port.
 func CreateEntityRule(namespace string, deploymentName string, ports ...uint16) v3.EntityRule {
 	return v3.EntityRule{
-		NamespaceSelector: fmt.Sprintf("projectcalico.org/name == '%s'", namespace),
+		NamespaceSelector: fmt.Sprintf("kubernetes.io/metadata.name == '%s'", namespace),
 		Selector:          fmt.Sprintf("k8s-app == '%s'", deploymentName),
 		Ports:             Ports(ports...),
 	}
@@ -93,7 +93,7 @@ func CreateEntityRule(namespace string, deploymentName string, ports ...uint16) 
 func CreateSourceEntityRule(namespace string, deploymentName string) v3.EntityRule {
 	return v3.EntityRule{
 		Selector:          fmt.Sprintf("k8s-app == '%s'", deploymentName),
-		NamespaceSelector: fmt.Sprintf("projectcalico.org/name == '%s'", namespace),
+		NamespaceSelector: fmt.Sprintf("kubernetes.io/metadata.name == '%s'", namespace),
 	}
 }
 
@@ -320,7 +320,7 @@ func DeprecatedAllowTigeraNetworkPolicyObject(name, namespace string) client.Obj
 const PrometheusSelector = "k8s-app == 'tigera-prometheus'"
 
 var PrometheusEntityRule = v3.EntityRule{
-	NamespaceSelector: "projectcalico.org/name == 'tigera-prometheus'",
+	NamespaceSelector: "kubernetes.io/metadata.name == 'tigera-prometheus'",
 	Selector:          PrometheusSelector,
 	Ports:             Ports(9095),
 }

--- a/pkg/render/common/selector/label.go
+++ b/pkg/render/common/selector/label.go
@@ -19,7 +19,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 const (
 	OpenShiftDNSDaemonsetLabel = "dns.operator.openshift.io/daemonset-dns"
 	K8sNameLabel               = "app.kubernetes.io/name"
-	CalicoNameLabel            = "projectcalico.org/name"
+	CalicoNameLabel            = "kubernetes.io/metadata.name"
 )
 
 func PodLabelSelector(name string) *metav1.LabelSelector {

--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -73,7 +73,7 @@ const (
 
 // Register secret/certs that need Server and Client Key usage
 var (
-	intrusionDetectionNamespaceSelector = fmt.Sprintf("projectcalico.org/name == '%s'", IntrusionDetectionNamespace)
+	intrusionDetectionNamespaceSelector = fmt.Sprintf("kubernetes.io/metadata.name == '%s'", IntrusionDetectionNamespace)
 	IntrusionDetectionSourceEntityRule  = v3.EntityRule{
 		NamespaceSelector: intrusionDetectionNamespaceSelector,
 		Selector:          fmt.Sprintf("k8s-app == '%s'", IntrusionDetectionControllerName),

--- a/pkg/render/intrusion_detection_test.go
+++ b/pkg/render/intrusion_detection_test.go
@@ -745,7 +745,7 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 					Action:   v3.Allow,
 					Protocol: &networkpolicy.UDPProtocol,
 					Destination: v3.EntityRule{
-						NamespaceSelector: "projectcalico.org/name == 'kube-system'",
+						NamespaceSelector: "kubernetes.io/metadata.name == 'kube-system'",
 						Selector:          "k8s-app in { 'kube-dns', 'coredns' }",
 						Ports:             networkpolicy.Ports(53),
 					},
@@ -759,7 +759,7 @@ var _ = Describe("Intrusion Detection rendering tests", func() {
 					Action:   v3.Allow,
 					Protocol: &networkpolicy.TCPProtocol,
 					Destination: v3.EntityRule{
-						NamespaceSelector: fmt.Sprintf("projectcalico.org/name == '%s'", tenantANamespace),
+						NamespaceSelector: fmt.Sprintf("kubernetes.io/metadata.name == '%s'", tenantANamespace),
 						Selector:          "k8s-app == 'calico-manager'",
 						Ports:             networkpolicy.Ports(9443),
 					},

--- a/pkg/render/logcollector/fluentbit_test.go
+++ b/pkg/render/logcollector/fluentbit_test.go
@@ -1387,7 +1387,7 @@ var _ = Describe("Tigera Secure Fluent Bit rendering tests", func() {
 				Protocol: &networkpolicy.TCPProtocol,
 				Source: v3.EntityRule{
 					Selector:          fmt.Sprintf("k8s-app == '%s'", render.ManagerDeploymentName),
-					NamespaceSelector: fmt.Sprintf("projectcalico.org/name == '%s'", render.ManagerNamespace),
+					NamespaceSelector: fmt.Sprintf("kubernetes.io/metadata.name == '%s'", render.ManagerNamespace),
 				},
 				Destination: v3.EntityRule{
 					Ports: networkpolicy.Ports(logcollector.FluentBitInputPort),

--- a/pkg/render/logcollector/networkpolicy.go
+++ b/pkg/render/logcollector/networkpolicy.go
@@ -150,7 +150,7 @@ func (c *fluentBitComponent) calicoSystemPolicy() *v3.NetworkPolicy {
 			Protocol: &networkpolicy.TCPProtocol,
 			Source:   v3.EntityRule{},
 			Destination: v3.EntityRule{
-				NamespaceSelector: fmt.Sprintf("projectcalico.org/name == '%s'", render.GuardianNamespace),
+				NamespaceSelector: fmt.Sprintf("kubernetes.io/metadata.name == '%s'", render.GuardianNamespace),
 				Selector:          networkpolicy.KubernetesAppSelector(render.GuardianServiceName),
 				NotPorts:          networkpolicy.Ports(8080),
 			},
@@ -161,7 +161,7 @@ func (c *fluentBitComponent) calicoSystemPolicy() *v3.NetworkPolicy {
 			Protocol: &networkpolicy.TCPProtocol,
 			Source:   v3.EntityRule{},
 			Destination: v3.EntityRule{
-				NamespaceSelector: fmt.Sprintf("projectcalico.org/name == '%s'", render.ElasticsearchNamespace),
+				NamespaceSelector: fmt.Sprintf("kubernetes.io/metadata.name == '%s'", render.ElasticsearchNamespace),
 				Selector:          networkpolicy.KubernetesAppSelector("tigera-secure-es-gateway"),
 				NotPorts:          networkpolicy.Ports(5554),
 			},
@@ -171,7 +171,7 @@ func (c *fluentBitComponent) calicoSystemPolicy() *v3.NetworkPolicy {
 			Protocol: &networkpolicy.TCPProtocol,
 			Source:   v3.EntityRule{},
 			Destination: v3.EntityRule{
-				NamespaceSelector: fmt.Sprintf("projectcalico.org/name == '%s'", render.ElasticsearchNamespace),
+				NamespaceSelector: fmt.Sprintf("kubernetes.io/metadata.name == '%s'", render.ElasticsearchNamespace),
 				Selector:          networkpolicy.KubernetesAppSelector("tigera-linseed"),
 				NotPorts:          networkpolicy.Ports(8444),
 			},

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -128,14 +128,14 @@ const (
 var (
 	ElasticsearchSelector   = fmt.Sprintf("elasticsearch.k8s.elastic.co/cluster-name == '%s'", ElasticsearchName)
 	ElasticsearchEntityRule = v3.EntityRule{
-		NamespaceSelector: fmt.Sprintf("projectcalico.org/name == '%s'", ElasticsearchNamespace),
+		NamespaceSelector: fmt.Sprintf("kubernetes.io/metadata.name == '%s'", ElasticsearchNamespace),
 		Selector:          ElasticsearchSelector,
 		Ports:             []numorstring.Port{{MinPort: ElasticsearchDefaultPort, MaxPort: ElasticsearchDefaultPort}},
 	}
 )
 
 var InternalElasticsearchEntityRule = v3.EntityRule{
-	NamespaceSelector: fmt.Sprintf("projectcalico.org/name == '%s'", ElasticsearchNamespace),
+	NamespaceSelector: fmt.Sprintf("kubernetes.io/metadata.name == '%s'", ElasticsearchNamespace),
 	Selector:          ElasticsearchSelector,
 	Ports:             []numorstring.Port{{MinPort: ElasticsearchInternalPort, MaxPort: ElasticsearchInternalPort}},
 }

--- a/pkg/render/logstorage/esgateway/esgateway.go
+++ b/pkg/render/logstorage/esgateway/esgateway.go
@@ -555,7 +555,7 @@ func (e *esGateway) cloudAccessNetworkPolicy() *v3.NetworkPolicy {
 				Action:   v3.Allow,
 				Protocol: &networkpolicy.TCPProtocol,
 				Source: v3.EntityRule{
-					NamespaceSelector: "projectcalico.org/name == 'monitoring'",
+					NamespaceSelector: "kubernetes.io/metadata.name == 'monitoring'",
 					Selector:          "app == 'prometheus'",
 				},
 				// Allow prometheus to scrape the metrics endpoint, which is enabled only on

--- a/pkg/render/logstorage/linseed/linseed.go
+++ b/pkg/render/logstorage/linseed/linseed.go
@@ -749,7 +749,7 @@ func (l *linseed) cloudAccessNetworkPolicy() *v3.NetworkPolicy {
 				Action:   v3.Allow,
 				Protocol: &networkpolicy.TCPProtocol,
 				Source: v3.EntityRule{
-					NamespaceSelector: "projectcalico.org/name == 'monitoring'",
+					NamespaceSelector: "kubernetes.io/metadata.name == 'monitoring'",
 					Selector:          "app == 'prometheus'",
 				},
 				Destination: v3.EntityRule{

--- a/pkg/render/testutils/expected_policies/alertmanager-mesh.json
+++ b/pkg/render/testutils/expected_policies/alertmanager-mesh.json
@@ -60,7 +60,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'kube-system'",
           "selector": "k8s-app in { 'kube-dns', 'coredns' }",
           "ports": [
             53

--- a/pkg/render/testutils/expected_policies/alertmanager-mesh_ocp.json
+++ b/pkg/render/testutils/expected_policies/alertmanager-mesh_ocp.json
@@ -60,7 +60,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -71,7 +71,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353

--- a/pkg/render/testutils/expected_policies/alertmanager.json
+++ b/pkg/render/testutils/expected_policies/alertmanager.json
@@ -29,7 +29,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'kube-system'",
           "selector": "k8s-app in { 'kube-dns', 'coredns' }",
           "ports": [
             53

--- a/pkg/render/testutils/expected_policies/alertmanager_ocp.json
+++ b/pkg/render/testutils/expected_policies/alertmanager_ocp.json
@@ -29,7 +29,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -40,7 +40,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353

--- a/pkg/render/testutils/expected_policies/apiserver.json
+++ b/pkg/render/testutils/expected_policies/apiserver.json
@@ -54,7 +54,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'kube-system'",
           "selector": "k8s-app in { 'kube-dns', 'coredns' }",
           "ports": [
             53
@@ -75,7 +75,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-prometheus'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-prometheus'",
           "selector": "k8s-app == 'tigera-prometheus'",
           "ports": [
             9095
@@ -87,7 +87,7 @@
         "protocol": "TCP",
         "destination": {
           "selector": "k8s-app == 'tigera-dex'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-dex'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-dex'",
           "ports" : [
             5556
           ]
@@ -97,7 +97,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "selector": "k8s-app == 'tigera-linseed'",
           "ports": [
             8444

--- a/pkg/render/testutils/expected_policies/apiserver_ocp.json
+++ b/pkg/render/testutils/expected_policies/apiserver_ocp.json
@@ -54,7 +54,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -65,7 +65,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -86,7 +86,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-prometheus'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-prometheus'",
           "selector": "k8s-app == 'tigera-prometheus'",
           "ports": [
             9095
@@ -98,7 +98,7 @@
         "protocol": "TCP",
         "destination": {
           "selector": "k8s-app == 'tigera-dex'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-dex'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-dex'",
           "ports" : [
             5556
           ]
@@ -108,7 +108,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "selector": "k8s-app == 'tigera-linseed'",
           "ports": [
             8444

--- a/pkg/render/testutils/expected_policies/dashboards.json
+++ b/pkg/render/testutils/expected_policies/dashboards.json
@@ -17,7 +17,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'kube-system'",
           "selector": "k8s-app in { 'kube-dns', 'coredns' }",
           "ports": [
             53
@@ -28,7 +28,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-kibana'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-kibana'",
           "selector": "k8s-app == 'tigera-secure'",
           "ports": [
             5601

--- a/pkg/render/testutils/expected_policies/dashboards_ocp.json
+++ b/pkg/render/testutils/expected_policies/dashboards_ocp.json
@@ -17,7 +17,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -28,7 +28,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -39,7 +39,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-kibana'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-kibana'",
           "selector": "k8s-app == 'tigera-secure'",
           "ports": [
             5601

--- a/pkg/render/testutils/expected_policies/dex.json
+++ b/pkg/render/testutils/expected_policies/dex.json
@@ -19,7 +19,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'calico-manager'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'"
         },
         "destination": {
           "ports": [
@@ -32,7 +32,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'"
         },
         "destination": {
           "ports": [
@@ -50,7 +50,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-packetcapture'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-packetcapture'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-packetcapture'"
         }
       },
       {
@@ -76,7 +76,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'calico-apiserver'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'"
         }
       }
     ],
@@ -85,7 +85,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'kube-system'",
           "selector": "k8s-app in { 'kube-dns', 'coredns' }",
           "ports": [
             53

--- a/pkg/render/testutils/expected_policies/dex_ocp.json
+++ b/pkg/render/testutils/expected_policies/dex_ocp.json
@@ -19,7 +19,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'calico-manager'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'"
         },
         "destination": {
           "ports": [
@@ -32,7 +32,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'"
         },
         "destination": {
           "ports": [
@@ -50,7 +50,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-packetcapture'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-packetcapture'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-packetcapture'"
         }
       },
       {
@@ -76,7 +76,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'calico-apiserver'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'"
         }
       }
     ],
@@ -85,7 +85,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -96,7 +96,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353

--- a/pkg/render/testutils/expected_policies/elastic-operator.json
+++ b/pkg/render/testutils/expected_policies/elastic-operator.json
@@ -17,7 +17,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'kube-system'",
           "selector": "k8s-app in { 'kube-dns', 'coredns' }",
           "ports": [
             53
@@ -39,7 +39,7 @@
         "protocol": "TCP",
         "destination": {
           "selector": "elasticsearch.k8s.elastic.co/cluster-name == 'tigera-secure'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "ports": [
             9200
           ]

--- a/pkg/render/testutils/expected_policies/elastic-operator_ocp.json
+++ b/pkg/render/testutils/expected_policies/elastic-operator_ocp.json
@@ -17,7 +17,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -28,7 +28,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -50,7 +50,7 @@
         "protocol": "TCP",
         "destination": {
           "selector": "elasticsearch.k8s.elastic.co/cluster-name == 'tigera-secure'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "ports": [
             9200
           ]

--- a/pkg/render/testutils/expected_policies/elasticsearch-internal.json
+++ b/pkg/render/testutils/expected_policies/elasticsearch-internal.json
@@ -32,7 +32,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "selector": "elasticsearch.k8s.elastic.co/cluster-name == 'tigera-secure'",
           "ports": [
             9300

--- a/pkg/render/testutils/expected_policies/elasticsearch.json
+++ b/pkg/render/testutils/expected_policies/elasticsearch.json
@@ -19,7 +19,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-secure'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-kibana'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-kibana'"
         },
         "destination": {
           "ports": [
@@ -32,7 +32,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'"
         },
         "destination": {
           "ports": [
@@ -45,7 +45,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-linseed'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'"
         },
         "destination": {
           "ports": [
@@ -64,7 +64,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'elastic-operator'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-eck-operator'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-eck-operator'"
         }
       },
       {
@@ -82,7 +82,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'kube-system'",
           "selector": "k8s-app in { 'kube-dns', 'coredns' }",
           "ports": [
             53
@@ -93,7 +93,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-dex'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-dex'",
           "selector": "k8s-app == 'tigera-dex'",
           "ports": [
             5556
@@ -104,7 +104,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
           "ports": [
             5554
@@ -115,7 +115,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "selector": "k8s-app == 'tigera-linseed'",
           "ports": [
             8444

--- a/pkg/render/testutils/expected_policies/elasticsearch_ocp.json
+++ b/pkg/render/testutils/expected_policies/elasticsearch_ocp.json
@@ -19,7 +19,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-secure'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-kibana'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-kibana'"
         },
         "destination": {
           "ports": [
@@ -32,7 +32,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'"
         },
         "destination": {
           "ports": [
@@ -45,7 +45,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-linseed'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'"
         },
         "destination": {
           "ports": [
@@ -63,7 +63,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'elastic-operator'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-eck-operator'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-eck-operator'"
         }
       },
       {
@@ -81,7 +81,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -92,7 +92,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -103,7 +103,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-dex'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-dex'",
           "selector": "k8s-app == 'tigera-dex'",
           "ports": [
             5556
@@ -114,7 +114,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
           "ports": [
             5554
@@ -125,7 +125,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "selector": "k8s-app == 'tigera-linseed'",
           "ports": [
             8444

--- a/pkg/render/testutils/expected_policies/es-gateway.json
+++ b/pkg/render/testutils/expected_policies/es-gateway.json
@@ -19,7 +19,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "job-name == 'intrusion-detection-es-job-installer'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-intrusion-detection'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-intrusion-detection'"
         },
         "destination": {
           "ports": [
@@ -32,7 +32,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'calico-manager'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'"
         },
         "destination": {
           "ports": [
@@ -50,7 +50,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'intrusion-detection-controller'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-intrusion-detection'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-intrusion-detection'"
         }
       },
       {
@@ -63,7 +63,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'elastic-operator'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-eck-operator'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-eck-operator'"
         }
       },
       {
@@ -76,7 +76,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-elasticsearch-metrics'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'"
         }
       },
       {
@@ -94,7 +94,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'kube-system'",
           "selector": "k8s-app in { 'kube-dns', 'coredns' }",
           "ports": [
             53
@@ -105,7 +105,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-dex'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-dex'",
           "selector": "k8s-app == 'tigera-dex'",
           "ports": [
             5556
@@ -126,7 +126,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "selector": "elasticsearch.k8s.elastic.co/cluster-name == 'tigera-secure'",
           "ports": [
             9200
@@ -137,7 +137,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-kibana'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-kibana'",
           "selector": "k8s-app == 'tigera-secure'",
           "ports": [
             5601

--- a/pkg/render/testutils/expected_policies/es-gateway_ocp.json
+++ b/pkg/render/testutils/expected_policies/es-gateway_ocp.json
@@ -19,7 +19,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "job-name == 'intrusion-detection-es-job-installer'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-intrusion-detection'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-intrusion-detection'"
         },
         "destination": {
           "ports": [
@@ -32,7 +32,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'calico-manager'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'"
         },
         "destination": {
           "ports": [
@@ -50,7 +50,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'intrusion-detection-controller'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-intrusion-detection'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-intrusion-detection'"
         }
       },
       {
@@ -63,7 +63,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'elastic-operator'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-eck-operator'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-eck-operator'"
         }
       },
       {
@@ -76,7 +76,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-elasticsearch-metrics'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'"
         }
       },
       {
@@ -94,7 +94,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -105,7 +105,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -116,7 +116,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-dex'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-dex'",
           "selector": "k8s-app == 'tigera-dex'",
           "ports": [
             5556
@@ -137,7 +137,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "selector": "elasticsearch.k8s.elastic.co/cluster-name == 'tigera-secure'",
           "ports": [
             9200
@@ -148,7 +148,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-kibana'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-kibana'",
           "selector": "k8s-app == 'tigera-secure'",
           "ports": [
             5601

--- a/pkg/render/testutils/expected_policies/es-kubecontrollers.json
+++ b/pkg/render/testutils/expected_policies/es-kubecontrollers.json
@@ -17,7 +17,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'kube-system'",
           "selector": "k8s-app in { 'kube-dns', 'coredns' }",
           "ports": [
             53
@@ -40,7 +40,7 @@
         "protocol": "TCP",
         "destination": {
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "ports": [
             5554
           ]
@@ -51,7 +51,7 @@
         "protocol": "TCP",
         "destination": {
           "selector": "k8s-app == 'calico-manager'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'",
           "ports": [
             9443
           ]

--- a/pkg/render/testutils/expected_policies/es-kubecontrollers_ocp.json
+++ b/pkg/render/testutils/expected_policies/es-kubecontrollers_ocp.json
@@ -17,7 +17,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -28,7 +28,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -51,7 +51,7 @@
         "protocol": "TCP",
         "destination": {
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "ports": [
             5554
           ]
@@ -62,7 +62,7 @@
         "protocol": "TCP",
         "destination": {
           "selector": "k8s-app == 'calico-manager'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'",
           "ports": [
             9443
           ]

--- a/pkg/render/testutils/expected_policies/es-metrics.json
+++ b/pkg/render/testutils/expected_policies/es-metrics.json
@@ -37,7 +37,7 @@
         },
         "destination": {
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "ports": [
             "5554"
           ]
@@ -47,7 +47,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'kube-system'",
           "selector": "k8s-app in { 'kube-dns', 'coredns' }",
           "ports": [
             53

--- a/pkg/render/testutils/expected_policies/es-metrics_ocp.json
+++ b/pkg/render/testutils/expected_policies/es-metrics_ocp.json
@@ -37,7 +37,7 @@
         },
         "destination": {
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "ports": [
             "5554"
           ]
@@ -47,7 +47,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -58,7 +58,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353

--- a/pkg/render/testutils/expected_policies/fluentbit_managed.json
+++ b/pkg/render/testutils/expected_policies/fluentbit_managed.json
@@ -36,7 +36,7 @@
         },
         "destination": {
           "selector": "k8s-app == 'guardian'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'",
           "notPorts": [
             8080
           ]

--- a/pkg/render/testutils/expected_policies/fluentbit_unmanaged.json
+++ b/pkg/render/testutils/expected_policies/fluentbit_unmanaged.json
@@ -37,7 +37,7 @@
         },
         "destination": {
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "notPorts": [
             5554
           ]
@@ -50,7 +50,7 @@
         },
         "destination": {
           "selector": "k8s-app == 'tigera-linseed'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "notPorts": [
             8444
           ]
@@ -60,7 +60,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'kube-system'",
           "selector": "k8s-app in { 'kube-dns', 'coredns' }",
           "ports": [
             53

--- a/pkg/render/testutils/expected_policies/fluentbit_unmanaged_ocp.json
+++ b/pkg/render/testutils/expected_policies/fluentbit_unmanaged_ocp.json
@@ -37,7 +37,7 @@
         },
         "destination": {
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "notPorts": [
             5554
           ]
@@ -50,7 +50,7 @@
         },
         "destination": {
           "selector": "k8s-app == 'tigera-linseed'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "notPorts": [
             8444
           ]
@@ -60,7 +60,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -71,7 +71,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353

--- a/pkg/render/testutils/expected_policies/guardian.json
+++ b/pkg/render/testutils/expected_policies/guardian.json
@@ -36,7 +36,7 @@
         },
         "protocol": "TCP",
         "source": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-intrusion-detection'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-intrusion-detection'",
           "selector": "k8s-app == 'intrusion-detection-controller'"
         }
       },
@@ -49,7 +49,7 @@
         },
         "protocol": "TCP",
         "source": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-intrusion-detection'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-intrusion-detection'",
           "selector": "job-name == 'intrusion-detection-es-job-installer'"
         }
       },
@@ -68,7 +68,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-packetcapture'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-packetcapture'",
           "selector": "k8s-app == 'tigera-packetcapture'",
           "ports": [
             8444
@@ -79,7 +79,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'kube-system'",
           "selector": "k8s-app in { 'kube-dns', 'coredns' }",
           "ports": [
             53
@@ -101,7 +101,7 @@
         "protocol": "TCP",
         "destination": {
           "selector": "k8s-app == 'tigera-prometheus'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-prometheus'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-prometheus'",
           "ports": [
             9095
           ]

--- a/pkg/render/testutils/expected_policies/guardian_ocp.json
+++ b/pkg/render/testutils/expected_policies/guardian_ocp.json
@@ -36,7 +36,7 @@
         },
         "protocol": "TCP",
         "source": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-intrusion-detection'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-intrusion-detection'",
           "selector": "k8s-app == 'intrusion-detection-controller'"
         }
       },
@@ -49,7 +49,7 @@
         },
         "protocol": "TCP",
         "source": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-intrusion-detection'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-intrusion-detection'",
           "selector": "job-name == 'intrusion-detection-es-job-installer'"
         }
       },
@@ -68,7 +68,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-packetcapture'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-packetcapture'",
           "selector": "k8s-app == 'tigera-packetcapture'",
           "ports": [
             8444
@@ -79,7 +79,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -90,7 +90,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -112,7 +112,7 @@
         "protocol": "TCP",
         "destination": {
           "selector": "k8s-app == 'tigera-prometheus'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-prometheus'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-prometheus'",
           "ports": [
             9095
           ]

--- a/pkg/render/testutils/expected_policies/intrusion-detection-controller_managed.json
+++ b/pkg/render/testutils/expected_policies/intrusion-detection-controller_managed.json
@@ -41,7 +41,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'kube-system'",
           "selector": "k8s-app in { 'kube-dns', 'coredns' }",
           "ports": [
             53
@@ -53,7 +53,7 @@
         "protocol": "TCP",
         "destination": {
           "selector": "k8s-app == 'guardian'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'",
           "ports": [
             8080
           ]

--- a/pkg/render/testutils/expected_policies/intrusion-detection-controller_managed_ocp.json
+++ b/pkg/render/testutils/expected_policies/intrusion-detection-controller_managed_ocp.json
@@ -41,7 +41,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -52,7 +52,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -64,7 +64,7 @@
         "protocol": "TCP",
         "destination": {
           "selector": "k8s-app == 'guardian'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'",
           "ports": [
             8080
           ]

--- a/pkg/render/testutils/expected_policies/intrusion-detection-controller_management.json
+++ b/pkg/render/testutils/expected_policies/intrusion-detection-controller_management.json
@@ -41,7 +41,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'kube-system'",
           "selector": "k8s-app in { 'kube-dns', 'coredns' }",
           "ports": [
             53
@@ -53,7 +53,7 @@
         "protocol": "TCP",
         "destination": {
           "selector": "k8s-app == 'tigera-linseed'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "ports": [
             8444
           ]
@@ -63,7 +63,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == '<MANAGER_NAMESPACE>'",
+          "namespaceSelector": "kubernetes.io/metadata.name == '<MANAGER_NAMESPACE>'",
           "selector": "k8s-app == '<MANAGER_NAME>'",
           "ports": [
             9443

--- a/pkg/render/testutils/expected_policies/intrusion-detection-controller_management_ocp.json
+++ b/pkg/render/testutils/expected_policies/intrusion-detection-controller_management_ocp.json
@@ -41,7 +41,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -52,7 +52,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -64,7 +64,7 @@
         "protocol": "TCP",
         "destination": {
           "selector": "k8s-app == 'tigera-linseed'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "ports": [
             8444
           ]
@@ -74,7 +74,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == '<MANAGER_NAMESPACE>'",
+          "namespaceSelector": "kubernetes.io/metadata.name == '<MANAGER_NAMESPACE>'",
           "selector": "k8s-app == '<MANAGER_NAME>'",
           "ports": [
             9443

--- a/pkg/render/testutils/expected_policies/intrusion-detection-controller_standalone.json
+++ b/pkg/render/testutils/expected_policies/intrusion-detection-controller_standalone.json
@@ -41,7 +41,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'kube-system'",
           "selector": "k8s-app in { 'kube-dns', 'coredns' }",
           "ports": [
             53
@@ -53,7 +53,7 @@
         "protocol": "TCP",
         "destination": {
           "selector": "k8s-app == 'tigera-linseed'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "ports": [
             8444
           ]

--- a/pkg/render/testutils/expected_policies/intrusion-detection-controller_standalone_ocp.json
+++ b/pkg/render/testutils/expected_policies/intrusion-detection-controller_standalone_ocp.json
@@ -41,7 +41,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -52,7 +52,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -64,7 +64,7 @@
         "protocol": "TCP",
         "destination": {
           "selector": "k8s-app == 'tigera-linseed'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "ports": [
             8444
           ]

--- a/pkg/render/testutils/expected_policies/intrusion-detection-elastic.json
+++ b/pkg/render/testutils/expected_policies/intrusion-detection-elastic.json
@@ -17,7 +17,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'kube-system'",
           "selector": "k8s-app in { 'kube-dns', 'coredns' }",
           "ports": [
             53
@@ -29,7 +29,7 @@
         "protocol": "TCP",
         "destination": {
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "ports": [
             5554
           ]

--- a/pkg/render/testutils/expected_policies/intrusion-detection-elastic_ocp.json
+++ b/pkg/render/testutils/expected_policies/intrusion-detection-elastic_ocp.json
@@ -17,7 +17,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -28,7 +28,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -40,7 +40,7 @@
         "protocol": "TCP",
         "destination": {
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "ports": [
             5554
           ]

--- a/pkg/render/testutils/expected_policies/kibana.json
+++ b/pkg/render/testutils/expected_policies/kibana.json
@@ -47,7 +47,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'"
         },
         "destination": {
           "ports": [
@@ -60,7 +60,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'dashboards-installer'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'"
         },
         "destination": {
           "ports": [
@@ -78,7 +78,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'elastic-operator'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-eck-operator'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-eck-operator'"
         }
       }
     ],
@@ -90,7 +90,7 @@
         },
         "destination": {
           "selector": "elasticsearch.k8s.elastic.co/cluster-name == 'tigera-secure'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "ports": [
             9200
           ]
@@ -100,7 +100,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'kube-system'",
           "selector": "k8s-app in { 'kube-dns', 'coredns' }",
           "ports": [
             53
@@ -124,7 +124,7 @@
             5554
           ],
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'"
         },
         "protocol": "TCP"
       }

--- a/pkg/render/testutils/expected_policies/kibana_ocp.json
+++ b/pkg/render/testutils/expected_policies/kibana_ocp.json
@@ -47,7 +47,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'"
         },
         "destination": {
           "ports": [
@@ -60,7 +60,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'dashboards-installer'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'"
         },
         "destination": {
           "ports": [
@@ -78,7 +78,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'elastic-operator'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-eck-operator'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-eck-operator'"
         }
       }
     ],
@@ -90,7 +90,7 @@
         },
         "destination": {
           "selector": "elasticsearch.k8s.elastic.co/cluster-name == 'tigera-secure'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "ports": [
             9200
           ]
@@ -100,7 +100,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -111,7 +111,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -135,7 +135,7 @@
             5554
           ],
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'"
         },
         "protocol": "TCP"
       }

--- a/pkg/render/testutils/expected_policies/kubecontrollers.json
+++ b/pkg/render/testutils/expected_policies/kubecontrollers.json
@@ -17,7 +17,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'kube-system'",
           "selector": "k8s-app in { 'kube-dns', 'coredns' }",
           "ports": [
             53
@@ -40,7 +40,7 @@
         "protocol": "TCP",
         "destination": {
           "selector": "k8s-app == 'calico-manager'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'",
           "ports": [
             9443
           ]

--- a/pkg/render/testutils/expected_policies/kubecontrollers_managed.json
+++ b/pkg/render/testutils/expected_policies/kubecontrollers_managed.json
@@ -17,7 +17,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'kube-system'",
           "selector": "k8s-app in { 'kube-dns', 'coredns' }",
           "ports": [
             53
@@ -40,7 +40,7 @@
         "protocol": "TCP",
         "destination": {
           "selector": "k8s-app == 'guardian'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'",
           "ports": [
             8080
           ]

--- a/pkg/render/testutils/expected_policies/kubecontrollers_managed_ocp.json
+++ b/pkg/render/testutils/expected_policies/kubecontrollers_managed_ocp.json
@@ -17,7 +17,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -28,7 +28,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -51,7 +51,7 @@
         "protocol": "TCP",
         "destination": {
           "selector": "k8s-app == 'guardian'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'",
           "ports": [
             8080
           ]

--- a/pkg/render/testutils/expected_policies/kubecontrollers_ocp.json
+++ b/pkg/render/testutils/expected_policies/kubecontrollers_ocp.json
@@ -17,7 +17,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -28,7 +28,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -51,7 +51,7 @@
         "protocol": "TCP",
         "destination": {
           "selector": "k8s-app == 'calico-manager'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'",
           "ports": [
             9443
           ]

--- a/pkg/render/testutils/expected_policies/linseed.json
+++ b/pkg/render/testutils/expected_policies/linseed.json
@@ -32,7 +32,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'eks-log-forwarder'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'"
         },
         "destination": {
           "ports": [
@@ -45,7 +45,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'calico-manager'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'"
         },
         "destination": {
           "ports": [
@@ -63,7 +63,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'intrusion-detection-controller'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-intrusion-detection'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-intrusion-detection'"
         }
       },
       {
@@ -76,7 +76,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'elastic-operator'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-eck-operator'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-eck-operator'"
         }
       },
       {
@@ -89,7 +89,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-elasticsearch-metrics'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'"
         }
       },
       {
@@ -102,7 +102,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-policy-recommendation'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'"
         }
       },
       {
@@ -110,7 +110,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'calico-apiserver'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'"
         },
         "destination": {
           "ports": [
@@ -124,7 +124,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'kube-system'",
           "selector": "k8s-app in { 'kube-dns', 'coredns' }",
           "ports": [
             53
@@ -145,7 +145,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "selector": "elasticsearch.k8s.elastic.co/cluster-name == 'tigera-secure'",
           "ports": [
             9200

--- a/pkg/render/testutils/expected_policies/linseed_dpi_enabled.json
+++ b/pkg/render/testutils/expected_policies/linseed_dpi_enabled.json
@@ -32,7 +32,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'eks-log-forwarder'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'"
         },
         "destination": {
           "ports": [
@@ -45,7 +45,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'calico-manager'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'"
         },
         "destination": {
           "ports": [
@@ -63,7 +63,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'intrusion-detection-controller'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-intrusion-detection'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-intrusion-detection'"
         }
       },
       {
@@ -76,7 +76,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'elastic-operator'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-eck-operator'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-eck-operator'"
         }
       },
       {
@@ -89,7 +89,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-elasticsearch-metrics'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'"
         }
       },
       {
@@ -102,7 +102,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-policy-recommendation'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'"
         }
       },
       {
@@ -110,7 +110,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'calico-apiserver'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'"
         },
         "destination": {
           "ports": [
@@ -133,7 +133,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'kube-system'",
           "selector": "k8s-app in { 'kube-dns', 'coredns' }",
           "ports": [
             53
@@ -154,7 +154,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "selector": "elasticsearch.k8s.elastic.co/cluster-name == 'tigera-secure'",
           "ports": [
             9200

--- a/pkg/render/testutils/expected_policies/linseed_ocp.json
+++ b/pkg/render/testutils/expected_policies/linseed_ocp.json
@@ -32,7 +32,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'eks-log-forwarder'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'"
         },
         "destination": {
           "ports": [
@@ -45,7 +45,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'calico-manager'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'"
         },
         "destination": {
           "ports": [
@@ -63,7 +63,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'intrusion-detection-controller'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-intrusion-detection'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-intrusion-detection'"
         }
       },
       {
@@ -76,7 +76,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'elastic-operator'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-eck-operator'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-eck-operator'"
         }
       },
       {
@@ -89,7 +89,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-elasticsearch-metrics'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'"
         }
       },
       {
@@ -102,7 +102,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-policy-recommendation'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'"
         }
       },
       {
@@ -110,7 +110,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'calico-apiserver'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'"
         },
         "destination": {
           "ports": [
@@ -124,7 +124,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -135,7 +135,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -156,7 +156,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "selector": "elasticsearch.k8s.elastic.co/cluster-name == 'tigera-secure'",
           "ports": [
             9200

--- a/pkg/render/testutils/expected_policies/linseed_ocp_dpi_enabled.json
+++ b/pkg/render/testutils/expected_policies/linseed_ocp_dpi_enabled.json
@@ -32,7 +32,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'eks-log-forwarder'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'"
         },
         "destination": {
           "ports": [
@@ -45,7 +45,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'calico-manager'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'"
         },
         "destination": {
           "ports": [
@@ -63,7 +63,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'intrusion-detection-controller'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-intrusion-detection'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-intrusion-detection'"
         }
       },
       {
@@ -76,7 +76,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'elastic-operator'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-eck-operator'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-eck-operator'"
         }
       },
       {
@@ -89,7 +89,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-elasticsearch-metrics'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'"
         }
       },
       {
@@ -102,7 +102,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'tigera-policy-recommendation'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'"
         }
       },
       {
@@ -110,7 +110,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'calico-apiserver'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'"
         },
         "destination": {
           "ports": [
@@ -133,7 +133,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -144,7 +144,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -165,7 +165,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "selector": "elasticsearch.k8s.elastic.co/cluster-name == 'tigera-secure'",
           "ports": [
             9200

--- a/pkg/render/testutils/expected_policies/manager.json
+++ b/pkg/render/testutils/expected_policies/manager.json
@@ -60,7 +60,7 @@
         "source": {},
         "destination": {
           "selector": "k8s-app == 'calico-manager'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'",
           "ports": [
             9443
           ]
@@ -82,7 +82,7 @@
         "source": {},
         "destination": {
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "ports": [
             5554
           ]
@@ -94,7 +94,7 @@
         "source": {},
         "destination": {
           "selector": "k8s-app == 'tigera-linseed'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "ports": [
             8444
           ]
@@ -104,7 +104,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-dex'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-dex'",
           "selector": "k8s-app == 'tigera-dex'",
           "ports": [
             5556
@@ -115,7 +115,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-packetcapture'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-packetcapture'",
           "selector": "k8s-app == 'tigera-packetcapture'",
           "ports": [
             8444
@@ -136,7 +136,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'kube-system'",
           "selector": "k8s-app in { 'kube-dns', 'coredns' }",
           "ports": [
             53
@@ -148,7 +148,7 @@
         "protocol": "TCP",
         "destination": {
           "selector": "k8s-app == 'tigera-prometheus'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-prometheus'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-prometheus'",
           "ports": [
             9095
           ]

--- a/pkg/render/testutils/expected_policies/manager_ocp.json
+++ b/pkg/render/testutils/expected_policies/manager_ocp.json
@@ -60,7 +60,7 @@
         "source": {},
         "destination": {
           "selector": "k8s-app == 'calico-manager'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'",
           "ports": [
             9443
           ]
@@ -82,7 +82,7 @@
         "source": {},
         "destination": {
           "selector": "k8s-app == 'tigera-secure-es-gateway'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "ports": [
             5554
           ]
@@ -94,7 +94,7 @@
         "source": {},
         "destination": {
           "selector": "k8s-app == 'tigera-linseed'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "ports": [
             8444
           ]
@@ -104,7 +104,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-dex'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-dex'",
           "selector": "k8s-app == 'tigera-dex'",
           "ports": [
             5556
@@ -115,7 +115,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-packetcapture'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-packetcapture'",
           "selector": "k8s-app == 'tigera-packetcapture'",
           "ports": [
             8444
@@ -136,7 +136,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -147,7 +147,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -159,7 +159,7 @@
         "protocol": "TCP",
         "destination": {
           "selector": "k8s-app == 'tigera-prometheus'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-prometheus'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-prometheus'",
           "ports": [
             9095
           ]

--- a/pkg/render/testutils/expected_policies/packetcapture.json
+++ b/pkg/render/testutils/expected_policies/packetcapture.json
@@ -19,7 +19,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'calico-manager'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'"
         },
         "destination": {
           "ports": [
@@ -43,7 +43,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'kube-system'",
           "selector": "k8s-app in { 'kube-dns', 'coredns' }",
           "ports": [
             53
@@ -54,7 +54,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-dex'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-dex'",
           "selector": "k8s-app == 'tigera-dex'",
           "ports": [
             5556

--- a/pkg/render/testutils/expected_policies/packetcapture_managed.json
+++ b/pkg/render/testutils/expected_policies/packetcapture_managed.json
@@ -19,7 +19,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'guardian'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'"
         },
         "destination": {
           "ports": [
@@ -43,7 +43,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'kube-system'",
           "selector": "k8s-app in { 'kube-dns', 'coredns' }",
           "ports": [
             53

--- a/pkg/render/testutils/expected_policies/packetcapture_managed_ocp.json
+++ b/pkg/render/testutils/expected_policies/packetcapture_managed_ocp.json
@@ -19,7 +19,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'guardian'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'"
         },
         "destination": {
           "ports": [
@@ -43,7 +43,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -54,7 +54,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353

--- a/pkg/render/testutils/expected_policies/packetcapture_ocp.json
+++ b/pkg/render/testutils/expected_policies/packetcapture_ocp.json
@@ -19,7 +19,7 @@
         "protocol": "TCP",
         "source": {
           "selector": "k8s-app == 'calico-manager'",
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'"
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'"
         },
         "destination": {
           "ports": [
@@ -43,7 +43,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -54,7 +54,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -65,7 +65,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-dex'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-dex'",
           "selector": "k8s-app == 'tigera-dex'",
           "ports": [
             5556

--- a/pkg/render/testutils/expected_policies/policyrecommendation.json
+++ b/pkg/render/testutils/expected_policies/policyrecommendation.json
@@ -28,7 +28,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'",
           "selector": "k8s-app == 'calico-manager'",
           "ports": [
             9443
@@ -42,7 +42,7 @@
         },
         "destination": {
           "selector": "k8s-app == 'tigera-linseed'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "ports": [
             8444
           ]
@@ -52,7 +52,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'kube-system'",
           "selector": "k8s-app in { 'kube-dns', 'coredns' }",
           "ports": [
             53

--- a/pkg/render/testutils/expected_policies/policyrecommendation_ocp.json
+++ b/pkg/render/testutils/expected_policies/policyrecommendation_ocp.json
@@ -28,7 +28,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'calico-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'calico-system'",
           "selector": "k8s-app == 'calico-manager'",
           "ports": [
             9443
@@ -42,7 +42,7 @@
         },
         "destination": {
           "selector": "k8s-app == 'tigera-linseed'",
-          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-elasticsearch'",
           "ports": [
             8444
           ]
@@ -52,7 +52,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -63,7 +63,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353

--- a/pkg/render/testutils/expected_policies/prometheus-api.json
+++ b/pkg/render/testutils/expected_policies/prometheus-api.json
@@ -29,7 +29,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'kube-system'",
           "selector": "k8s-app in { 'kube-dns', 'coredns' }",
           "ports": [
             53
@@ -40,7 +40,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-prometheus'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-prometheus'",
           "selector": "k8s-app == 'tigera-prometheus'",
           "ports": [
             9095

--- a/pkg/render/testutils/expected_policies/prometheus-api_ocp.json
+++ b/pkg/render/testutils/expected_policies/prometheus-api_ocp.json
@@ -29,7 +29,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -40,7 +40,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -51,7 +51,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-prometheus'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-prometheus'",
           "selector": "k8s-app == 'tigera-prometheus'",
           "ports": [
             9095

--- a/pkg/render/testutils/expected_policies/prometheus-operator.json
+++ b/pkg/render/testutils/expected_policies/prometheus-operator.json
@@ -17,7 +17,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'kube-system'",
           "selector": "k8s-app in { 'kube-dns', 'coredns' }",
           "ports": [
             53

--- a/pkg/render/testutils/expected_policies/prometheus-operator_ocp.json
+++ b/pkg/render/testutils/expected_policies/prometheus-operator_ocp.json
@@ -17,7 +17,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -28,7 +28,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353

--- a/pkg/render/testutils/expected_policies/prometheus.json
+++ b/pkg/render/testutils/expected_policies/prometheus.json
@@ -29,7 +29,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'kube-system'",
           "selector": "k8s-app in { 'kube-dns', 'coredns' }",
           "ports": [
             53
@@ -97,7 +97,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-dex'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-dex'",
           "selector": "k8s-app == 'tigera-dex'",
           "ports": [
             5556

--- a/pkg/render/testutils/expected_policies/prometheus_ocp.json
+++ b/pkg/render/testutils/expected_policies/prometheus_ocp.json
@@ -29,7 +29,7 @@
         "action": "Allow",
         "protocol": "UDP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -40,7 +40,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'openshift-dns'",
           "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
           "ports": [
             5353
@@ -108,7 +108,7 @@
         "action": "Allow",
         "protocol": "TCP",
         "destination": {
-          "namespaceSelector": "projectcalico.org/name == 'tigera-dex'",
+          "namespaceSelector": "kubernetes.io/metadata.name == 'tigera-dex'",
           "selector": "k8s-app == 'tigera-dex'",
           "ports": [
             5556


### PR DESCRIPTION
 Type: Bug fix / enhancement
  
  Why: On platforms where the Calico namespace controller is not enabled (e.g., EKS with AmazonVPC CNI, where ENABLED_CONTROLLERS=node,loadbalancer), the projectcalico.org/name label is never applied to
  namespaces. Operator-managed NetworkPolicies reference this label in namespace selectors, so their rules never match — breaking DNS resolution for components like Whisker and Goldmane.
  
  Fix: Replace all uses of projectcalico.org/name with kubernetes.io/metadata.name in namespace selectors (both Calico v3 and Kubernetes NetworkPolicies). This label is automatically applied by
  Kubernetes to all namespaces since v1.21 and requires no controller.
  
  Components affected:
  
  - pkg/render/common/networkpolicy/ — core DNS egress and entity rule helpers
  - pkg/render/common/selector/ — CalicoNameLabel constant
  - pkg/render/logcollector/, pkg/render/logstorage/, pkg/render/intrusion_detection.go
  - pkg/controller/policyrecommendation/ — namespace exclusion selectors
  - 58 test fixture JSON files
  
  Testing:
  
  - All unit tests pass (29 packages including render, tiers, logcollector, logstorage, gateway, gatewayapi, policyrecommendation, whisker)
  - Pre-commit hooks pass
  
  Issue: https://github.com/tigera/operator/issues/4624 (https://github.com/tigera/operator/issues/4624)
  
  Fixes #4624
  
  Release Note
  
```release-note
  Operator-managed NetworkPolicies now use the kubernetes.io/metadata.name label for namespace selectors instead of projectcalico.org/name. 
```
  
  For PR author
  
  - [x] Tests for change.
  - [ ] If changing pkg/apis/, run make gen-files (not applicable — no API changes)
  - [ ] If changing versions, run make gen-versions (not applicable)