### PR TITLE
Align third-party versions with calico-private release-calient-v3.22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ REPO?=tigera/operator
 PACKAGE_NAME?=github.com/tigera/operator
 LOCAL_USER_ID?=$(shell id -u $$USER)
 # The project Go version.
-GO_VERSION?=1.25.12
+GO_VERSION?=1.25.13
 # Version of Kubernetes to use for dependencies, tests, and kubectl.
 K8S_VERSION?=v1.35.7
 # The version of LLVM to use for the go-build image.
@@ -256,7 +256,7 @@ endif
 
 # To update the Istio version, see "Updating the bundled version of Istio" in docs/common_tasks.md.
 ISTIO_HELM_REPO ?= https://istio-release.storage.googleapis.com/charts
-ISTIO_VERSION ?= 1.29.2
+ISTIO_VERSION ?= 1.29.6
 ISTIO_RESOURCES_DIR = pkg/render/istio
 ISTIO_CHARTS = base istiod cni ztunnel
 ISTIO_CHART_FILES = $(addprefix $(ISTIO_RESOURCES_DIR)/,$(addsuffix .tgz,$(ISTIO_CHARTS)))

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/tigera/operator/api
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.80.1

--- a/config/enterprise_versions.yml
+++ b/config/enterprise_versions.yml
@@ -46,12 +46,12 @@ components:
     image: tigera/dex
     version: v3.22.6
   eck-kibana:
-    version: 8.19.19
+    version: 8.19.20
   kibana:
     image: tigera/kibana
     version: v3.22.6
   eck-elasticsearch:
-    version: 8.19.19
+    version: 8.19.20
   elasticsearch:
     image: tigera/elasticsearch
     version: v3.22.6
@@ -106,14 +106,14 @@ components:
   # coreos-prometheus holds the version of prometheus built for tigera/prometheus,
   # which prometheus operator uses to validate.
   coreos-prometheus:
-    version: v3.12.0
+    version: v3.13.2
   prometheus:
     image: tigera/prometheus
     version: v3.22.6
   # coreos-prometheus holds the version of alertmanager built for tigera/alertmanager,
   # which prometheus operator uses to validate.
   coreos-alertmanager:
-    version: v0.32.1
+    version: v0.33.1
   alertmanager:
     image: tigera/alertmanager
     version: v3.22.6

--- a/pkg/components/enterprise.go
+++ b/pkg/components/enterprise.go
@@ -69,12 +69,12 @@ var (
 	}
 
 	ComponentEckElasticsearch = Component{
-		Version:  "8.19.19",
+		Version:  "8.19.20",
 		Registry: "",
 	}
 
 	ComponentEckKibana = Component{
-		Version:  "8.19.19",
+		Version:  "8.19.20",
 		Registry: "",
 	}
 
@@ -228,7 +228,7 @@ var (
 	}
 
 	ComponentCoreOSPrometheus = Component{
-		Version:  "v3.12.0",
+		Version:  "v3.13.2",
 		Registry: "",
 	}
 
@@ -245,7 +245,7 @@ var (
 	}
 
 	ComponentCoreOSAlertmanager = Component{
-		Version:  "v0.32.1",
+		Version:  "v0.33.1",
 		Registry: "",
 	}
 


### PR DESCRIPTION
## Description

Moves this branch's third-party pins to match calico-private `release-calient-v3.22`, which is bumping them in [tigera/calico-private#13238](https://github.com/tigera/calico-private/pull/13238) (components) and [#13255](https://github.com/tigera/calico-private/pull/13255) (Go/k8s).

This branch tracks `release-calient-v3.22` (`config/enterprise_versions.yml` → `libcalico-go`), and the operator deploys those images, so its pins have to move with calico's or it will deploy versions that no longer get built.

| pin | before | after | from |
|---|---|---|---|
| `eck-kibana` | 8.19.19 | **8.19.20** | #13238 |
| `eck-elasticsearch` | 8.19.19 | **8.19.20** | #13238 |
| `coreos-prometheus` | v3.12.0 | **v3.13.2** | #13238 |
| `coreos-alertmanager` | v0.32.1 | **v0.33.1** | #13238 |
| `ISTIO_VERSION` (Makefile) | 1.29.2 | **1.29.6** | #13238 |
| `GO_VERSION` (Makefile) | 1.25.12 | **1.25.13** | #13255 |
| `api/go.mod` go directive | 1.25.12 | **1.25.13** | #13255 |

`GO_BUILD_VER` is composed from `GO_VERSION`/`LLVM_VERSION`/`K8S_VERSION`, so it becomes **1.25.13-llvm18.1.8-k8s1.35.7** — byte-for-byte the build image calico-private v3.22 moves to in #13255. That tag is published; I built against it.

`pkg/components/enterprise.go` is regenerated from the yaml by `gen-versions` — not hand-edited — so `validate-gen-versions` stays clean.

### Already aligned, so untouched

- `K8S_VERSION` is already `v1.35.7`, which is exactly what #13255 moves v3.22 to.
- `eck-elasticsearch-operator` is already `3.4.1`, matching v3.22, and this branch's `pkg/crds/enterprise/01-crd-eck-bundle.yaml` is already the 3.4.1 bundle. (The v1.42 companion needs that bump; this branch doesn't.)

### One judgement call

The `api/go.mod` go directive is normally owned by its own Renovate rule — `365268f8b` bumped it to 1.25.12 separately from the `GO_VERSION` bump, so the two are tracked independently even though they currently agree. I've included it so they don't disagree on the branch after this PR, but it's the one line here that Renovate would otherwise carry on its own. Happy to drop it if you'd rather avoid the overlap.

Note this only changes the *api submodule's* language version; the main module stays at `go 1.26.5` and the binary still compiles with Go 1.26.5 via the branch's `GOTOOLCHAIN=go1.26.4+auto`, unchanged by this PR.

### Verified

- `go build ./...` passes on `calico/go-build:1.25.13-llvm18.1.8-k8s1.35.7`.
- Istio charts re-fetched at 1.29.6 — `pkg/render/istio` passes (no golden fixtures are pinned to the chart version).
- `pkg/render/logstorage/...` (elasticsearch, kibana, eck, esgateway, esmetrics, linseed, dashboards) and `pkg/components` all pass.

### Companion PR

- release-v1.42: #5177 — the equivalent alignment against `release-calient-v3.23`. It deliberately does **not** take v3.23's Go 1.25.13, because that branch is on the Go 1.26 line.

## Release Note

```release-note
None
```
