### PR TITLE
Grant calico-kube-controllers access to Networks

### DIFF
--- a/pkg/enterprise/installation/kubecontrollers.go
+++ b/pkg/enterprise/installation/kubecontrollers.go
@@ -275,6 +275,12 @@ func calicoKubeControllersEnterpriseRules(gatewayAPIPresent, managedCluster, rba
 			Verbs:     []string{"watch", "list", "get"},
 		},
 		rbacv1.PolicyRule{
+			// The node controller's IPAM syncer watches Networks to reserve their subnet edges.
+			APIGroups: []string{"projectcalico.org", "crd.projectcalico.org"},
+			Resources: []string{"networks"},
+			Verbs:     []string{"watch", "list", "get"},
+		},
+		rbacv1.PolicyRule{
 			APIGroups: []string{""},
 			Resources: []string{"endpoints"},
 			Verbs:     []string{"create", "update", "delete"},

--- a/pkg/enterprise/installation/kubecontrollers_test.go
+++ b/pkg/enterprise/installation/kubecontrollers_test.go
@@ -186,6 +186,20 @@ var _ = Describe("calico-kube-controllers enterprise surface", func() {
 		Expect(ok).To(BeFalse())
 	})
 
+	It("grants the node controller's IPAM syncer list access to Networks", func() {
+		eci, _, err := ext.Installation().ExtendInputs(ctx, newControllerInputs(operatorv1.CalicoEnterprise))
+		Expect(err).NotTo(HaveOccurred())
+		objs := renderKubeControllers(newControllerInputs(operatorv1.CalicoEnterprise), eci.RenderInputs)
+
+		role, ok := extensions.FindObject[*rbacv1.ClusterRole](objs, kubecontrollers.KubeControllerRole)
+		Expect(ok).To(BeTrue())
+		Expect(role.Rules).To(ContainElement(rbacv1.PolicyRule{
+			APIGroups: []string{"projectcalico.org", "crd.projectcalico.org"},
+			Resources: []string{"networks"},
+			Verbs:     []string{"watch", "list", "get"},
+		}))
+	})
+
 	It("layers the full WAF surface on when the GatewayAPI extension is enabled", func() {
 		ci := wafControllerInputs()
 		eci, managed, err := ext.Installation().ExtendInputs(ctx, ci)


### PR DESCRIPTION
Automatic host endpoints and LoadBalancer IP assignment stop being programmed on Enterprise clusters. kube-controllers has no permission to list networks, so its datastore syncer retries the list forever and never reaches in-sync, which leaves the node and load balancer controllers idle.

This grants get, list and watch on networks to the calico-kube-controllers cluster role.

```release-note
Fixes automatic host endpoints and LoadBalancer IP addresses not being programmed.
```
