### PR TITLE
Match the Enterprise product, not one of its two spellings

### DIFF
--- a/pkg/controller/utils/component_enterprise_test.go
+++ b/pkg/controller/utils/component_enterprise_test.go
@@ -41,45 +41,52 @@ import (
 // A real typha component goes through the handler with the enterprise modifier
 // attached, so this fails if dispatch or the modifier stops matching render.
 var _ = Describe("enterprise typha modifier integration", func() {
-	It("applies the enterprise typha modifier to real render output", func() {
-		scheme := runtime.NewScheme()
-		Expect(apis.AddToScheme(scheme, false)).NotTo(HaveOccurred())
-		cli := ctrlrfake.DefaultFakeClientBuilder(scheme).Build()
+	// Both spellings have to reach the modifier: an Installation asking for the
+	// deprecated TigeraSecureEnterprise otherwise renders Typha without the
+	// Enterprise-only permissions, and Typha never becomes ready.
+	DescribeTable("applies the enterprise typha modifier to real render output",
+		func(variant operatorv1.ProductVariant) {
+			scheme := runtime.NewScheme()
+			Expect(apis.AddToScheme(scheme, false)).NotTo(HaveOccurred())
+			cli := ctrlrfake.DefaultFakeClientBuilder(scheme).Build()
 
-		certManager, err := certificatemanager.Create(cli, nil, "", common.OperatorNamespace(), certificatemanager.AllowCACreation())
-		Expect(err).NotTo(HaveOccurred())
-		nodeKeyPair, err := certManager.GetOrCreateKeyPair(cli, render.NodeTLSSecretName, common.OperatorNamespace(), []string{render.FelixCommonName})
-		Expect(err).NotTo(HaveOccurred())
-		typhaKeyPair, err := certManager.GetOrCreateKeyPair(cli, render.TyphaTLSSecretName, common.OperatorNamespace(), []string{render.TyphaCommonName})
-		Expect(err).NotTo(HaveOccurred())
+			certManager, err := certificatemanager.Create(cli, nil, "", common.OperatorNamespace(), certificatemanager.AllowCACreation())
+			Expect(err).NotTo(HaveOccurred())
+			nodeKeyPair, err := certManager.GetOrCreateKeyPair(cli, render.NodeTLSSecretName, common.OperatorNamespace(), []string{render.FelixCommonName})
+			Expect(err).NotTo(HaveOccurred())
+			typhaKeyPair, err := certManager.GetOrCreateKeyPair(cli, render.TyphaTLSSecretName, common.OperatorNamespace(), []string{render.TyphaCommonName})
+			Expect(err).NotTo(HaveOccurred())
 
-		instance := &operatorv1.InstallationSpec{
-			Variant: operatorv1.CalicoEnterprise,
-			CNI:     &operatorv1.CNISpec{Type: operatorv1.PluginCalico},
-		}
-		typhaCfg := &render.TyphaConfiguration{
-			K8sServiceEp:    k8sapi.ServiceEndpoint{},
-			Installation:    instance,
-			ClusterDomain:   dns.DefaultClusterDomain,
-			FelixHealthPort: 9099,
-			TLS: &render.TyphaNodeTLS{
-				TrustedBundle:   certManager.CreateTrustedBundle(),
-				TyphaSecret:     typhaKeyPair,
-				TyphaCommonName: render.TyphaCommonName,
-				NodeSecret:      nodeKeyPair,
-				NodeCommonName:  render.FelixCommonName,
-			},
-		}
+			instance := &operatorv1.InstallationSpec{
+				Variant: variant,
+				CNI:     &operatorv1.CNISpec{Type: operatorv1.PluginCalico},
+			}
+			typhaCfg := &render.TyphaConfiguration{
+				K8sServiceEp:    k8sapi.ServiceEndpoint{},
+				Installation:    instance,
+				ClusterDomain:   dns.DefaultClusterDomain,
+				FelixHealthPort: 9099,
+				TLS: &render.TyphaNodeTLS{
+					TrustedBundle:   certManager.CreateTrustedBundle(),
+					TyphaSecret:     typhaKeyPair,
+					TyphaCommonName: render.TyphaCommonName,
+					NodeSecret:      nodeKeyPair,
+					NodeCommonName:  render.FelixCommonName,
+				},
+			}
 
-		ext := enterprise.New(operatorv1.CalicoEnterprise, eoptions.Options{}).Installation()
-		renderInputs := render.Inputs{Installation: instance}
-		handler := utils.NewComponentHandler(logf.Log, cli, scheme, nil, utils.WithModifier(func(c render.Component) render.Component {
-			return ext.Modify(c, renderInputs)
-		}))
-		Expect(handler.CreateOrUpdateOrDelete(context.Background(), render.Typha(typhaCfg), nil)).NotTo(HaveOccurred())
+			ext := enterprise.New(variant, eoptions.Options{}).Installation()
+			renderInputs := render.Inputs{Installation: instance}
+			handler := utils.NewComponentHandler(logf.Log, cli, scheme, nil, utils.WithModifier(func(c render.Component) render.Component {
+				return ext.Modify(c, renderInputs)
+			}))
+			Expect(handler.CreateOrUpdateOrDelete(context.Background(), render.Typha(typhaCfg), nil)).NotTo(HaveOccurred())
 
-		role := &rbacv1.ClusterRole{}
-		Expect(cli.Get(context.Background(), client.ObjectKey{Name: "calico-typha"}, role)).NotTo(HaveOccurred())
-		Expect(role.Rules).To(ContainElement(HaveField("Resources", ContainElement("licensekeys"))))
-	})
+			role := &rbacv1.ClusterRole{}
+			Expect(cli.Get(context.Background(), client.ObjectKey{Name: "calico-typha"}, role)).NotTo(HaveOccurred())
+			Expect(role.Rules).To(ContainElement(HaveField("Resources", ContainElement("licensekeys"))))
+		},
+		Entry("CalicoEnterprise", operatorv1.CalicoEnterprise),
+		Entry("TigeraSecureEnterprise", operatorv1.TigeraSecureEnterprise),
+	)
 })

--- a/pkg/controller/utils/component_enterprise_test.go
+++ b/pkg/controller/utils/component_enterprise_test.go
@@ -87,6 +87,7 @@ var _ = Describe("enterprise typha modifier integration", func() {
 			Expect(role.Rules).To(ContainElement(HaveField("Resources", ContainElement("licensekeys"))))
 		},
 		Entry("CalicoEnterprise", operatorv1.CalicoEnterprise),
+		//nolint:staticcheck // SA1019: the deprecated spelling is what this covers
 		Entry("TigeraSecureEnterprise", operatorv1.TigeraSecureEnterprise),
 	)
 })

--- a/pkg/enterprise/register.go
+++ b/pkg/enterprise/register.go
@@ -27,15 +27,19 @@ import (
 // New builds the Calico Enterprise extensions. After the monorepo split this is what
 // calico-private's main constructs instead.
 func New(variant operatorv1.ProductVariant, o eoptions.Options) extensions.Extensions {
-	switch variant {
-	case operatorv1.CalicoEnterprise:
+	// Enterprise has two spellings, so match on the product rather than the constant:
+	// an Installation asking for the deprecated TigeraSecureEnterprise still gets the
+	// Enterprise extensions.
+	if variant.IsEnterprise() {
 		return extensions.New(extensions.Set{
 			Installation:      installation.New(variant, o),
 			Windows:           windows.New(variant),
 			APIServer:         apiserver.New(variant, o),
 			ClusterConnection: clusterconnection.New(variant),
 		})
-	case operatorv1.Calico:
+	}
+
+	if variant == operatorv1.Calico {
 		// Clean up what a prior Enterprise installation left behind.
 		return extensions.New(extensions.Set{APIServer: apiserver.CalicoCleanup{}})
 	}

--- a/pkg/extensions/component.go
+++ b/pkg/extensions/component.go
@@ -28,10 +28,17 @@ type Modifier func(create, delete []client.Object) (newCreate, newDelete []clien
 // Decorate wraps base so modify runs over its rendered objects. An Installation
 // asking for a different variant gets base untouched.
 func Decorate(base render.Component, ri render.Inputs, variant operatorv1.ProductVariant, modify Modifier) render.Component {
-	if ri.Installation == nil || ri.Installation.Variant != variant {
+	if ri.Installation == nil || !sameProduct(ri.Installation.Variant, variant) {
 		return base
 	}
 	return &decoratedComponent{Component: base, modify: modify}
+}
+
+// sameProduct reports whether two variant values name the same product. Enterprise has
+// two spellings: TigeraSecureEnterprise is a deprecated alias for CalicoEnterprise, and
+// an Installation using either has to reach the same extension.
+func sameProduct(a, b operatorv1.ProductVariant) bool {
+	return a == b || (a.IsEnterprise() && b.IsEnterprise())
 }
 
 // decoratedComponent renders its base component and runs the modifier over the result.

--- a/pkg/extensions/extensions_test.go
+++ b/pkg/extensions/extensions_test.go
@@ -58,6 +58,7 @@ var _ = Describe("Decorate", func() {
 	})
 
 	It("runs the modifier for the deprecated Enterprise spelling", func() {
+		//nolint:staticcheck // SA1019: the deprecated spelling is what this covers
 		c := extensions.Decorate(baseComponent(), inputsFor(operatorv1.TigeraSecureEnterprise), operatorv1.CalicoEnterprise, addConfigMap)
 
 		create, _ := c.Objects()

--- a/pkg/extensions/extensions_test.go
+++ b/pkg/extensions/extensions_test.go
@@ -57,6 +57,13 @@ var _ = Describe("Decorate", func() {
 		Expect(ok).To(BeTrue())
 	})
 
+	It("runs the modifier for the deprecated Enterprise spelling", func() {
+		c := extensions.Decorate(baseComponent(), inputsFor(operatorv1.TigeraSecureEnterprise), operatorv1.CalicoEnterprise, addConfigMap)
+
+		create, _ := c.Objects()
+		Expect(create).To(HaveLen(2))
+	})
+
 	It("leaves the component alone when the Installation asks for another variant", func() {
 		c := extensions.Decorate(baseComponent(), inputsFor(operatorv1.Calico), operatorv1.CalicoEnterprise, addConfigMap)
 


### PR DESCRIPTION
## Problem

calico-private's kind clusters have been failing to come up since #4871 landed. Typha never goes ready, and its log fills with:

```
Failed to perform list of current data during resync ListRoot=".../v3/pc.org/licensekeys" cacheID=1
  error=connection is unauthorized: licensekeys.projectcalico.org is forbidden:
  User "system:serviceaccount:calico-system:calico-typha" cannot list resource "licensekeys"
  in API group "projectcalico.org" at the cluster scope
```

The same happens for `networks`, `externalnetworks`, `egressgatewaypolicies`, `packetcaptures`, `bfdconfigurations`, `deeppacketinspections` and `remoteclusterconfigurations`, on both `calico-typha` and `calico-node`. That set is exactly what `modifyTypha` and `modifyNode` add, so the Enterprise extensions were not running at all.

## Cause

`ProductVariant` has two Enterprise spellings — `CalicoEnterprise`, and `TigeraSecureEnterprise` kept as a deprecated alias (#4607). `enterprise.New` switched on the constant:

```go
switch variant {
case operatorv1.CalicoEnterprise:
	return extensions.New(extensions.Set{...})
case operatorv1.Calico:
	...
}
return extensions.Extensions{}
```

An Installation asking for `TigeraSecureEnterprise` matched neither case and fell through to the zero value, which extends nothing. Every Enterprise modifier — installation, windows, apiserver, clusterconnection — silently went missing. calico-private's `hack/test/kind/infra/values.yaml` sets `variant: TigeraSecureEnterprise`, so its kind clusters took the whole regression.

## Fix

Match on `variant.IsEnterprise()` rather than the constant, and compare the same way in `extensions.Decorate`, so an Installation and an extension that spell the variant differently still pair up. `pkg/render` was already alias-safe: every other comparison tests against `Calico`, which has only one spelling.

## Testing

`pkg/controller/utils/component_enterprise_test.go` already renders a real Typha through the handler and asserts `licensekeys` lands in the cluster role. It hardcoded `CalicoEnterprise` — the one spelling that worked — so it now runs over both, and fails on `TigeraSecureEnterprise` without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)