### PR TITLE
[v1.43-2] PMREQ-810: Let kube-controllers watch Networks

### DIFF
--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -559,6 +559,15 @@ func kubeControllersRoleEnterpriseCommonRules(cfg *KubeControllersConfiguration)
 			Verbs:     []string{"update"},
 		},
 		{
+			// The node controller watches Networks so that it can discount an L2
+			// network's subnet edges and gateways from the reserved-IP metric.
+			// The Network resource is only available in Enterprise / Cloud at
+			// this time.
+			APIGroups: []string{"projectcalico.org", "crd.projectcalico.org"},
+			Resources: []string{"networks"},
+			Verbs:     []string{"list", "watch"},
+		},
+		{
 			APIGroups: []string{"projectcalico.org", "crd.projectcalico.org"},
 			Resources: []string{"deeppacketinspections"},
 			Verbs:     []string{"get", "watch", "list"},

--- a/pkg/render/kubecontrollers/kube-controllers_test.go
+++ b/pkg/render/kubecontrollers/kube-controllers_test.go
@@ -306,7 +306,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(len(dp.Spec.Template.Spec.Volumes)).To(Equal(1))
 
 		clusterRole := rtest.GetResource(resources, kubecontrollers.KubeControllerRole, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
-		Expect(clusterRole.Rules).To(HaveLen(38), "cluster role should have 38 rules")
+		Expect(clusterRole.Rules).To(HaveLen(39), "cluster role should have 39 rules")
 
 		// Application-layer reconciler RBAC: WAF CRDs (resources, /status, /finalizers).
 		Expect(clusterRole.Rules).To(ContainElement(rbacv1.PolicyRule{
@@ -484,7 +484,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(dp.Spec.Template.Spec.Volumes[0].ConfigMap.Name).To(Equal("tigera-ca-bundle"))
 
 		clusterRole := rtest.GetResource(resources, kubecontrollers.EsKubeControllerRole, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
-		Expect(clusterRole.Rules).To(HaveLen(36), "cluster role should have 36 rules")
+		Expect(clusterRole.Rules).To(HaveLen(37), "cluster role should have 37 rules")
 		Expect(clusterRole.Rules).To(ContainElement(
 			rbacv1.PolicyRule{
 				APIGroups: []string{""},
@@ -783,7 +783,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		Expect(dp.Spec.Template.Spec.Containers[0].Image).To(Equal("test-reg/tigera/calico:" + components.ComponentTigeraCalico.Version))
 
 		clusterRole := rtest.GetResource(resources, kubecontrollers.EsKubeControllerRole, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
-		Expect(clusterRole.Rules).To(HaveLen(36), "cluster role should have 36 rules")
+		Expect(clusterRole.Rules).To(HaveLen(37), "cluster role should have 37 rules")
 		Expect(clusterRole.Rules).To(ContainElement(
 			rbacv1.PolicyRule{
 				APIGroups: []string{""},


### PR DESCRIPTION
Picks the PMREQ-810 operator change that has already merged to master onto the
EP2 release branch, alongside the matching monorepo pick
(tigera/calico-private#13174) onto `release-calient-v3.24-2`.

**Cherry-pick history**
- Pick onto **release-v1.43-2**: tigera/operator#5148

kube-controllers needs `list`/`watch` on `networks` to serve the L2 Network
resource. Without it the `list` is denied, and because a 403 stalls the whole
DataFeed rather than just that one syncer, the symptom shows up somewhere
unrelated — an `[Feature:AutoHEPs]` e2e failure.

Applied with only auto-merge; no conflicts.

Two related changes need no pick. Operator#4883, which grants Network access to
`tigera-network-admin` and `tigera-ui-user`, merged on 2026-06-03 and is
already an ancestor of this branch. The Network CRD's L2 bridge and VLAN fields
are absent from this branch today, but they arrive through the automated
`Sync versions from Calico and Calico Enterprise` job — which runs on
`release-v1.43-2` — once the monorepo pick lands on
`release-calient-v3.24-2`. Hand-picking the generated CRDs would only conflict
with that job.

### Testing

`go test ./pkg/render/kubecontrollers/...` passes. `go build ./...` is clean.

PMREQ-810

**Release note:**
```release-note
kube-controllers can now watch Network resources, which L2 bridge support requires.
```
