### PR TITLE
Mount host /proc into calico-node at /host/proc

### DIFF
--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1457,6 +1457,12 @@ func (c *nodeComponent) nodeVolumeMounts() []corev1.VolumeMount {
 		// Read-only so Felix can detect kernel lockdown=confidentiality via
 		// /sys/kernel/security/lockdown (securityfs is separate from /sys/fs).
 		corev1.VolumeMount{MountPath: "/sys/kernel/security", Name: "sys-kernel-security", ReadOnly: true},
+		// Read-only bind of the host's /proc. Felix reaches host-mount-namespace
+		// paths (pod netns files, the CRI socket) through host PID-1's root at
+		// /host/proc/1/root, which works regardless of calico-node's PID
+		// namespace and does not require hostPID=true. Reuses the "nodeproc"
+		// HostPath(/proc) volume already declared in nodeVolumes().
+		corev1.VolumeMount{MountPath: "/host/proc", Name: "nodeproc", ReadOnly: true},
 		c.cfg.TLS.NodeSecret.VolumeMount(c.SupportedOSType()),
 	)
 

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -364,6 +364,7 @@ var _ = Describe("Node rendering tests", func() {
 					{MountPath: "/var/log/calico/cni", Name: "cni-log-dir", ReadOnly: false},
 					{MountPath: "/sys/fs/bpf", Name: "bpffs"},
 					{MountPath: "/sys/kernel/security", Name: "sys-kernel-security", ReadOnly: true},
+					{MountPath: "/host/proc", Name: "nodeproc", ReadOnly: true},
 				}
 				Expect(ds.Spec.Template.Spec.Containers[0].VolumeMounts).To(ConsistOf(expectedNodeVolumeMounts))
 
@@ -558,6 +559,7 @@ var _ = Describe("Node rendering tests", func() {
 					{MountPath: "/var/log/calico/cni", Name: "cni-log-dir", ReadOnly: false},
 					{MountPath: "/sys/fs/bpf", Name: "bpffs"},
 					{MountPath: "/sys/kernel/security", Name: "sys-kernel-security", ReadOnly: true},
+					{MountPath: "/host/proc", Name: "nodeproc", ReadOnly: true},
 				}
 				Expect(ds.Spec.Template.Spec.Containers[0].VolumeMounts).To(ConsistOf(expectedNodeVolumeMounts))
 
@@ -988,6 +990,7 @@ var _ = Describe("Node rendering tests", func() {
 					{MountPath: "/var/log/calico/cni", Name: "cni-log-dir", ReadOnly: false},
 					{MountPath: "/sys/fs/bpf", Name: "bpffs"},
 					{MountPath: "/sys/kernel/security", Name: "sys-kernel-security", ReadOnly: true},
+					{MountPath: "/host/proc", Name: "nodeproc", ReadOnly: true},
 				}
 				Expect(ds.Spec.Template.Spec.Containers[0].VolumeMounts).To(ConsistOf(expectedNodeVolumeMounts))
 
@@ -1125,6 +1128,7 @@ var _ = Describe("Node rendering tests", func() {
 					{MountPath: "/node-certs", Name: render.NodeTLSSecretName, ReadOnly: true},
 					{MountPath: "/sys/fs/bpf", Name: "bpffs"},
 					{MountPath: "/sys/kernel/security", Name: "sys-kernel-security", ReadOnly: true},
+					{MountPath: "/host/proc", Name: "nodeproc", ReadOnly: true},
 				}
 				Expect(ds.Spec.Template.Spec.Containers[0].VolumeMounts).To(ConsistOf(expectedNodeVolumeMounts))
 
@@ -1396,6 +1400,7 @@ var _ = Describe("Node rendering tests", func() {
 					{MountPath: "/var/log/calico/cni", Name: "cni-log-dir", ReadOnly: false},
 					{MountPath: "/sys/fs/bpf", Name: "bpffs"},
 					{MountPath: "/sys/kernel/security", Name: "sys-kernel-security", ReadOnly: true},
+					{MountPath: "/host/proc", Name: "nodeproc", ReadOnly: true},
 				}
 				Expect(ds.Spec.Template.Spec.Containers[0].VolumeMounts).To(ConsistOf(expectedNodeVolumeMounts))
 
@@ -1530,6 +1535,7 @@ var _ = Describe("Node rendering tests", func() {
 					{MountPath: "/node-certs", Name: render.NodeTLSSecretName, ReadOnly: true},
 					{MountPath: "/sys/fs/bpf", Name: "bpffs"},
 					{MountPath: "/sys/kernel/security", Name: "sys-kernel-security", ReadOnly: true},
+					{MountPath: "/host/proc", Name: "nodeproc", ReadOnly: true},
 				}
 				Expect(ds.Spec.Template.Spec.Containers[0].VolumeMounts).To(ConsistOf(expectedNodeVolumeMounts))
 


### PR DESCRIPTION
## Description

Companion to the calico-side "Resolve pod netns in Felix" change (implements design tigera/designs#62). Felix's new pod-netns resolution reaches host-mount-namespace paths (pod netns files, the CRI socket) through host PID-1's root at `/host/proc/1/root`, which works regardless of calico-node's PID namespace and does **not** require `hostPID=true`.

This PR bind-mounts the host's `/proc` into calico-node at `/host/proc` (read-only), reusing the existing `nodeproc` HostPath(`/proc`) volume. The existing `hostPID=true` usage for process-path collection is left as-is; converging it is a separate Enterprise follow-up.

- Affected: `pkg/render/node.go` (+ node render test). No API change.
- The `ValidatingAdmissionPolicy` delivery and the `Installation.spec.cniAnnotationsPolicy` toggle land in a follow-up PR stacked on this one.

## Release Note

```release-note
The operator bind-mounts the host /proc into calico-node at /host/proc (read-only) to support Felix pod network-namespace resolution.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
