### PR TITLE
Align third-party versions with calico-private release-calient-v3.23

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,7 +239,7 @@ endif
 
 # To update the Istio version, see "Updating the bundled version of Istio" in docs/common_tasks.md.
 ISTIO_HELM_REPO ?= https://istio-release.storage.googleapis.com/charts
-ISTIO_VERSION ?= 1.29.4
+ISTIO_VERSION ?= 1.29.6
 ISTIO_RESOURCES_DIR = pkg/render/istio
 ISTIO_CHARTS = base istiod cni ztunnel
 ISTIO_CHART_FILES = $(addprefix $(ISTIO_RESOURCES_DIR)/,$(addsuffix .tgz,$(ISTIO_CHARTS)))

--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -47,13 +47,13 @@ components:
     version: v3.23.1
   # eck-kibana holds the version of Kibana built for tigera/kibana
   eck-kibana:
-    version: 8.19.16
+    version: 8.19.20
   kibana:
     image: kibana
     version: v3.23.1
   # eck-elasticsearch holds the version of Elasticsearch built for tigera/elasticsearch
   eck-elasticsearch:
-    version: 8.19.16
+    version: 8.19.20
   elasticsearch:
     image: elasticsearch
     version: v3.23.1
@@ -108,14 +108,14 @@ components:
   # coreos-prometheus holds the version of prometheus built for tigera/prometheus,
   # which prometheus operator uses to validate.
   coreos-prometheus:
-    version: v3.9.1
+    version: v3.13.2
   prometheus:
     image: prometheus
     version: v3.23.1
   # coreos-alertmanager holds the version of alertmanager built for tigera/alertmanager,
   # which prometheus operator uses to validate.
   coreos-alertmanager:
-    version: v0.30.1
+    version: v0.33.1
   alertmanager:
     image: alertmanager
     version: v3.23.1
@@ -140,7 +140,7 @@ components:
   # eck-elasticsearch-operator holds the version of the ECK operator used to manage
   # Elasticsearch
   eck-elasticsearch-operator:
-    version: 3.4.0
+    version: 3.4.1
   l7-collector:
     image: l7-collector
     version: v3.23.1

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -85,12 +85,12 @@ var (
 	}
 
 	ComponentEckElasticsearch = Component{
-		Version: "8.19.16",
+		Version: "8.19.20",
 		variant: enterpriseVariant,
 	}
 
 	ComponentEckKibana = Component{
-		Version: "8.19.16",
+		Version: "8.19.20",
 		variant: enterpriseVariant,
 	}
 
@@ -111,7 +111,7 @@ var (
 	}
 
 	ComponentECKElasticsearchOperator = Component{
-		Version: "3.4.0",
+		Version: "3.4.1",
 		variant: enterpriseVariant,
 	}
 
@@ -291,7 +291,7 @@ var (
 	}
 
 	ComponentCoreOSPrometheus = Component{
-		Version: "v3.9.1",
+		Version: "v3.13.2",
 		variant: enterpriseVariant,
 	}
 
@@ -312,7 +312,7 @@ var (
 	}
 
 	ComponentCoreOSAlertmanager = Component{
-		Version: "v0.30.1",
+		Version: "v0.33.1",
 		variant: enterpriseVariant,
 	}
 


### PR DESCRIPTION
## Description

Moves this branch's third-party pins to match calico-private `release-calient-v3.23`, which is bumping them in [tigera/calico-private#13239](https://github.com/tigera/calico-private/pull/13239).

This branch tracks `release-calient-v3.23` (`config/enterprise_versions.yml` → `libcalico-go`), and the operator deploys those images, so its pins have to move with calico's or it will deploy versions that no longer get built.

| component | before | after |
|---|---|---|
| `eck-kibana` | 8.19.16 | **8.19.20** |
| `eck-elasticsearch` | 8.19.16 | **8.19.20** |
| `coreos-prometheus` | v3.9.1 | **v3.13.2** |
| `coreos-alertmanager` | v0.30.1 | **v0.33.1** |
| `eck-elasticsearch-operator` | 3.4.0 | **3.4.1** |
| `ISTIO_VERSION` (Makefile) | 1.29.4 | **1.29.6** |

`pkg/components/enterprise.go` is regenerated from the yaml by `gen-versions` — not hand-edited — so `validate-gen-versions` stays clean.

### Also fixes an inconsistency

The `eck-elasticsearch-operator` bump repairs a mismatch already on this branch: `pkg/imports/crds/enterprise/01-crd-eck-bundle.yaml` was synced to ECK **3.4.1** in #5173, while this pin still claimed **3.4.0**. They now agree.

### Deliberately not changed

**Go and k8s.** [calico-private#13254](https://github.com/tigera/calico-private/pull/13254) moves v3.23 to Go 1.25.13, but this branch is on the Go 1.26 line (`GO_VERSION=1.26.5`, `K8S_VERSION=v1.36.3`). Those pins are not meant to track calico-private, and #5172 (helm v3.21.3) **requires** Go 1.26 here — aligning them downward would break it. The operator/calico Go versions have been independent on this branch for a while.

**`hack/release/prep_test.go`.** It contains the literals `8.19.16` and `v3.9.1`, so a grep for the old versions finds them. They're inputs to a self-contained round-trip test asserting that `updateConfigVersions` leaves third-party pins alone while rewriting product versions; the values are arbitrary and match nothing real. Changing them would be diff noise.

### Verified

- `go build ./...` passes.
- Istio charts re-fetched at 1.29.6 — `pkg/render/istio` passes (no golden fixtures are pinned to the chart version).
- `pkg/render/logstorage/...` (elasticsearch, kibana, eck, esgateway, esmetrics, linseed, dashboards), `pkg/components` and `hack/release` all pass.

### Companion PR

- release-v1.40: the equivalent alignment against `release-calient-v3.22`, which additionally carries Go 1.25.12 → 1.25.13.

## Release Note

```release-note
None
```
