### PR TITLE
Raise the Go toolchain floor to 1.26.6 and re-sync the lint image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ CONTAINERIZED= mkdir -p .go-pkg-cache $(GOMOD_CACHE) && \
 		-e KUBECONFIG=/go/src/$(PACKAGE_NAME)/kubeconfig.yaml \
 		-e ACK_GINKGO_RC=true \
 		-e ACK_GINKGO_DEPRECATIONS=1.16.5 \
-		-e GOTOOLCHAIN=go1.26.4+auto \
+		-e GOTOOLCHAIN=go1.26.6+auto \
 		-w /go/src/$(PACKAGE_NAME) \
 		--net=host \
 		$(EXTRA_DOCKER_ARGS)
@@ -515,10 +515,15 @@ cluster-destroy: $(BINDIR)/kubectl $(BINDIR)/kind
 .PHONY: static-checks
 ## Perform static checks on the code.
 # Use the newer go-build image for lint because golangci-lint bundled in the
-# 1.25.x image was built with Go 1.25 and refuses to lint code targeting
-# Go 1.26.3. The binary build still uses GO_BUILD_VER (1.25.x) to ensure
-# glibc compatibility with the runtime UBI image.
-CALICO_BUILD_LINT ?= calico/go-build:1.26.3-llvm21.1.8-k8s1.35.5-$(BUILDARCH)
+# 1.25.x image was built with Go 1.25 and refuses to lint code targeting the
+# Go 1.26.x that go.mod asks for.
+#
+# The binary build keeps GO_BUILD_VER (1.25.x) as the *container*, for glibc
+# compatibility with the runtime UBI image, but the Go toolchain that actually
+# compiles it comes from GOTOOLCHAIN above plus the go.mod directive - not from
+# GO_VERSION. Keep this image's Go version in step with that floor so lint and
+# the binary are checked by the same compiler.
+CALICO_BUILD_LINT ?= calico/go-build:1.26.6-llvm21.1.8-k8s1.36.3-$(BUILDARCH)
 static-checks:
 	$(CONTAINERIZED) $(CALICO_BUILD_LINT) golangci-lint run --timeout 5m
 


### PR DESCRIPTION
Hardening follow-up to the Go toolchain handling on `release-v1.40`, prompted by the v3.22 hashrelease scan (2026-08-14).

### Context: the CVEs are already fixed

The scan flagged **CVE-2026-46600** (7.5, SVCB/HTTPS RR parsing panic) and **CVE-2026-39821** (8.2, idna ToASCII/ToUnicode privilege escalation) on the `operator` and `operator-init` images, which reported `stdlib:v1.26.5`.

Those are already resolved on this branch — `7b79e32f8` moved the `go.mod` directive `1.26.5` → `1.26.6` a few hours after that image was built, so the next build picks up 1.26.6 with no change here. **This PR is not the fix**; it closes two gaps around it.

### 1. The GOTOOLCHAIN floor was below the fix

```diff
-		-e GOTOOLCHAIN=go1.26.4+auto \
+		-e GOTOOLCHAIN=go1.26.6+auto \
```

Toolchain selection is `max(floor, go.mod directive)`, so 1.26.6 wins today regardless. But with the floor at 1.26.4, if the directive ever regresses below 1.26.6 — a dependency downgrade, a reverted renovate bump — the floor would silently permit a toolchain that still ships **both** CVEs. Raising it makes that impossible.

**No effect on the version selected today** (`max(1.26.6, 1.26.6)` = `max(1.26.4, 1.26.6)` = 1.26.6). Zero-risk by construction.

### 2. Lint ran on a different Go than the build

```diff
-CALICO_BUILD_LINT ?= calico/go-build:1.26.3-llvm21.1.8-k8s1.35.5-$(BUILDARCH)
+CALICO_BUILD_LINT ?= calico/go-build:1.26.6-llvm21.1.8-k8s1.36.3-$(BUILDARCH)
```

The lint image was three patches behind the compiler that actually builds the binary, so static checks and the build were being done by different Go versions. Now matched to the floor.

### 3. Corrected a misleading comment

The comment above `CALICO_BUILD_LINT` claimed *"The binary build still uses GO_BUILD_VER (1.25.x)"*. That isn't accurate: the 1.25.13 image supplies the **container** — the glibc-parity point it makes is still correct and is preserved — but `GOTOOLCHAIN` plus the `go.mod` directive decide the **compiler**.

The scan is the evidence: the image built from `28723c7f1249` reported `stdlib:v1.26.5`, matching `go.mod` at that commit rather than `GO_VERSION=1.25.13`. Rewritten to say which knob does what, since that ambiguity is what made these images look like they were on 1.25.

### Testing

- `calico/go-build:1.26.6-llvm21.1.8-k8s1.36.3` confirmed published for **amd64 and arm64** (the recipe pulls `-$(BUILDARCH)`).
- Ran `make static-checks` with the new image **and** with the old one as a control: both report exactly the same single finding (an unrelated missing Istio `base.tgz` artifact, a local prerequisite CI satisfies first). So the image swap introduces no new lint findings.
- Makefile-only change; no Go code touched, so no new tests.

For reference, `master` solved this differently — it moved `GO_VERSION` itself to 1.26.5 and dropped the override entirely. This branch keeps the 1.25.x container for runtime glibc compatibility, so the override stays; this just keeps its floor current.
