### PR TITLE
docs: add the missing "Updating the bundled version of Istio" section

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,10 @@ else
   GIT_VERSION?=$(shell git describe --tags --dirty --always --abbrev=12)
 endif
 
-# To update the Istio version, see "Updating the bundled version of Istio" in docs/common_tasks.md.
+# To update the Istio version, see "Updating the bundled version of Istio" in
+# docs/common_tasks.md.  Keep this in step with the Istio version the calico
+# repo builds the Istio images from, or the rendered manifests will point at
+# images built from a different release.
 ISTIO_HELM_REPO ?= https://istio-release.storage.googleapis.com/charts
 ISTIO_VERSION ?= 1.29.2
 ISTIO_RESOURCES_DIR = pkg/render/istio

--- a/docs/common_tasks.md
+++ b/docs/common_tasks.md
@@ -211,3 +211,43 @@ spec:
 1. Commit everything and post as a `projectcalico/calico` PR.
 
 1. Review, address issues, merge, monitor hashrelease builds, address any further issues, etc.
+
+### Updating the bundled version of Istio
+
+The operator does not vendor Istio's manifests. It downloads Istio's Helm
+charts at build time and renders them itself, so bumping Istio is mostly a
+version change plus a re-render.
+
+Note that this version has to stay in step with the Istio version that
+`projectcalico/calico` builds its Istio images from. The operator renders the
+upstream charts, but the images those manifests point at (`istio-pilot`,
+`istio-install-cni`, `istio-ztunnel`, `istio-proxyv2`) are built in the calico
+repo under `istio/` and `third_party/istio-ztunnel/`. If the two disagree you
+get manifests from one Istio release pointing at images built from another.
+
+1. In `Makefile`, update `ISTIO_VERSION`.
+
+1. Remove the previously downloaded charts, so the new ones are fetched:
+   `rm -f pkg/render/istio/*.tgz` (or `make clean`). They are gitignored and
+   never committed, so a stale copy on disk will silently keep being used.
+
+1. Run `make istio_charts` to download `base`, `istiod`, `cni` and `ztunnel`
+   at the new version.
+
+1. Run `make build`. The charts are embedded into the binary with `go:embed`,
+   so a missing chart shows up as `pattern base.tgz: no matching files found`
+   rather than as a download error.
+
+1. Run `make ut`, or at minimum `go test ./pkg/render/istio/...`. There are no
+   golden files pinned to the chart version — the tests render the charts
+   live — so a rendering change surfaces as a test failure rather than a diff.
+
+1. Check whether the new release adds, removes or renames any rendered
+   resource, and update `pkg/render/istio` if so.
+
+1. In `projectcalico/calico`, update `ISTIO_VERSION` in `istio/Makefile` and
+   `ZTUNNEL_VERSION` in `third_party/istio-ztunnel/Makefile` to the same
+   version, and refresh any patches that no longer apply.
+
+1. Commit everything and post as a `tigera/operator` PR, alongside the
+   corresponding `projectcalico/calico` PR.


### PR DESCRIPTION
## Description

The `Makefile` has pointed at a doc section that was never written:

```make
# To update the Istio version, see "Updating the bundled version of Istio" in docs/common_tasks.md.
```

`docs/common_tasks.md` has the equivalent **Envoy Gateway** section but nothing for Istio, so that pointer is dead — on master and on every release branch back to release-v1.40. Anyone following it to bump Istio finds nothing.

This writes the section, following the Envoy Gateway one, from the procedure as it actually works today: bump `ISTIO_VERSION`, delete the downloaded charts, re-run `istio_charts`, rebuild, re-run the render tests.

### Two things worth writing down

Both are easy to get wrong and neither is discoverable from the Makefile:

- **The chart tarballs are gitignored and never committed**, so a stale copy left in `pkg/render/istio` silently keeps being used after a version bump — `make istio_charts` won't re-fetch over an existing file. They have to be deleted, not just re-made. (The failure mode is worse than it sounds: you get a green build and green tests rendering the *old* Istio version.)
- **The version has to stay in step with the calico repo.** The operator renders the upstream Helm charts; `projectcalico/calico` builds the images those manifests point at (`istio-pilot`, `istio-install-cni`, `istio-ztunnel`, `istio-proxyv2`) under `istio/` and `third_party/istio-ztunnel/`. If the two drift you get manifests from one Istio release referencing images built from another. The Makefile comment now says this too.

### Origin

Found by the review bot on #5177, a version-alignment PR against release-v1.42. The finding was valid but pre-existing and repo-wide, so it's fixed here at the source rather than in the release-branch PRs — those keep to version pins only, and this can be picked back if it's wanted on the release branches.

Docs-only; no code or generated files change.

## Release Note

```release-note
None
```
