### PR TITLE
Move non-cluster-host typha into the enterprise extension

### DIFF
--- a/pkg/controller/inputs.go
+++ b/pkg/controller/inputs.go
@@ -18,9 +18,12 @@
 package controller
 
 import (
+	"context"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/tigera/operator/pkg/controller/certificatemanager"
+	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/render"
 )
 
@@ -43,4 +46,12 @@ type Inputs struct {
 
 	Client             client.Client
 	CertificateManager certificatemanager.CertificateManager
+
+	// Status and ShutdownContext are set by the controllers whose extension owns a
+	// background goroutine. Everywhere else they are nil.
+	Status          status.StatusManager
+	ShutdownContext context.Context
+
+	// Terminating reports that the resource this controller owns is being deleted.
+	Terminating bool
 }

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -39,12 +39,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/cache"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/controller"
@@ -55,7 +53,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
-	calicoclient "github.com/tigera/api/pkg/client/clientset_generated/clientset"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/active"
@@ -269,14 +266,8 @@ func newReconciler(mgr manager.Manager, opts options.ControllerOptions) (*Reconc
 
 	statusManager := status.New(mgr.GetClient(), "calico", opts.KubernetesVersion)
 
-	// Create the SharedIndexInformer used by the typhaAutoscaler
-	nodeListWatch := cache.NewListWatchFromClient(opts.K8sClientset.CoreV1().RESTClient(), "nodes", "", fields.Everything())
-	nodeIndexInformer := cache.NewSharedIndexInformer(nodeListWatch, &corev1.Node{}, 0, cache.Indexers{})
-	go nodeIndexInformer.Run(opts.ShutdownContext.Done())
-
 	// Create a Typha autoscaler.
-	typhaListWatch := cache.NewListWatchFromClient(opts.K8sClientset.AppsV1().RESTClient(), "deployments", "calico-system", fields.OneTermEqualSelector("metadata.name", "calico-typha"))
-	typhaScaler := newTyphaAutoscaler(opts.K8sClientset, nodeIndexInformer, typhaListWatch, statusManager)
+	typhaScaler := NewTyphaAutoscaler(mgr.GetClient(), common.TyphaDeploymentName, NodeReplicaCounter, statusManager)
 
 	r := &ReconcileInstallation{
 		config:              mgr.GetConfig(),
@@ -293,7 +284,7 @@ func newReconciler(mgr manager.Manager, opts options.ControllerOptions) (*Reconc
 		ext:                 opts.Extensions.Installation(),
 	}
 	r.status.Run(opts.ShutdownContext)
-	r.typhaAutoscaler.start(opts.ShutdownContext)
+	r.typhaAutoscaler.Start(opts.ShutdownContext)
 
 	return r, nil
 }
@@ -335,8 +326,8 @@ type ReconcileInstallation struct {
 	scheme                        *runtime.Scheme
 	watches                       map[runtime.Object]struct{}
 	status                        status.StatusManager
-	typhaAutoscaler               *typhaAutoscaler
-	typhaAutoscalerNonClusterHost *typhaAutoscaler
+	typhaAutoscaler               *TyphaAutoscaler
+	typhaAutoscalerNonClusterHost *TyphaAutoscaler
 	namespaceMigration            migration.NamespaceMigration
 	migrationChecked              bool
 	tierWatchReady                *utils.ReadyFlag
@@ -939,15 +930,15 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 	if !installationMarkedForDeletion {
 		// If the autoscalar is degraded then trigger a run and recheck the degraded status. If it is still degraded after the
 		// the run the reset the degraded status and requeue the request.
-		if r.typhaAutoscaler.isDegraded() {
-			if err := r.typhaAutoscaler.triggerRun(); err != nil {
+		if r.typhaAutoscaler.IsDegraded() {
+			if err := r.typhaAutoscaler.TriggerRun(); err != nil {
 				r.status.SetDegraded(operatorv1.ResourceScalingError, "Failed to scale typha", err, reqLogger)
 				return reconcile.Result{RequeueAfter: utils.StandardRetry}, nil
 			}
 		}
 
-		if r.typhaAutoscalerNonClusterHost != nil && r.typhaAutoscalerNonClusterHost.isDegraded() {
-			if err := r.typhaAutoscalerNonClusterHost.triggerRun(); err != nil {
+		if r.typhaAutoscalerNonClusterHost != nil && r.typhaAutoscalerNonClusterHost.IsDegraded() {
+			if err := r.typhaAutoscalerNonClusterHost.TriggerRun(); err != nil {
 				r.status.SetDegraded(operatorv1.ResourceScalingError, "Failed to scale typha for noncluster hosts", err, reqLogger)
 				return reconcile.Result{RequeueAfter: utils.StandardRetry}, nil
 			}
@@ -1238,19 +1229,9 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 			}
 
 			if r.typhaAutoscalerNonClusterHost == nil {
-				calicoClient, err := calicoclient.NewForConfig(r.config)
-				if err != nil {
-					r.status.SetDegraded(operatorv1.InvalidConfigurationError, "Failed to initialize Calico client", err, reqLogger)
-					return reconcile.Result{}, err
-				}
-
-				hepListWatch := cache.NewListWatchFromClient(calicoClient.ProjectcalicoV3().RESTClient(), "hostendpoints", corev1.NamespaceAll, fields.Everything())
-				hepIndexInformer := cache.NewSharedIndexInformer(hepListWatch, &v3.HostEndpoint{}, 0, cache.Indexers{})
-				go hepIndexInformer.Run(r.opts.ShutdownContext.Done())
-
-				typhaNonClusterHostWatch := cache.NewListWatchFromClient(r.opts.K8sClientset.AppsV1().RESTClient(), "deployments", "calico-system", fields.OneTermEqualSelector("metadata.name", "calico-typha"+render.TyphaNonClusterHostSuffix))
-				r.typhaAutoscalerNonClusterHost = newTyphaAutoscaler(r.opts.K8sClientset, hepIndexInformer, typhaNonClusterHostWatch, r.status, typhaAutoscalerOptionNonclusterHost(true))
-				r.typhaAutoscalerNonClusterHost.start(r.opts.ShutdownContext)
+				name := common.TyphaDeploymentName + render.TyphaNonClusterHostSuffix
+				r.typhaAutoscalerNonClusterHost = NewTyphaAutoscaler(r.client, name, HostEndpointReplicaCounter, r.status)
+				r.typhaAutoscalerNonClusterHost.Start(r.opts.ShutdownContext)
 			}
 		}
 	}

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 
 	"github.com/elastic/cloud-on-k8s/v2/pkg/utils/stringsutil"
-	"github.com/sirupsen/logrus"
 
 	"github.com/go-logr/logr"
 	configv1 "github.com/openshift/api/config/v1"
@@ -66,10 +65,10 @@ import (
 	"github.com/tigera/operator/pkg/controller/migration/datastoremigration"
 	"github.com/tigera/operator/pkg/controller/options"
 	"github.com/tigera/operator/pkg/controller/status"
+	"github.com/tigera/operator/pkg/controller/typhaautoscaler"
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/controller/utils/imageset"
 	"github.com/tigera/operator/pkg/ctrlruntime"
-	eutils "github.com/tigera/operator/pkg/enterprise/utils"
 	"github.com/tigera/operator/pkg/extensions"
 	"github.com/tigera/operator/pkg/imports/admission"
 	"github.com/tigera/operator/pkg/imports/crds"
@@ -267,7 +266,7 @@ func newReconciler(mgr manager.Manager, opts options.ControllerOptions) (*Reconc
 	statusManager := status.New(mgr.GetClient(), "calico", opts.KubernetesVersion)
 
 	// Create a Typha autoscaler.
-	typhaScaler := NewTyphaAutoscaler(mgr.GetClient(), common.TyphaDeploymentName, NodeReplicaCounter, statusManager)
+	typhaScaler := typhaautoscaler.New(mgr.GetClient(), common.TyphaDeploymentName, typhaautoscaler.NodeReplicaCounter, statusManager)
 
 	r := &ReconcileInstallation{
 		config:              mgr.GetConfig(),
@@ -321,19 +320,18 @@ var _ reconcile.Reconciler = &ReconcileInstallation{}
 type ReconcileInstallation struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
-	config                        *rest.Config
-	client                        client.Client
-	scheme                        *runtime.Scheme
-	watches                       map[runtime.Object]struct{}
-	status                        status.StatusManager
-	typhaAutoscaler               *TyphaAutoscaler
-	typhaAutoscalerNonClusterHost *TyphaAutoscaler
-	namespaceMigration            migration.NamespaceMigration
-	migrationChecked              bool
-	tierWatchReady                *utils.ReadyFlag
-	migrationWatchReady           *utils.ReadyFlag
-	opts                          options.ControllerOptions
-	ext                           extensions.InstallationExtension
+	config              *rest.Config
+	client              client.Client
+	scheme              *runtime.Scheme
+	watches             map[runtime.Object]struct{}
+	status              status.StatusManager
+	typhaAutoscaler     *typhaautoscaler.Autoscaler
+	namespaceMigration  migration.NamespaceMigration
+	migrationChecked    bool
+	tierWatchReady      *utils.ReadyFlag
+	migrationWatchReady *utils.ReadyFlag
+	opts                options.ControllerOptions
+	ext                 extensions.InstallationExtension
 
 	// newComponentHandler returns a new component handler. Useful stub for unit testing.
 	newComponentHandler func(log logr.Logger, client client.Client, scheme *runtime.Scheme, cr metav1.Object, opts ...utils.ComponentHandlerOption) utils.ComponentHandler
@@ -936,13 +934,6 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 				return reconcile.Result{RequeueAfter: utils.StandardRetry}, nil
 			}
 		}
-
-		if r.typhaAutoscalerNonClusterHost != nil && r.typhaAutoscalerNonClusterHost.IsDegraded() {
-			if err := r.typhaAutoscalerNonClusterHost.TriggerRun(); err != nil {
-				r.status.SetDegraded(operatorv1.ResourceScalingError, "Failed to scale typha for noncluster hosts", err, reqLogger)
-				return reconcile.Result{RequeueAfter: utils.StandardRetry}, nil
-			}
-		}
 	}
 
 	// Query for pull secrets in operator namespace
@@ -1094,6 +1085,9 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		},
 		Client:             r.client,
 		CertificateManager: certificateManager,
+		Status:             r.status,
+		ShutdownContext:    r.opts.ShutdownContext,
+		Terminating:        installationMarkedForDeletion,
 	}
 	ci, extraKeyPairs, err := r.ext.ExtendInputs(ctx, ci)
 	if err != nil {
@@ -1189,7 +1183,6 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 	keyPairOptions := []rcertificatemanagement.KeyPairOption{
 		rcertificatemanagement.NewKeyPairOption(typhaNodeTLS.NodeSecret, true, true),
 		rcertificatemanagement.NewKeyPairOption(typhaNodeTLS.TyphaSecret, true, true),
-		rcertificatemanagement.NewKeyPairOption(typhaNodeTLS.TyphaSecretNonClusterHost, true, true),
 	}
 	// Manage any key pairs the variant extension created controller-side.
 	for _, kp := range extraKeyPairs {
@@ -1204,48 +1197,14 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 			TrustedBundle:   typhaNodeTLS.TrustedBundle,
 		}))
 
-	// Check if non-cluster host feature is enabled.
-	var nonclusterhost *operatorv1.NonClusterHost
-	if instance.Spec.Variant.IsEnterprise() {
-		nonclusterhost, err = eutils.GetNonClusterHost(ctx, r.client)
-		if err != nil {
-			r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to query NonClusterHost resource", err, reqLogger)
-			return reconcile.Result{}, err
-		} else if nonclusterhost != nil {
-			// This is the default common name in CSR from non-cluster hosts.
-			typhaNodeTLS.NodeNonClusterHostCommonName = render.FelixCommonName + render.TyphaNonClusterHostSuffix
-			// Attempt to retrieve the BYO node certificates for non-cluster hosts if they are present.
-			secret, err := utils.GetSecret(context.TODO(), r.client, render.NodeTLSSecretNameNonClusterHost, common.OperatorNamespace())
-			if err != nil {
-				logrus.WithError(err).Warn("failed to retrieve BYO non-cluster host node TLS secret. Using default common name instead.")
-			} else if secret != nil {
-				cn, urisan, err := parseCommonNameAndURISAN(secret)
-				if err != nil {
-					logrus.WithError(err).Warn("failed to parse common name or URI SAN in BYO non-cluster host node TLS secret. Using default common name instead.")
-				}
-
-				typhaNodeTLS.NodeNonClusterHostCommonName = cn
-				typhaNodeTLS.NodeNonClusterHostURISAN = urisan
-			}
-
-			if r.typhaAutoscalerNonClusterHost == nil {
-				name := common.TyphaDeploymentName + render.TyphaNonClusterHostSuffix
-				r.typhaAutoscalerNonClusterHost = NewTyphaAutoscaler(r.client, name, HostEndpointReplicaCounter, r.status)
-				r.typhaAutoscalerNonClusterHost.Start(r.opts.ShutdownContext)
-			}
-		}
-	}
-
 	// Build a configuration for rendering calico/typha.
 	typhaCfg := render.TyphaConfiguration{
-		K8sServiceEp:           k8sapi.Endpoint,
-		K8sServiceEpPodNetwork: k8sapi.PodNetworkEndpoint,
-		Installation:           &instance.Spec,
-		TLS:                    typhaNodeTLS,
-		MigrateNamespaces:      needsNamespaceMigration,
-		ClusterDomain:          r.opts.ClusterDomain,
-		NonClusterHost:         nonclusterhost,
-		FelixHealthPort:        *felixConfiguration.Spec.HealthPort,
+		K8sServiceEp:      k8sapi.Endpoint,
+		Installation:      &instance.Spec,
+		TLS:               typhaNodeTLS,
+		MigrateNamespaces: needsNamespaceMigration,
+		ClusterDomain:     r.opts.ClusterDomain,
+		FelixHealthPort:   *felixConfiguration.Spec.HealthPort,
 	}
 	components = append(components, render.Typha(&typhaCfg))
 
@@ -1435,9 +1394,6 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 	// deployment becomes unhealthy and reconciliation of non-NetworkPolicy resources in the core controller
 	// would resolve it, we render the network policies of components last to prevent a chicken-and-egg scenario.
 	if includeV3NetworkPolicy {
-		if nonclusterhost != nil {
-			components = append(components, render.NewTyphaNonClusterHostPolicy(&typhaCfg))
-		}
 		components = append(components,
 			kubecontrollers.NewCalicoKubeControllersPolicy(&kubeControllersCfg, calicoSystemDefaultDenyForCalicoSystem()),
 		)
@@ -1564,9 +1520,8 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 
 	// Check BYO certificate expiry warnings and propagate them to the status manager.
 	keyPairWarnings := map[string]certificatemanagement.KeyPairInterface{
-		render.TyphaTLSSecretName:                                    typhaNodeTLS.TyphaSecret,
-		render.NodeTLSSecretName:                                     typhaNodeTLS.NodeSecret,
-		render.TyphaTLSSecretName + render.TyphaNonClusterHostSuffix: typhaNodeTLS.TyphaSecretNonClusterHost,
+		render.TyphaTLSSecretName: typhaNodeTLS.TyphaSecret,
+		render.NodeTLSSecretName:  typhaNodeTLS.NodeSecret,
 	}
 	for _, kp := range extraKeyPairs {
 		keyPairWarnings[kp.GetName()] = kp
@@ -1666,7 +1621,6 @@ func getOrCreateTyphaNodeTLSConfig(cli client.Client, certificateManager certifi
 	}
 	node, nodeCommonName, nodeURISAN := getOrCreateKeyPair(render.NodeTLSSecretName, render.FelixCommonName, true)
 	typha, typhaCommonName, typhaURISAN := getOrCreateKeyPair(render.TyphaTLSSecretName, render.TyphaCommonName, true)
-	typhaNonClusterHost, _, _ := getOrCreateKeyPair(render.TyphaTLSSecretName+render.TyphaNonClusterHostSuffix, render.TyphaCommonName+render.TyphaNonClusterHostSuffix, false)
 	var trustedBundle certificatemanagement.TrustedBundle
 	configMap, err := getConfigMap(cli, render.TyphaCAConfigMapName)
 	if err != nil {
@@ -1691,14 +1645,13 @@ func getOrCreateTyphaNodeTLSConfig(cli client.Client, certificateManager certifi
 		return nil, fmt.Errorf("%s", strings.Join(errMsgs, ";"))
 	}
 	return &render.TyphaNodeTLS{
-		TrustedBundle:             trustedBundle,
-		TyphaSecret:               typha,
-		TyphaSecretNonClusterHost: typhaNonClusterHost,
-		TyphaCommonName:           typhaCommonName,
-		TyphaURISAN:               typhaURISAN,
-		NodeSecret:                node,
-		NodeCommonName:            nodeCommonName,
-		NodeURISAN:                nodeURISAN,
+		TrustedBundle:   trustedBundle,
+		TyphaSecret:     typha,
+		TyphaCommonName: typhaCommonName,
+		TyphaURISAN:     typhaURISAN,
+		NodeSecret:      node,
+		NodeCommonName:  nodeCommonName,
+		NodeURISAN:      nodeURISAN,
 	}, nil
 }
 
@@ -2291,22 +2244,4 @@ func calicoSystemDefaultDenyForCalicoSystem() *v3.NetworkPolicy {
 			Types:    []v3.PolicyType{v3.PolicyTypeIngress, v3.PolicyTypeEgress},
 		},
 	}
-}
-
-func parseCommonNameAndURISAN(secret *corev1.Secret) (cn, urisan string, err error) {
-	certData, ok := secret.Data[corev1.TLSCertKey]
-	if !ok {
-		return "", "", fmt.Errorf("failed to find cert data in secret")
-	}
-
-	cert, err := certificatemanagement.ParseCertificate(certData)
-	if err != nil {
-		return "", "", err
-	}
-
-	cn = cert.Subject.CommonName
-	if len(cert.URIs) > 0 {
-		urisan = cert.URIs[0].String()
-	}
-	return cn, urisan, nil
 }

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -41,8 +41,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	kfake "k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -99,7 +97,6 @@ func (f *fakeNamespaceMigration) CleanupMigration(ctx context.Context, log logr.
 
 var _ = Describe("Testing core-controller installation", func() {
 	var c client.Client
-	var cs *kfake.Clientset
 	var ctx context.Context
 	var cancel context.CancelFunc
 	var r ReconcileInstallation
@@ -130,8 +127,6 @@ var _ = Describe("Testing core-controller installation", func() {
 	ready.MarkAsReady()
 
 	Context("mainline tests", func() {
-		var nodeIndexInformer cache.SharedIndexInformer
-
 		BeforeEach(func() {
 			// The schema contains all objects that should be known to the fake client when the test runs.
 			scheme = runtime.NewScheme()
@@ -145,25 +140,6 @@ var _ = Describe("Testing core-controller installation", func() {
 			// Create a client that will have a crud interface of k8s objects.
 			c = ctrlrfake.DefaultFakeClientBuilder(scheme).Build()
 			ctx, cancel = context.WithCancel(context.Background())
-
-			// Create a fake clientset for the autoscaler.
-			var replicas int32 = 1
-			objs := []runtime.Object{
-				&corev1.Node{
-					TypeMeta: metav1.TypeMeta{},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:   "node1",
-						Labels: map[string]string{"kubernetes.io/os": "linux"},
-					},
-					Spec: corev1.NodeSpec{},
-				},
-				&appsv1.Deployment{
-					TypeMeta:   metav1.TypeMeta{},
-					ObjectMeta: metav1.ObjectMeta{Name: "calico-typha", Namespace: "calico-system"},
-					Spec:       appsv1.DeploymentSpec{Replicas: &replicas},
-				},
-			}
-			cs = kfake.NewClientset(objs...)
 
 			// Create an object we can use throughout the test to do the compliance reconcile loops.
 			mockStatus = &status.MockStatus{}
@@ -181,15 +157,6 @@ var _ = Describe("Testing core-controller installation", func() {
 			mockStatus.On("ReadyToMonitor")
 			mockStatus.On("SetMetaData", mock.Anything).Return()
 
-			// Create the indexer and informer used by the typhaAutoscaler
-			nlw := test.NewNodeListWatch(cs)
-			nodeIndexInformer = cache.NewSharedIndexInformer(nlw, &corev1.Node{}, 0, cache.Indexers{})
-
-			go nodeIndexInformer.Run(ctx.Done())
-			for nodeIndexInformer.HasSynced() {
-				time.Sleep(100 * time.Millisecond)
-			}
-
 			// As the parameters in the client changes, we expect the outcomes of the reconcile loops to change.
 			r = ReconcileInstallation{
 				ext: testExtensions.Installation(),
@@ -202,7 +169,7 @@ var _ = Describe("Testing core-controller installation", func() {
 				client:              c,
 				scheme:              scheme,
 				status:              mockStatus,
-				typhaAutoscaler:     newTyphaAutoscaler(cs, nodeIndexInformer, test.NewTyphaListWatch(cs), mockStatus),
+				typhaAutoscaler:     NewTyphaAutoscaler(c, common.TyphaDeploymentName, fixedReplicaCounter(1), mockStatus),
 				namespaceMigration:  &fakeNamespaceMigration{},
 				migrationChecked:    true,
 				tierWatchReady:      ready,
@@ -210,7 +177,7 @@ var _ = Describe("Testing core-controller installation", func() {
 				newComponentHandler: utils.NewComponentHandler,
 			}
 
-			r.typhaAutoscaler.start(ctx)
+			r.typhaAutoscaler.Start(ctx)
 			certificateManager, err := certificatemanager.Create(c, nil, "", common.OperatorNamespace(), certificatemanager.AllowCACreation())
 			Expect(err).NotTo(HaveOccurred())
 
@@ -270,8 +237,9 @@ var _ = Describe("Testing core-controller installation", func() {
 					ObjectMeta: nonClusterHostObjectMeta,
 				})).NotTo(HaveOccurred())
 
-				r.typhaAutoscalerNonClusterHost = newTyphaAutoscaler(cs, nodeIndexInformer, test.NewTyphaListWatch(cs), mockStatus)
-				r.typhaAutoscalerNonClusterHost.start(ctx)
+				nchName := common.TyphaDeploymentName + render.TyphaNonClusterHostSuffix
+				r.typhaAutoscalerNonClusterHost = NewTyphaAutoscaler(c, nchName, fixedReplicaCounter(1), mockStatus)
+				r.typhaAutoscalerNonClusterHost.Start(ctx)
 			})
 
 			AfterEach(func() {
@@ -791,27 +759,6 @@ var _ = Describe("Testing core-controller installation", func() {
 			c = ctrlrfake.DefaultFakeClientBuilder(scheme).Build()
 			ctx, cancel = context.WithCancel(context.Background())
 
-			// Create a fake clientset for the autoscaler.
-			var replicas int32 = 1
-			objs := []runtime.Object{
-				&corev1.Node{
-					TypeMeta: metav1.TypeMeta{},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:   "node1",
-						Labels: map[string]string{"kubernetes.io/os": "linux"},
-					},
-					Spec: corev1.NodeSpec{},
-				},
-				&appsv1.Deployment{
-					TypeMeta:   metav1.TypeMeta{},
-					ObjectMeta: metav1.ObjectMeta{Name: "calico-typha", Namespace: "calico-system"},
-					Spec: appsv1.DeploymentSpec{
-						Replicas: &replicas,
-					},
-				},
-			}
-			cs = kfake.NewClientset(objs...)
-
 			// Create an object we can use throughout the test to do the compliance reconcile loops.
 			mockStatus = &status.MockStatus{}
 			mockStatus.On("AddDaemonsets", mock.Anything).Return()
@@ -828,15 +775,6 @@ var _ = Describe("Testing core-controller installation", func() {
 			mockStatus.On("ReadyToMonitor")
 			mockStatus.On("SetMetaData", mock.Anything).Return()
 
-			// Create the indexer and informer used by the typhaAutoscaler
-			nlw := test.NewNodeListWatch(cs)
-			nodeIndexInformer := cache.NewSharedIndexInformer(nlw, &corev1.Node{}, 0, cache.Indexers{})
-
-			go nodeIndexInformer.Run(ctx.Done())
-			for nodeIndexInformer.HasSynced() {
-				time.Sleep(100 * time.Millisecond)
-			}
-
 			// As the parameters in the client changes, we expect the outcomes of the reconcile loops to change.
 			r = ReconcileInstallation{
 				ext: testExtensions.Installation(),
@@ -850,14 +788,14 @@ var _ = Describe("Testing core-controller installation", func() {
 				client:              c,
 				scheme:              scheme,
 				status:              mockStatus,
-				typhaAutoscaler:     newTyphaAutoscaler(cs, nodeIndexInformer, test.NewTyphaListWatch(cs), mockStatus),
+				typhaAutoscaler:     NewTyphaAutoscaler(c, common.TyphaDeploymentName, fixedReplicaCounter(1), mockStatus),
 				namespaceMigration:  &fakeNamespaceMigration{},
 				migrationChecked:    true,
 				tierWatchReady:      ready,
 				migrationWatchReady: &utils.ReadyFlag{},
 				newComponentHandler: utils.NewComponentHandler,
 			}
-			r.typhaAutoscaler.start(ctx)
+			r.typhaAutoscaler.Start(ctx)
 
 			cr = &operator.Installation{
 				ObjectMeta: metav1.ObjectMeta{Name: "default"},
@@ -1005,41 +943,6 @@ var _ = Describe("Testing core-controller installation", func() {
 			c = ctrlrfake.DefaultFakeClientBuilder(scheme).Build()
 			ctx, cancel = context.WithCancel(context.Background())
 
-			// Create a fake clientset for the autoscaler.
-			var replicas int32 = 1
-			objs := []runtime.Object{
-				&corev1.Node{
-					TypeMeta: metav1.TypeMeta{},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:   "node1",
-						Labels: map[string]string{"kubernetes.io/os": "linux"},
-					},
-					Spec: corev1.NodeSpec{},
-				},
-				&corev1.Node{
-					TypeMeta: metav1.TypeMeta{},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:   "node2",
-						Labels: map[string]string{"kubernetes.io/os": "linux"},
-					},
-					Spec: corev1.NodeSpec{},
-				},
-				&corev1.Node{
-					TypeMeta: metav1.TypeMeta{},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:   "node3",
-						Labels: map[string]string{"kubernetes.io/os": "linux"},
-					},
-					Spec: corev1.NodeSpec{},
-				},
-				&appsv1.Deployment{
-					TypeMeta:   metav1.TypeMeta{},
-					ObjectMeta: metav1.ObjectMeta{Name: "calico-typha", Namespace: "calico-system"},
-					Spec:       appsv1.DeploymentSpec{Replicas: &replicas},
-				},
-			}
-			cs = kfake.NewClientset(objs...)
-
 			// Create an object we can use throughout the test to do the core reconcile loops.
 			mockStatus = &status.MockStatus{}
 			mockStatus.On("AddDaemonsets", mock.Anything).Return()
@@ -1053,16 +956,6 @@ var _ = Describe("Testing core-controller installation", func() {
 			mockStatus.On("ReadyToMonitor")
 			mockStatus.On("SetMetaData", mock.Anything).Return()
 
-			// Create the indexer and informer used by the typhaAutoscaler
-			nlw := test.NewNodeListWatch(cs)
-
-			nodeIndexInformer := cache.NewSharedIndexInformer(nlw, &corev1.Node{}, 0, cache.Indexers{})
-
-			go nodeIndexInformer.Run(ctx.Done())
-			for nodeIndexInformer.HasSynced() {
-				time.Sleep(100 * time.Millisecond)
-			}
-
 			// As the parameters in the client changes, we expect the outcomes of the reconcile loops to change.
 			r = ReconcileInstallation{
 				ext: testExtensions.Installation(),
@@ -1075,7 +968,7 @@ var _ = Describe("Testing core-controller installation", func() {
 				client:              c,
 				scheme:              scheme,
 				status:              mockStatus,
-				typhaAutoscaler:     newTyphaAutoscaler(cs, nodeIndexInformer, test.NewTyphaListWatch(cs), mockStatus),
+				typhaAutoscaler:     NewTyphaAutoscaler(c, common.TyphaDeploymentName, fixedReplicaCounter(1), mockStatus),
 				namespaceMigration:  &fakeNamespaceMigration{},
 				migrationChecked:    true,
 				tierWatchReady:      ready,
@@ -1083,7 +976,7 @@ var _ = Describe("Testing core-controller installation", func() {
 				newComponentHandler: utils.NewComponentHandler,
 			}
 
-			r.typhaAutoscaler.start(ctx)
+			r.typhaAutoscaler.Start(ctx)
 			ca, err := tls.MakeCA("test")
 			Expect(err).NotTo(HaveOccurred())
 			cert, _, _ := ca.Config.GetPEMBytes() // create a valid pem block
@@ -2356,27 +2249,6 @@ var _ = Describe("Testing core-controller installation", func() {
 			c = ctrlrfake.DefaultFakeClientBuilder(scheme).Build()
 			ctx, cancel = context.WithCancel(context.Background())
 
-			// Create a fake clientset for the autoscaler.
-			var replicas int32 = 1
-			objs := []runtime.Object{
-				&corev1.Node{
-					TypeMeta: metav1.TypeMeta{},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:   "node1",
-						Labels: map[string]string{"kubernetes.io/os": "linux"},
-					},
-					Spec: corev1.NodeSpec{},
-				},
-				&appsv1.Deployment{
-					TypeMeta:   metav1.TypeMeta{},
-					ObjectMeta: metav1.ObjectMeta{Name: "calico-typha", Namespace: "calico-system"},
-					Spec: appsv1.DeploymentSpec{
-						Replicas: &replicas,
-					},
-				},
-			}
-			cs = kfake.NewClientset(objs...)
-
 			// Create an object we can use throughout the test to do the compliance reconcile loops.
 			mockStatus = &status.MockStatus{}
 			mockStatus.On("AddDaemonsets", mock.Anything).Return()
@@ -2393,15 +2265,6 @@ var _ = Describe("Testing core-controller installation", func() {
 			mockStatus.On("ReadyToMonitor")
 			mockStatus.On("SetMetaData", mock.Anything).Return()
 
-			// Create the indexer and informer used by the typhaAutoscaler
-			nlw := test.NewNodeListWatch(cs)
-			nodeIndexInformer := cache.NewSharedIndexInformer(nlw, &corev1.Node{}, 0, cache.Indexers{})
-
-			go nodeIndexInformer.Run(ctx.Done())
-			for nodeIndexInformer.HasSynced() {
-				time.Sleep(100 * time.Millisecond)
-			}
-
 			// As the parameters in the client changes, we expect the outcomes of the reconcile loops to change.
 			r = ReconcileInstallation{
 				ext: testExtensions.Installation(),
@@ -2415,14 +2278,14 @@ var _ = Describe("Testing core-controller installation", func() {
 				client:              c,
 				scheme:              scheme,
 				status:              mockStatus,
-				typhaAutoscaler:     newTyphaAutoscaler(cs, nodeIndexInformer, test.NewTyphaListWatch(cs), mockStatus),
+				typhaAutoscaler:     NewTyphaAutoscaler(c, common.TyphaDeploymentName, fixedReplicaCounter(1), mockStatus),
 				namespaceMigration:  &fakeNamespaceMigration{},
 				migrationChecked:    true,
 				tierWatchReady:      ready,
 				migrationWatchReady: &utils.ReadyFlag{},
 				newComponentHandler: utils.NewComponentHandler,
 			}
-			r.typhaAutoscaler.start(ctx)
+			r.typhaAutoscaler.Start(ctx)
 
 			cr = &operator.Installation{
 				ObjectMeta: metav1.ObjectMeta{Name: "default"},
@@ -2500,25 +2363,6 @@ var _ = Describe("Testing core-controller installation", func() {
 			c = ctrlrfake.DefaultFakeClientBuilder(scheme).Build()
 			ctx, cancel = context.WithCancel(context.Background())
 
-			// Create a fake clientset for the autoscaler.
-			var replicas int32 = 1
-			objs := []runtime.Object{
-				&corev1.Node{
-					TypeMeta: metav1.TypeMeta{},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:   "node1",
-						Labels: map[string]string{"kubernetes.io/os": "linux"},
-					},
-					Spec: corev1.NodeSpec{},
-				},
-				&appsv1.Deployment{
-					TypeMeta:   metav1.TypeMeta{},
-					ObjectMeta: metav1.ObjectMeta{Name: "calico-typha", Namespace: "calico-system"},
-					Spec:       appsv1.DeploymentSpec{Replicas: &replicas},
-				},
-			}
-			cs = kfake.NewClientset(objs...)
-
 			// Create an object we can use throughout the test to do the compliance reconcile loops.
 			mockStatus = &status.MockStatus{}
 			mockStatus.On("AddDaemonsets", mock.Anything).Return()
@@ -2535,15 +2379,6 @@ var _ = Describe("Testing core-controller installation", func() {
 			mockStatus.On("ReadyToMonitor")
 			mockStatus.On("SetMetaData", mock.Anything).Return()
 
-			// Create the indexer and informer used by the typhaAutoscaler
-			nlw := test.NewNodeListWatch(cs)
-			nodeIndexInformer := cache.NewSharedIndexInformer(nlw, &corev1.Node{}, 0, cache.Indexers{})
-
-			go nodeIndexInformer.Run(ctx.Done())
-			for nodeIndexInformer.HasSynced() {
-				time.Sleep(100 * time.Millisecond)
-			}
-
 			componentHandler = newFakeComponentHandler()
 			r = ReconcileInstallation{
 				ext: testExtensions.Installation(),
@@ -2556,7 +2391,7 @@ var _ = Describe("Testing core-controller installation", func() {
 				client:              c,
 				scheme:              scheme,
 				status:              mockStatus,
-				typhaAutoscaler:     newTyphaAutoscaler(cs, nodeIndexInformer, test.NewTyphaListWatch(cs), mockStatus),
+				typhaAutoscaler:     NewTyphaAutoscaler(c, common.TyphaDeploymentName, fixedReplicaCounter(1), mockStatus),
 				namespaceMigration:  &fakeNamespaceMigration{},
 				migrationChecked:    true,
 				tierWatchReady:      ready,
@@ -2566,7 +2401,7 @@ var _ = Describe("Testing core-controller installation", func() {
 				},
 			}
 
-			r.typhaAutoscaler.start(ctx)
+			r.typhaAutoscaler.Start(ctx)
 			certificateManager, err := certificatemanager.Create(c, nil, "", common.OperatorNamespace(), certificatemanager.AllowCACreation())
 			Expect(err).NotTo(HaveOccurred())
 
@@ -3228,3 +3063,9 @@ var _ = Describe("updateValidatingAdmissionPolicies", func() {
 		Expect(componentHandler.objectsToCreate).To(HaveLen(2))
 	})
 })
+
+func fixedReplicaCounter(replicas int) ReplicaCounter {
+	return func(context.Context, client.Client) (int, error) {
+		return replicas, nil
+	}
+}

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -56,6 +56,7 @@ import (
 	"github.com/tigera/operator/pkg/controller/certificatemanager"
 	"github.com/tigera/operator/pkg/controller/options"
 	"github.com/tigera/operator/pkg/controller/status"
+	"github.com/tigera/operator/pkg/controller/typhaautoscaler"
 	"github.com/tigera/operator/pkg/controller/utils"
 	ctrlrfake "github.com/tigera/operator/pkg/ctrlruntime/client/fake"
 	"github.com/tigera/operator/pkg/dns"
@@ -164,12 +165,13 @@ var _ = Describe("Testing core-controller installation", func() {
 					Extensions:       testExtensions,
 					DetectedProvider: operator.ProviderNone,
 					Variant:          operator.CalicoEnterprise,
+					ShutdownContext:  ctx,
 				},
 				config:              nil, // there is no fake for config
 				client:              c,
 				scheme:              scheme,
 				status:              mockStatus,
-				typhaAutoscaler:     NewTyphaAutoscaler(c, common.TyphaDeploymentName, fixedReplicaCounter(1), mockStatus),
+				typhaAutoscaler:     typhaautoscaler.New(c, common.TyphaDeploymentName, fixedReplicaCounter(1), mockStatus),
 				namespaceMigration:  &fakeNamespaceMigration{},
 				migrationChecked:    true,
 				tierWatchReady:      ready,
@@ -237,13 +239,9 @@ var _ = Describe("Testing core-controller installation", func() {
 					ObjectMeta: nonClusterHostObjectMeta,
 				})).NotTo(HaveOccurred())
 
-				nchName := common.TyphaDeploymentName + render.TyphaNonClusterHostSuffix
-				r.typhaAutoscalerNonClusterHost = NewTyphaAutoscaler(c, nchName, fixedReplicaCounter(1), mockStatus)
-				r.typhaAutoscalerNonClusterHost.Start(ctx)
 			})
 
 			AfterEach(func() {
-				r.typhaAutoscalerNonClusterHost = nil
 				Expect(c.Delete(ctx, &operator.NonClusterHost{ObjectMeta: nonClusterHostObjectMeta})).NotTo(HaveOccurred())
 			})
 
@@ -788,7 +786,7 @@ var _ = Describe("Testing core-controller installation", func() {
 				client:              c,
 				scheme:              scheme,
 				status:              mockStatus,
-				typhaAutoscaler:     NewTyphaAutoscaler(c, common.TyphaDeploymentName, fixedReplicaCounter(1), mockStatus),
+				typhaAutoscaler:     typhaautoscaler.New(c, common.TyphaDeploymentName, fixedReplicaCounter(1), mockStatus),
 				namespaceMigration:  &fakeNamespaceMigration{},
 				migrationChecked:    true,
 				tierWatchReady:      ready,
@@ -963,12 +961,13 @@ var _ = Describe("Testing core-controller installation", func() {
 					Extensions:       testExtensions,
 					DetectedProvider: operator.ProviderNone,
 					Variant:          operator.CalicoEnterprise,
+					ShutdownContext:  ctx,
 				},
 				config:              nil, // there is no fake for config
 				client:              c,
 				scheme:              scheme,
 				status:              mockStatus,
-				typhaAutoscaler:     NewTyphaAutoscaler(c, common.TyphaDeploymentName, fixedReplicaCounter(1), mockStatus),
+				typhaAutoscaler:     typhaautoscaler.New(c, common.TyphaDeploymentName, fixedReplicaCounter(1), mockStatus),
 				namespaceMigration:  &fakeNamespaceMigration{},
 				migrationChecked:    true,
 				tierWatchReady:      ready,
@@ -2278,7 +2277,7 @@ var _ = Describe("Testing core-controller installation", func() {
 				client:              c,
 				scheme:              scheme,
 				status:              mockStatus,
-				typhaAutoscaler:     NewTyphaAutoscaler(c, common.TyphaDeploymentName, fixedReplicaCounter(1), mockStatus),
+				typhaAutoscaler:     typhaautoscaler.New(c, common.TyphaDeploymentName, fixedReplicaCounter(1), mockStatus),
 				namespaceMigration:  &fakeNamespaceMigration{},
 				migrationChecked:    true,
 				tierWatchReady:      ready,
@@ -2386,12 +2385,13 @@ var _ = Describe("Testing core-controller installation", func() {
 					Extensions:       testExtensions,
 					DetectedProvider: operator.ProviderNone,
 					Variant:          operator.CalicoEnterprise,
+					ShutdownContext:  ctx,
 				},
 				config:              nil, // there is no fake for config
 				client:              c,
 				scheme:              scheme,
 				status:              mockStatus,
-				typhaAutoscaler:     NewTyphaAutoscaler(c, common.TyphaDeploymentName, fixedReplicaCounter(1), mockStatus),
+				typhaAutoscaler:     typhaautoscaler.New(c, common.TyphaDeploymentName, fixedReplicaCounter(1), mockStatus),
 				namespaceMigration:  &fakeNamespaceMigration{},
 				migrationChecked:    true,
 				tierWatchReady:      ready,
@@ -3064,7 +3064,7 @@ var _ = Describe("updateValidatingAdmissionPolicies", func() {
 	})
 })
 
-func fixedReplicaCounter(replicas int) ReplicaCounter {
+func fixedReplicaCounter(replicas int) typhaautoscaler.ReplicaCounter {
 	return func(context.Context, client.Client) (int, error) {
 		return replicas, nil
 	}

--- a/pkg/controller/installation/installation_controller_suite_test.go
+++ b/pkg/controller/installation/installation_controller_suite_test.go
@@ -29,13 +29,20 @@ import (
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/enterprise"
 	eoptions "github.com/tigera/operator/pkg/enterprise/options"
+	"github.com/tigera/operator/pkg/extensions"
 )
 
 // testExtensions is the enterprise extension Set the installation controller
 // tests reconcile with, mirroring how main wires it in production. Reconcilers
 // built in these tests put it on their options so the node image overrides and
 // modifiers apply.
-var testExtensions = enterprise.New(operatorv1.CalicoEnterprise, eoptions.Options{})
+var testExtensions extensions.Extensions
+
+// The installation extension owns background goroutines keyed to a spec's context, so
+// each spec gets its own Set.
+var _ = ginkgo.BeforeEach(func() {
+	testExtensions = enterprise.New(operatorv1.CalicoEnterprise, eoptions.Options{})
+})
 
 func TestInstallation(t *testing.T) {
 	// Disable WatchListClient for tests. In client-go v0.35+, this feature defaults to true and

--- a/pkg/controller/installation/typha_autoscaler.go
+++ b/pkg/controller/installation/typha_autoscaler.go
@@ -20,18 +20,16 @@ import (
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/cache"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	operator "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/controller/status"
-	"github.com/tigera/operator/pkg/render"
 )
 
 var typhaLog = logf.Log.WithName("typha_autoscaler")
@@ -43,90 +41,54 @@ const (
 	hepCreatedLabelValue = "calico-kube-controllers"
 )
 
-// typhaAutoscaler periodically lists the nodes and, if needed, scales the Typha deployment up/down.
-// Number of replicas should be at least (1 typha for every 200 nodes) + 1 but the number of typhas
-// cannot exceed the number of nodes+masters.
-type typhaAutoscaler struct {
-	client         kubernetes.Interface
+// ReplicaCounter reports how many Typha replicas the cluster needs.
+type ReplicaCounter func(ctx context.Context, cli client.Client) (int, error)
+
+// TyphaAutoscaler periodically recounts the cluster and, if needed, scales the Typha deployment up/down.
+type TyphaAutoscaler struct {
+	client         client.Client
+	deployment     string
+	count          ReplicaCounter
 	syncPeriod     time.Duration
 	statusManager  status.StatusManager
 	triggerRunChan chan chan error
 	isDegradedChan chan chan bool
-	indexInformer  cache.SharedIndexInformer
-	typhaInformer  cache.Controller
-	typhaIndexer   cache.Store
-	nonClusterHost bool
 
 	// done is closed when the autoscaler goroutine exits, so callers can wait for shutdown.
 	done chan struct{}
-
-	// Number of currently running replicas.
-	activeReplicas int32
 }
 
-type typhaAutoscalerOption func(*typhaAutoscaler)
+type TyphaAutoscalerOption func(*TyphaAutoscaler)
 
-// typhaAutoscalerOptionPeriod is an option that sets a custom sync period for the Typha autoscaler.
-func typhaAutoscalerOptionPeriod(syncPeriod time.Duration) typhaAutoscalerOption {
-	return func(t *typhaAutoscaler) {
+// TyphaAutoscalerOptionPeriod is an option that sets a custom sync period for the Typha autoscaler.
+func TyphaAutoscalerOptionPeriod(syncPeriod time.Duration) TyphaAutoscalerOption {
+	return func(t *TyphaAutoscaler) {
 		t.syncPeriod = syncPeriod
 	}
 }
 
-// typhaAutoScalerOptionNonclusterHost is an option that sets the Typha autoscaler to for non-cluster host.
-func typhaAutoscalerOptionNonclusterHost(nonClusterHost bool) typhaAutoscalerOption {
-	return func(t *typhaAutoscaler) {
-		t.nonClusterHost = nonClusterHost
-	}
-}
-
-// newTyphaAutoscaler creates a new Typha autoscaler, optionally applying any options to the default autoscaler instance.
-// The default sync period is 10 seconds.
-func newTyphaAutoscaler(cs kubernetes.Interface, indexInformer cache.SharedIndexInformer, typhaListWatch cache.ListerWatcher, statusManager status.StatusManager, options ...typhaAutoscalerOption) *typhaAutoscaler {
-	ta := &typhaAutoscaler{
-		client:         cs,
+// NewTyphaAutoscaler creates a new Typha autoscaler for the named deployment in the calico-system namespace, sized by
+// count, optionally applying any options to the default autoscaler instance. The default sync period is 10 seconds.
+func NewTyphaAutoscaler(cli client.Client, deployment string, count ReplicaCounter, statusManager status.StatusManager, options ...TyphaAutoscalerOption) *TyphaAutoscaler {
+	ta := &TyphaAutoscaler{
+		client:         cli,
+		deployment:     deployment,
+		count:          count,
 		statusManager:  statusManager,
 		syncPeriod:     defaultTyphaAutoscalerSyncPeriod,
 		triggerRunChan: make(chan chan error),
 		isDegradedChan: make(chan chan bool),
-		indexInformer:  indexInformer,
 	}
-
-	// Configure an informer to monitor the active replicas.
-	typhaHandlers := cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			if d, ok := obj.(*appsv1.Deployment); ok {
-				if d.Spec.Replicas != nil {
-					ta.activeReplicas = *d.Spec.Replicas
-				}
-			}
-		},
-		UpdateFunc: func(old, obj interface{}) {
-			if d, ok := obj.(*appsv1.Deployment); ok {
-				if d.Spec.Replicas != nil {
-					ta.activeReplicas = *d.Spec.Replicas
-				}
-			}
-		},
-	}
-	ta.typhaIndexer, ta.typhaInformer = cache.NewInformerWithOptions(cache.InformerOptions{
-		ListerWatcher: typhaListWatch,
-		ObjectType:    &appsv1.Deployment{},
-		ResyncPeriod:  0,
-		Handler:       typhaHandlers,
-		Indexers:      cache.Indexers{},
-	})
-
 	for _, option := range options {
 		option(ta)
 	}
 	return ta
 }
 
-// start starts the Typha autoscaler, updating the Typha deployment's replica count every sync period. The triggerRunChan
+// Start starts the Typha autoscaler, updating the Typha deployment's replica count every sync period. The triggerRunChan
 // can be used to trigger an auto scale run immediately, while the isDegradedChan can be used to get the degraded status
-// of the last run. The triggerRun and isDegraded functions should be used instead of instead of access these channels directly.
-func (t *typhaAutoscaler) start(ctx context.Context) {
+// of the last run. The TriggerRun and IsDegraded functions should be used instead of instead of access these channels directly.
+func (t *TyphaAutoscaler) Start(ctx context.Context) {
 	t.done = make(chan struct{})
 	go func() {
 		defer close(t.done)
@@ -135,18 +97,6 @@ func (t *typhaAutoscaler) start(ctx context.Context) {
 		defer ticker.Stop()
 		typhaLog.Info("Starting typha autoscaler", "syncPeriod", t.syncPeriod)
 
-		// Start the informer.
-		go t.typhaInformer.Run(ctx.Done())
-		// Wait for the informers to sync, bailing out if we're asked to shut down first.
-		for !t.indexInformer.HasSynced() || !t.typhaInformer.HasSynced() {
-			select {
-			case <-ctx.Done():
-				typhaLog.Info("typha autoscaler shutting down")
-				return
-			case <-time.After(100 * time.Millisecond):
-			}
-		}
-
 		// Don't autoscale or report degraded if the context has been cancelled - we're shutting down.
 		if ctx.Err() != nil {
 			typhaLog.Info("typha autoscaler shutting down")
@@ -154,7 +104,7 @@ func (t *typhaAutoscaler) start(ctx context.Context) {
 		}
 
 		// Autoscale on start up then do it again every tick.
-		if err := t.autoscaleReplicas(); err != nil {
+		if err := t.autoscaleReplicas(ctx); err != nil {
 			degraded = true
 			typhaLog.Error(err, "Failed to autoscale typha")
 			t.statusManager.SetDegraded(operator.ResourceScalingError, fmt.Sprintf("Failed to autoscale typha - %s", err.Error()), nil, log)
@@ -163,7 +113,7 @@ func (t *typhaAutoscaler) start(ctx context.Context) {
 		for {
 			select {
 			case <-ticker.C:
-				if err := t.autoscaleReplicas(); err != nil {
+				if err := t.autoscaleReplicas(ctx); err != nil {
 					degraded = true
 					typhaLog.Error(err, "Failed to autoscale typha")
 
@@ -173,7 +123,7 @@ func (t *typhaAutoscaler) start(ctx context.Context) {
 					degraded = false
 				}
 			case errCh := <-t.triggerRunChan:
-				if err := t.autoscaleReplicas(); err != nil {
+				if err := t.autoscaleReplicas(ctx); err != nil {
 					degraded = true
 
 					// Return the error so the "caller" can decided what to do with the error
@@ -197,23 +147,23 @@ func (t *typhaAutoscaler) start(ctx context.Context) {
 	}()
 }
 
-// waitForShutdown blocks until the autoscaler goroutine started by start() has exited. It is a no-op
-// if the autoscaler was never started. Cancel the context passed to start() to trigger shutdown.
-func (t *typhaAutoscaler) waitForShutdown() {
+// WaitForShutdown blocks until the autoscaler goroutine started by Start has exited. It is a no-op
+// if the autoscaler was never started. Cancel the context passed to Start to trigger shutdown.
+func (t *TyphaAutoscaler) WaitForShutdown() {
 	if t.done != nil {
 		<-t.done
 	}
 }
 
-func (t *typhaAutoscaler) triggerRun() error {
+func (t *TyphaAutoscaler) TriggerRun() error {
 	errChan := make(chan error)
 	t.triggerRunChan <- errChan
 
 	return <-errChan
 }
 
-// isDegraded checks if the last run autoscale run failed and returns true if it did and false otherwise.
-func (t *typhaAutoscaler) isDegraded() bool {
+// IsDegraded checks if the last run autoscale run failed and returns true if it did and false otherwise.
+func (t *TyphaAutoscaler) IsDegraded() bool {
 	boolChan := make(chan bool)
 	t.isDegradedChan <- boolChan
 
@@ -221,67 +171,70 @@ func (t *typhaAutoscaler) isDegraded() bool {
 }
 
 // autoscaleReplicas calculates the number of typha pods that should be running and scales the typha deployment accordingly
-func (t *typhaAutoscaler) autoscaleReplicas() error {
-	var expectedReplicas int
-	if t.nonClusterHost {
-		heps := t.getHostEndpointCounts()
-		expectedReplicas = common.GetExpectedTyphaScale(heps)
-	} else {
-		allSchedulableNodes, linuxNodes := t.getNodeCounts()
-		typhaLog.V(5).Info("Number of nodes to consider for typha autoscaling", "all", allSchedulableNodes, "linux", linuxNodes)
-		expectedReplicas = common.GetExpectedTyphaScale(allSchedulableNodes)
-		if linuxNodes < expectedReplicas {
-			return fmt.Errorf("not enough linux nodes to schedule typha pods on, require %d and have %d", expectedReplicas, linuxNodes)
-		}
-	}
-
-	typhaLog.V(5).Info("Checking if we need to scale typha", "expectedReplicas", expectedReplicas, "currentReplicas", t.activeReplicas)
-	if int32(expectedReplicas) != t.activeReplicas {
-		err := t.updateReplicas(int32(expectedReplicas))
-		if err != nil && !apierrors.IsNotFound(err) {
-			return fmt.Errorf("could not scale Typha deployment: %w", err)
-		}
-	}
-
-	return nil
-}
-
-// updateReplicas updates the Typha deployment to the expected replicas if the current replica count differs.
-func (t *typhaAutoscaler) updateReplicas(expectedReplicas int32) error {
-	name := common.TyphaDeploymentName
-	if t.nonClusterHost {
-		name += render.TyphaNonClusterHostSuffix
-	}
-	typha, err := t.client.AppsV1().Deployments(common.CalicoNamespace).Get(context.Background(), name, metav1.GetOptions{})
+func (t *TyphaAutoscaler) autoscaleReplicas(ctx context.Context) error {
+	expectedReplicas, err := t.count(ctx, t.client)
 	if err != nil {
 		return err
 	}
 
+	if err := t.updateReplicas(ctx, int32(expectedReplicas)); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("could not scale Typha deployment: %w", err)
+	}
+	return nil
+}
+
+// updateReplicas updates the Typha deployment to the expected replicas if the current replica count differs.
+func (t *TyphaAutoscaler) updateReplicas(ctx context.Context, expectedReplicas int32) error {
+	typha := &appsv1.Deployment{}
+	if err := t.client.Get(ctx, types.NamespacedName{Name: t.deployment, Namespace: common.CalicoNamespace}, typha); err != nil {
+		return err
+	}
+
 	// The replicas field defaults to 1. We need this in case spec.Replicas is nil.
-	var prevReplicas int32
-	prevReplicas = 1
+	prevReplicas := int32(1)
 	if typha.Spec.Replicas != nil {
 		prevReplicas = *typha.Spec.Replicas
 	}
-
 	if prevReplicas == expectedReplicas {
 		return nil
 	}
 
 	typhaLog.Info(fmt.Sprintf("Updating typha replicas from %d to %d", prevReplicas, expectedReplicas))
-	typha.Spec.Replicas = &expectedReplicas
-	_, err = t.client.AppsV1().Deployments(common.CalicoNamespace).Update(context.Background(), typha, metav1.UpdateOptions{})
-	return err
+
+	// A merge patch carries no resourceVersion precondition, so a stale cached read
+	// cannot turn into a write conflict.
+	patch := []byte(fmt.Sprintf(`{"spec":{"replicas":%d}}`, expectedReplicas))
+	return t.client.Patch(ctx, typha, client.RawPatch(types.MergePatchType, patch))
 }
 
-// getNodeCounts returns the number of all the schedulable nodes and the number of the schedulable linux nodes. The linux
+// NodeReplicaCounter sizes Typha by the number of schedulable nodes. Number of replicas
+// should be at least (1 typha for every 200 nodes) + 1 but the number of typhas cannot exceed the number of nodes+masters.
+func NodeReplicaCounter(ctx context.Context, cli client.Client) (int, error) {
+	allSchedulableNodes, linuxNodes, err := nodeCounts(ctx, cli)
+	if err != nil {
+		return 0, err
+	}
+
+	typhaLog.V(5).Info("Number of nodes to consider for typha autoscaling", "all", allSchedulableNodes, "linux", linuxNodes)
+	expectedReplicas := common.GetExpectedTyphaScale(allSchedulableNodes)
+	if linuxNodes < expectedReplicas {
+		return 0, fmt.Errorf("not enough linux nodes to schedule typha pods on, require %d and have %d", expectedReplicas, linuxNodes)
+	}
+	return expectedReplicas, nil
+}
+
+// nodeCounts returns the number of all the schedulable nodes and the number of the schedulable linux nodes. The linux
 // node count is needed because typha pods can only be scheduled on linux nodes, however, nodes of other os types (i.e. windows)
 // still need to use typha.
-func (t *typhaAutoscaler) getNodeCounts() (int, int) {
+func nodeCounts(ctx context.Context, cli client.Client) (int, int, error) {
+	nodes := &corev1.NodeList{}
+	if err := cli.List(ctx, nodes); err != nil {
+		return 0, 0, fmt.Errorf("could not list nodes: %w", err)
+	}
+
 	linuxNodes := 0
 	schedulable := 0
-	for _, obj := range t.indexInformer.GetIndexer().List() {
-		n := obj.(*v1.Node)
+	for _, n := range nodes.Items {
 		if n.Spec.Unschedulable {
 			continue
 		}
@@ -301,20 +254,24 @@ func (t *typhaAutoscaler) getNodeCounts() (int, int) {
 			linuxNodes++
 		}
 	}
-	return schedulable, linuxNodes
+	return schedulable, linuxNodes, nil
 }
 
-// getHostEndpointCounts returns the number of host endpoints in the cluster that are not created by the kube-controllers.
-func (t *typhaAutoscaler) getHostEndpointCounts() int {
+// HostEndpointReplicaCounter sizes Typha by the number of host endpoints that
+// calico-kube-controllers did not create.
+func HostEndpointReplicaCounter(ctx context.Context, cli client.Client) (int, error) {
+	list := &v3.HostEndpointList{}
+	if err := cli.List(ctx, list); err != nil {
+		return 0, fmt.Errorf("could not list host endpoints: %w", err)
+	}
+
 	heps := 0
-	for _, obj := range t.indexInformer.GetIndexer().List() {
-		// Exclude auto host endpoints that are created by calico-kube-controllers.
-		hep := obj.(*v3.HostEndpoint)
-		if _, ok := hep.Labels[hepCreatedLabelKey]; ok && hep.Labels[hepCreatedLabelKey] == hepCreatedLabelValue {
+	for _, hep := range list.Items {
+		if hep.Labels[hepCreatedLabelKey] == hepCreatedLabelValue {
 			continue
 		}
 
 		heps++
 	}
-	return heps
+	return common.GetExpectedTyphaScale(heps), nil
 }

--- a/pkg/controller/installation/typha_autoscaler_test.go
+++ b/pkg/controller/installation/typha_autoscaler_test.go
@@ -16,59 +16,47 @@ package installation
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
 
-	operator "github.com/tigera/operator/api/v1"
-	"github.com/tigera/operator/pkg/controller/status"
-	. "github.com/tigera/operator/test"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes"
-	kfake "k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/tools/cache"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+	operator "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/apis"
+	"github.com/tigera/operator/pkg/common"
+	"github.com/tigera/operator/pkg/controller/status"
+	ctrlrfake "github.com/tigera/operator/pkg/ctrlruntime/client/fake"
 )
 
 var _ = Describe("Test typha autoscaler ", func() {
 	var statusManager *status.MockStatus
-	var c *kfake.Clientset
+	var c client.Client
 	var ctx context.Context
 	var cancel context.CancelFunc
-	var nlw, tlw cache.ListerWatcher
-	var nodeIndexInformer cache.SharedIndexInformer
-	var ta *typhaAutoscaler
+	var ta *TyphaAutoscaler
 
 	BeforeEach(func() {
 		ta = nil
 		statusManager = new(status.MockStatus)
 
-		objs := []runtime.Object{
-			&corev1.Namespace{
-				TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "calico-system",
-				},
-			},
-		}
-		c = kfake.NewClientset(objs...)
-		nlw = NewNodeListWatch(c)
-		tlw = NewTyphaListWatch(c)
-
-		// Create the indexer and informer used by the typhaAutoscaler
-		nodeIndexInformer = cache.NewSharedIndexInformer(nlw, &corev1.Node{}, 0, cache.Indexers{})
+		scheme := runtime.NewScheme()
+		Expect(apis.AddToScheme(scheme, false)).NotTo(HaveOccurred())
+		Expect(appsv1.SchemeBuilder.AddToScheme(scheme)).NotTo(HaveOccurred())
+		c = ctrlrfake.DefaultFakeClientBuilder(scheme).Build()
 
 		ctx, cancel = context.WithCancel(context.Background())
-		go nodeIndexInformer.Run(ctx.Done())
-		for !nodeIndexInformer.HasSynced() {
-			time.Sleep(100 * time.Millisecond)
-		}
+		Expect(c.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: common.CalicoNamespace},
+		})).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
@@ -77,207 +65,136 @@ var _ = Describe("Test typha autoscaler ", func() {
 		// spec has ended, panicking a later, unrelated spec.
 		cancel()
 		if ta != nil {
-			ta.waitForShutdown()
+			ta.WaitForShutdown()
 		}
 	})
 
 	It("should initialize an autoscaler", func() {
-		ta = newTyphaAutoscaler(c, nodeIndexInformer, tlw, statusManager)
-		ta.start(ctx)
+		createNode(ctx, c, "node1", map[string]string{"kubernetes.io/os": "linux"})
+
+		ta = NewTyphaAutoscaler(c, common.TyphaDeploymentName, NodeReplicaCounter, statusManager)
+		ta.Start(ctx)
 	})
 
 	It("should get the correct number of nodes", func() {
-		n1 := CreateNode(c, "node1", map[string]string{"kubernetes.io/os": "linux"}, nil)
-		_ = CreateNode(c, "node2", map[string]string{"kubernetes.io/os": "linux"}, nil)
+		n1 := createNode(ctx, c, "node1", map[string]string{"kubernetes.io/os": "linux"})
+		createNode(ctx, c, "node2", map[string]string{"kubernetes.io/os": "linux"})
 
-		// Don't start the autoscaler - this test only exercises getNodeCounts(), which reads
-		// from the nodeIndexInformer directly. Starting it would race with node creation,
-		// since autoscaleReplicas() can fire before the informer has picked up the new nodes.
-		ta = newTyphaAutoscaler(c, nodeIndexInformer, tlw, statusManager)
-
-		Eventually(func() error {
-			schedulableNodes, linuxNodes := ta.getNodeCounts()
-			if schedulableNodes != 2 {
-				return fmt.Errorf("Expected 2 schedulable nodes, got %d", schedulableNodes)
-			}
-			if linuxNodes != 2 {
-				return fmt.Errorf("Expected 2 linux nodes, got %d", linuxNodes)
-			}
-			return nil
-		}, 5*time.Second).ShouldNot(HaveOccurred())
+		schedulableNodes, linuxNodes, err := nodeCounts(ctx, c)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(schedulableNodes).To(Equal(2))
+		Expect(linuxNodes).To(Equal(2))
 
 		n1.Spec.Unschedulable = true
-		_, err := c.CoreV1().Nodes().Update(ctx, n1, metav1.UpdateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		Expect(c.Update(ctx, n1)).NotTo(HaveOccurred())
 
-		Eventually(func() error {
-			schedulableNodes, linuxNodes := ta.getNodeCounts()
-			if schedulableNodes != 1 {
-				return fmt.Errorf("Expected 2 schedulable nodes, got %d", schedulableNodes)
-			}
-			if linuxNodes != 1 {
-				return fmt.Errorf("Expected 2 linux nodes, got %d", linuxNodes)
-			}
-			return nil
-		}, 5*time.Second).ShouldNot(HaveOccurred())
+		schedulableNodes, linuxNodes, err = nodeCounts(ctx, c)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(schedulableNodes).To(Equal(1))
+		Expect(linuxNodes).To(Equal(1))
 	})
 
 	It("should scale the Typha up and down in response to the number of schedulable nodes", func() {
-		typhaMeta := metav1.ObjectMeta{
-			Name:      "calico-typha",
-			Namespace: "calico-system",
-		}
-		// Create a typha deployment
-		var r int32 = 0
-		typha := &appsv1.Deployment{
-			TypeMeta:   metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
-			ObjectMeta: typhaMeta,
-			Spec: appsv1.DeploymentSpec{
-				Replicas: &r,
-			},
-		}
-		_, err := c.AppsV1().Deployments("calico-system").Create(ctx, typha, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		createTypha(ctx, c, common.TyphaDeploymentName)
 
 		// Create a few nodes
-		CreateNode(c, "node1", map[string]string{"kubernetes.io/os": "linux"}, nil)
-		CreateNode(c, "node2", map[string]string{"kubernetes.io/os": "linux"}, nil)
+		createNode(ctx, c, "node1", map[string]string{"kubernetes.io/os": "linux"})
+		createNode(ctx, c, "node2", map[string]string{"kubernetes.io/os": "linux"})
 
 		// Create the autoscaler and run it
-		ta = newTyphaAutoscaler(c, nodeIndexInformer, tlw, statusManager, typhaAutoscalerOptionPeriod(10*time.Millisecond))
-		ta.start(ctx)
+		ta = NewTyphaAutoscaler(c, common.TyphaDeploymentName, NodeReplicaCounter, statusManager, TyphaAutoscalerOptionPeriod(10*time.Millisecond))
+		ta.Start(ctx)
 
 		// For clusters smaller than 3 nodes we only expect 1 replica.
 		verifyTyphaReplicas(c, 1)
 
 		// For three and four node clusters, we expect 2.
-		n3 := CreateNode(c, "node3", map[string]string{"kubernetes.io/os": "linux"}, nil)
+		n3 := createNode(ctx, c, "node3", map[string]string{"kubernetes.io/os": "linux"})
 		verifyTyphaReplicas(c, 2)
-		CreateNode(c, "node4", map[string]string{"kubernetes.io/os": "linux"}, nil)
+		createNode(ctx, c, "node4", map[string]string{"kubernetes.io/os": "linux"})
 		verifyTyphaReplicas(c, 2)
 
 		// For > 4 nodes, we expect redundancy with 3 replicas.
-		CreateNode(c, "node5", map[string]string{"kubernetes.io/os": "linux"}, nil)
+		createNode(ctx, c, "node5", map[string]string{"kubernetes.io/os": "linux"})
 		verifyTyphaReplicas(c, 3)
 
 		// Verify that making a node unschedulable updates replicas. Should bring us back
 		// down to 4 node scale.
 		n3.Spec.Unschedulable = true
-		_, err = c.CoreV1().Nodes().Update(ctx, n3, metav1.UpdateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		Expect(c.Update(ctx, n3)).NotTo(HaveOccurred())
 		verifyTyphaReplicas(c, 2)
 	})
 
 	It("should not ignore non-migrated nodes in its count", func() {
-		typhaMeta := metav1.ObjectMeta{
-			Name:      "calico-typha",
-			Namespace: "calico-system",
-		}
-
-		// Create a typha deployment
-		var r int32 = 0
-		typha := &appsv1.Deployment{
-			TypeMeta:   metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
-			ObjectMeta: typhaMeta,
-			Spec: appsv1.DeploymentSpec{
-				Replicas: &r,
-			},
-		}
-		_, err := c.AppsV1().Deployments("calico-system").Create(ctx, typha, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		createTypha(ctx, c, common.TyphaDeploymentName)
 
 		// Create five nodes, one of which is not yet migrated
-		CreateNode(c, "node1", map[string]string{"kubernetes.io/os": "linux", "projectcalico.org/operator-node-migration": "migrated"}, nil)
-		CreateNode(c, "node2", map[string]string{"kubernetes.io/os": "linux", "projectcalico.org/operator-node-migration": "migrated"}, nil)
-		CreateNode(c, "node3", map[string]string{"kubernetes.io/os": "linux", "projectcalico.org/operator-node-migration": "migrated"}, nil)
-		CreateNode(c, "node4", map[string]string{"kubernetes.io/os": "linux", "projectcalico.org/operator-node-migration": "migrated"}, nil)
-		CreateNode(c, "node5", map[string]string{"kubernetes.io/os": "linux", "projectcalico.org/operator-node-migration": "pre-operator"}, nil)
-
-		Eventually(func() []any {
-			return nodeIndexInformer.GetStore().List()
-		}).Should(HaveLen(5))
+		createNode(ctx, c, "node1", map[string]string{"kubernetes.io/os": "linux", "projectcalico.org/operator-node-migration": "migrated"})
+		createNode(ctx, c, "node2", map[string]string{"kubernetes.io/os": "linux", "projectcalico.org/operator-node-migration": "migrated"})
+		createNode(ctx, c, "node3", map[string]string{"kubernetes.io/os": "linux", "projectcalico.org/operator-node-migration": "migrated"})
+		createNode(ctx, c, "node4", map[string]string{"kubernetes.io/os": "linux", "projectcalico.org/operator-node-migration": "migrated"})
+		createNode(ctx, c, "node5", map[string]string{"kubernetes.io/os": "linux", "projectcalico.org/operator-node-migration": "pre-operator"})
 
 		// Create the autoscaler and run it
-		ta = newTyphaAutoscaler(c, nodeIndexInformer, tlw, statusManager, typhaAutoscalerOptionPeriod(10*time.Millisecond))
-		ta.start(ctx)
+		ta = NewTyphaAutoscaler(c, common.TyphaDeploymentName, NodeReplicaCounter, statusManager, TyphaAutoscalerOptionPeriod(10*time.Millisecond))
+		ta.Start(ctx)
 
 		verifyTyphaReplicas(c, 3)
 	})
 
 	It("should ignore aks virtual nodes in its count", func() {
-		typhaMeta := metav1.ObjectMeta{
-			Name:      "calico-typha",
-			Namespace: "calico-system",
-		}
-		// Create a typha deployment
-		var r int32 = 0
-		typha := &appsv1.Deployment{
-			TypeMeta:   metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
-			ObjectMeta: typhaMeta,
-			Spec: appsv1.DeploymentSpec{
-				Replicas: &r,
-			},
-		}
-		_, err := c.AppsV1().Deployments("calico-system").Create(ctx, typha, metav1.CreateOptions{})
-		Expect(err).To(BeNil())
+		createTypha(ctx, c, common.TyphaDeploymentName)
 
 		// Create five nodes, one of which is a virtual-kubelet
-		CreateNode(c, "node1", map[string]string{"kubernetes.io/os": "linux"}, nil)
-		CreateNode(c, "node2", map[string]string{"kubernetes.io/os": "linux"}, nil)
-		CreateNode(c, "node3", map[string]string{"kubernetes.io/os": "linux"}, nil)
-		CreateNode(c, "node4", map[string]string{"kubernetes.io/os": "linux"}, nil)
-		CreateNode(c, "node5", map[string]string{"kubernetes.io/os": "linux", "kubernetes.azure.com/cluster": "foo", "type": "virtual-kubelet"}, nil)
-
-		Eventually(func() []any {
-			return nodeIndexInformer.GetStore().List()
-		}).Should(HaveLen(5))
+		createNode(ctx, c, "node1", map[string]string{"kubernetes.io/os": "linux"})
+		createNode(ctx, c, "node2", map[string]string{"kubernetes.io/os": "linux"})
+		createNode(ctx, c, "node3", map[string]string{"kubernetes.io/os": "linux"})
+		createNode(ctx, c, "node4", map[string]string{"kubernetes.io/os": "linux"})
+		createNode(ctx, c, "node5", map[string]string{"kubernetes.io/os": "linux", "kubernetes.azure.com/cluster": "foo", "type": "virtual-kubelet"})
 
 		// Create the autoscaler and run it
-		ta = newTyphaAutoscaler(c, nodeIndexInformer, tlw, statusManager, typhaAutoscalerOptionPeriod(10*time.Millisecond))
-		ta.start(ctx)
+		ta = NewTyphaAutoscaler(c, common.TyphaDeploymentName, NodeReplicaCounter, statusManager, TyphaAutoscalerOptionPeriod(10*time.Millisecond))
+		ta.Start(ctx)
 
 		// normally we'd expect to see three replicas for five nodes, but since one node is a virtual-kubelet,
 		// we should still only expect two
 		verifyTyphaReplicas(c, 2)
 	})
 
-	It("should be degraded if there's not enough linux nodes", func() {
-		typhaMeta := metav1.ObjectMeta{
-			Name:      "calico-typha",
-			Namespace: "calico-system",
-		}
+	It("should scale the non-cluster-host Typha by host endpoint count", func() {
+		name := common.TyphaDeploymentName + "-noncluster-host"
+		createTypha(ctx, c, name)
 
-		// Create a typha deployment
-		var r int32 = 0
-		typha := &appsv1.Deployment{
-			TypeMeta:   metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
-			ObjectMeta: typhaMeta,
-			Spec: appsv1.DeploymentSpec{
-				Replicas: &r,
-			},
-		}
-		_, err := c.AppsV1().Deployments("calico-system").Create(ctx, typha, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		// Only the host endpoints kube-controllers did not create should count.
+		createHostEndpoint(ctx, c, "hep1", nil)
+		createHostEndpoint(ctx, c, "hep2", nil)
+		createHostEndpoint(ctx, c, "hep3", nil)
+		createHostEndpoint(ctx, c, "auto-hep", map[string]string{hepCreatedLabelKey: hepCreatedLabelValue})
+
+		ta = NewTyphaAutoscaler(c, name, HostEndpointReplicaCounter, statusManager, TyphaAutoscalerOptionPeriod(10*time.Millisecond))
+		ta.Start(ctx)
+
+		verifyTyphaReplicasFor(c, name, 2)
+	})
+
+	It("should be degraded if there's not enough linux nodes", func() {
+		createTypha(ctx, c, common.TyphaDeploymentName)
 
 		statusManager.On("SetDegraded", operator.ResourceScalingError, "Failed to autoscale typha - not enough linux nodes to schedule typha pods on, require 3 and have 2", mock.Anything, mock.Anything)
 
 		// Create a few nodes
-		CreateNode(c, "node1", map[string]string{"kubernetes.io/os": "linux"}, nil)
-		CreateNode(c, "node2", map[string]string{"kubernetes.io/os": "linux"}, nil)
-		CreateNode(c, "node3", map[string]string{"kubernetes.io/os": "windows"}, nil)
-		CreateNode(c, "node4", map[string]string{"kubernetes.io/os": "windows"}, nil)
-		CreateNode(c, "node5", map[string]string{"kubernetes.io/os": "windows"}, nil)
-
-		Eventually(func() []any {
-			return nodeIndexInformer.GetStore().List()
-		}).Should(HaveLen(5))
+		createNode(ctx, c, "node1", map[string]string{"kubernetes.io/os": "linux"})
+		createNode(ctx, c, "node2", map[string]string{"kubernetes.io/os": "linux"})
+		createNode(ctx, c, "node3", map[string]string{"kubernetes.io/os": "windows"})
+		createNode(ctx, c, "node4", map[string]string{"kubernetes.io/os": "windows"})
+		createNode(ctx, c, "node5", map[string]string{"kubernetes.io/os": "windows"})
 
 		// Create the autoscaler and run it
-		ta = newTyphaAutoscaler(c, nodeIndexInformer, tlw, statusManager, typhaAutoscalerOptionPeriod(10*time.Millisecond))
-		ta.start(ctx)
+		ta = NewTyphaAutoscaler(c, common.TyphaDeploymentName, NodeReplicaCounter, statusManager, TyphaAutoscalerOptionPeriod(10*time.Millisecond))
+		ta.Start(ctx)
 
 		// This blocks until the first run is done.
-		ta.isDegraded()
+		ta.IsDegraded()
 
 		statusManager.AssertExpectations(GinkgoT())
 	})
@@ -289,19 +206,48 @@ var _ = Describe("Test typha autoscaler ", func() {
 		cancelledCtx, cancelStart := context.WithCancel(context.Background())
 		cancelStart()
 
-		ta = newTyphaAutoscaler(c, nodeIndexInformer, tlw, statusManager)
-		ta.start(cancelledCtx)
+		ta = NewTyphaAutoscaler(c, common.TyphaDeploymentName, NodeReplicaCounter, statusManager)
+		ta.Start(cancelledCtx)
 
 		// The goroutine should observe the cancelled context and exit without autoscaling.
-		ta.waitForShutdown()
+		ta.WaitForShutdown()
 		statusManager.AssertNotCalled(GinkgoT(), "SetDegraded", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	})
 })
 
-func verifyTyphaReplicas(c kubernetes.Interface, expectedReplicas int) {
-	EventuallyWithOffset(1, func() int32 {
-		typha, err := c.AppsV1().Deployments("calico-system").Get(context.Background(), "calico-typha", metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
+func createNode(ctx context.Context, c client.Client, name string, labels map[string]string) *corev1.Node {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels},
+	}
+	ExpectWithOffset(1, c.Create(ctx, node)).NotTo(HaveOccurred())
+	return node
+}
+
+func createTypha(ctx context.Context, c client.Client, name string) {
+	var replicas int32 = 0
+	typha := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: common.CalicoNamespace},
+		Spec:       appsv1.DeploymentSpec{Replicas: &replicas},
+	}
+	ExpectWithOffset(1, c.Create(ctx, typha)).NotTo(HaveOccurred())
+}
+
+func createHostEndpoint(ctx context.Context, c client.Client, name string, labels map[string]string) {
+	hep := &v3.HostEndpoint{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels},
+	}
+	ExpectWithOffset(1, c.Create(ctx, hep)).NotTo(HaveOccurred())
+}
+
+func verifyTyphaReplicas(c client.Client, expectedReplicas int) {
+	verifyTyphaReplicasFor(c, common.TyphaDeploymentName, expectedReplicas)
+}
+
+func verifyTyphaReplicasFor(c client.Client, name string, expectedReplicas int) {
+	Eventually(func() int32 {
+		typha := &appsv1.Deployment{}
+		key := types.NamespacedName{Name: name, Namespace: common.CalicoNamespace}
+		Expect(c.Get(context.Background(), key, typha)).NotTo(HaveOccurred())
 		// Just return an invalid number that will never match an expected replica count.
 		if typha.Spec.Replicas == nil {
 			return -1

--- a/pkg/controller/typhaautoscaler/typhaautoscaler.go
+++ b/pkg/controller/typhaautoscaler/typhaautoscaler.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package installation
+// Package typhaautoscaler scales a Typha deployment to match a count of the cluster.
+package typhaautoscaler
 
 import (
 	"context"
@@ -35,7 +36,7 @@ import (
 var typhaLog = logf.Log.WithName("typha_autoscaler")
 
 const (
-	defaultTyphaAutoscalerSyncPeriod = 10 * time.Second
+	defaultSyncPeriod = 10 * time.Second
 
 	hepCreatedLabelKey   = "projectcalico.org/created-by"
 	hepCreatedLabelValue = "calico-kube-controllers"
@@ -44,8 +45,8 @@ const (
 // ReplicaCounter reports how many Typha replicas the cluster needs.
 type ReplicaCounter func(ctx context.Context, cli client.Client) (int, error)
 
-// TyphaAutoscaler periodically recounts the cluster and, if needed, scales the Typha deployment up/down.
-type TyphaAutoscaler struct {
+// Autoscaler periodically recounts the cluster and, if needed, scales the Typha deployment up/down.
+type Autoscaler struct {
 	client         client.Client
 	deployment     string
 	count          ReplicaCounter
@@ -58,24 +59,24 @@ type TyphaAutoscaler struct {
 	done chan struct{}
 }
 
-type TyphaAutoscalerOption func(*TyphaAutoscaler)
+type Option func(*Autoscaler)
 
-// TyphaAutoscalerOptionPeriod is an option that sets a custom sync period for the Typha autoscaler.
-func TyphaAutoscalerOptionPeriod(syncPeriod time.Duration) TyphaAutoscalerOption {
-	return func(t *TyphaAutoscaler) {
+// OptionPeriod is an option that sets a custom sync period for the Typha autoscaler.
+func OptionPeriod(syncPeriod time.Duration) Option {
+	return func(t *Autoscaler) {
 		t.syncPeriod = syncPeriod
 	}
 }
 
-// NewTyphaAutoscaler creates a new Typha autoscaler for the named deployment in the calico-system namespace, sized by
+// New creates a new Typha autoscaler for the named deployment in the calico-system namespace, sized by
 // count, optionally applying any options to the default autoscaler instance. The default sync period is 10 seconds.
-func NewTyphaAutoscaler(cli client.Client, deployment string, count ReplicaCounter, statusManager status.StatusManager, options ...TyphaAutoscalerOption) *TyphaAutoscaler {
-	ta := &TyphaAutoscaler{
+func New(cli client.Client, deployment string, count ReplicaCounter, statusManager status.StatusManager, options ...Option) *Autoscaler {
+	ta := &Autoscaler{
 		client:         cli,
 		deployment:     deployment,
 		count:          count,
 		statusManager:  statusManager,
-		syncPeriod:     defaultTyphaAutoscalerSyncPeriod,
+		syncPeriod:     defaultSyncPeriod,
 		triggerRunChan: make(chan chan error),
 		isDegradedChan: make(chan chan bool),
 	}
@@ -88,7 +89,7 @@ func NewTyphaAutoscaler(cli client.Client, deployment string, count ReplicaCount
 // Start starts the Typha autoscaler, updating the Typha deployment's replica count every sync period. The triggerRunChan
 // can be used to trigger an auto scale run immediately, while the isDegradedChan can be used to get the degraded status
 // of the last run. The TriggerRun and IsDegraded functions should be used instead of instead of access these channels directly.
-func (t *TyphaAutoscaler) Start(ctx context.Context) {
+func (t *Autoscaler) Start(ctx context.Context) {
 	t.done = make(chan struct{})
 	go func() {
 		defer close(t.done)
@@ -107,7 +108,7 @@ func (t *TyphaAutoscaler) Start(ctx context.Context) {
 		if err := t.autoscaleReplicas(ctx); err != nil {
 			degraded = true
 			typhaLog.Error(err, "Failed to autoscale typha")
-			t.statusManager.SetDegraded(operator.ResourceScalingError, fmt.Sprintf("Failed to autoscale typha - %s", err.Error()), nil, log)
+			t.statusManager.SetDegraded(operator.ResourceScalingError, fmt.Sprintf("Failed to autoscale typha - %s", err.Error()), nil, typhaLog)
 		}
 
 		for {
@@ -118,7 +119,7 @@ func (t *TyphaAutoscaler) Start(ctx context.Context) {
 					typhaLog.Error(err, "Failed to autoscale typha")
 
 					// Since this run was triggered by the ticker we need to degrade the tigera status now.
-					t.statusManager.SetDegraded(operator.ResourceScalingError, fmt.Sprintf("Failed to autoscale typha - %s", err.Error()), nil, log)
+					t.statusManager.SetDegraded(operator.ResourceScalingError, fmt.Sprintf("Failed to autoscale typha - %s", err.Error()), nil, typhaLog)
 				} else {
 					degraded = false
 				}
@@ -149,13 +150,13 @@ func (t *TyphaAutoscaler) Start(ctx context.Context) {
 
 // WaitForShutdown blocks until the autoscaler goroutine started by Start has exited. It is a no-op
 // if the autoscaler was never started. Cancel the context passed to Start to trigger shutdown.
-func (t *TyphaAutoscaler) WaitForShutdown() {
+func (t *Autoscaler) WaitForShutdown() {
 	if t.done != nil {
 		<-t.done
 	}
 }
 
-func (t *TyphaAutoscaler) TriggerRun() error {
+func (t *Autoscaler) TriggerRun() error {
 	errChan := make(chan error)
 	t.triggerRunChan <- errChan
 
@@ -163,7 +164,7 @@ func (t *TyphaAutoscaler) TriggerRun() error {
 }
 
 // IsDegraded checks if the last run autoscale run failed and returns true if it did and false otherwise.
-func (t *TyphaAutoscaler) IsDegraded() bool {
+func (t *Autoscaler) IsDegraded() bool {
 	boolChan := make(chan bool)
 	t.isDegradedChan <- boolChan
 
@@ -171,7 +172,7 @@ func (t *TyphaAutoscaler) IsDegraded() bool {
 }
 
 // autoscaleReplicas calculates the number of typha pods that should be running and scales the typha deployment accordingly
-func (t *TyphaAutoscaler) autoscaleReplicas(ctx context.Context) error {
+func (t *Autoscaler) autoscaleReplicas(ctx context.Context) error {
 	expectedReplicas, err := t.count(ctx, t.client)
 	if err != nil {
 		return err
@@ -184,7 +185,7 @@ func (t *TyphaAutoscaler) autoscaleReplicas(ctx context.Context) error {
 }
 
 // updateReplicas updates the Typha deployment to the expected replicas if the current replica count differs.
-func (t *TyphaAutoscaler) updateReplicas(ctx context.Context, expectedReplicas int32) error {
+func (t *Autoscaler) updateReplicas(ctx context.Context, expectedReplicas int32) error {
 	typha := &appsv1.Deployment{}
 	if err := t.client.Get(ctx, types.NamespacedName{Name: t.deployment, Namespace: common.CalicoNamespace}, typha); err != nil {
 		return err

--- a/pkg/controller/typhaautoscaler/typhaautoscaler_suite_test.go
+++ b/pkg/controller/typhaautoscaler/typhaautoscaler_suite_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package typhaautoscaler
+
+import (
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func TestTyphaAutoscaler(t *testing.T) {
+	logf.SetLogger(zap.New(zap.WriteTo(ginkgo.GinkgoWriter)))
+	gomega.RegisterFailHandler(ginkgo.Fail)
+
+	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
+	reporterConfig.JUnitReport = "../../../report/ut/typha_autoscaler_suite.xml"
+	ginkgo.RunSpecs(t, "pkg/controller/typhaautoscaler Suite", suiteConfig, reporterConfig)
+}

--- a/pkg/controller/typhaautoscaler/typhaautoscaler_test.go
+++ b/pkg/controller/typhaautoscaler/typhaautoscaler_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package installation
+package typhaautoscaler
 
 import (
 	"context"
@@ -42,7 +42,7 @@ var _ = Describe("Test typha autoscaler ", func() {
 	var c client.Client
 	var ctx context.Context
 	var cancel context.CancelFunc
-	var ta *TyphaAutoscaler
+	var ta *Autoscaler
 
 	BeforeEach(func() {
 		ta = nil
@@ -72,7 +72,7 @@ var _ = Describe("Test typha autoscaler ", func() {
 	It("should initialize an autoscaler", func() {
 		createNode(ctx, c, "node1", map[string]string{"kubernetes.io/os": "linux"})
 
-		ta = NewTyphaAutoscaler(c, common.TyphaDeploymentName, NodeReplicaCounter, statusManager)
+		ta = New(c, common.TyphaDeploymentName, NodeReplicaCounter, statusManager)
 		ta.Start(ctx)
 	})
 
@@ -102,7 +102,7 @@ var _ = Describe("Test typha autoscaler ", func() {
 		createNode(ctx, c, "node2", map[string]string{"kubernetes.io/os": "linux"})
 
 		// Create the autoscaler and run it
-		ta = NewTyphaAutoscaler(c, common.TyphaDeploymentName, NodeReplicaCounter, statusManager, TyphaAutoscalerOptionPeriod(10*time.Millisecond))
+		ta = New(c, common.TyphaDeploymentName, NodeReplicaCounter, statusManager, OptionPeriod(10*time.Millisecond))
 		ta.Start(ctx)
 
 		// For clusters smaller than 3 nodes we only expect 1 replica.
@@ -136,7 +136,7 @@ var _ = Describe("Test typha autoscaler ", func() {
 		createNode(ctx, c, "node5", map[string]string{"kubernetes.io/os": "linux", "projectcalico.org/operator-node-migration": "pre-operator"})
 
 		// Create the autoscaler and run it
-		ta = NewTyphaAutoscaler(c, common.TyphaDeploymentName, NodeReplicaCounter, statusManager, TyphaAutoscalerOptionPeriod(10*time.Millisecond))
+		ta = New(c, common.TyphaDeploymentName, NodeReplicaCounter, statusManager, OptionPeriod(10*time.Millisecond))
 		ta.Start(ctx)
 
 		verifyTyphaReplicas(c, 3)
@@ -153,7 +153,7 @@ var _ = Describe("Test typha autoscaler ", func() {
 		createNode(ctx, c, "node5", map[string]string{"kubernetes.io/os": "linux", "kubernetes.azure.com/cluster": "foo", "type": "virtual-kubelet"})
 
 		// Create the autoscaler and run it
-		ta = NewTyphaAutoscaler(c, common.TyphaDeploymentName, NodeReplicaCounter, statusManager, TyphaAutoscalerOptionPeriod(10*time.Millisecond))
+		ta = New(c, common.TyphaDeploymentName, NodeReplicaCounter, statusManager, OptionPeriod(10*time.Millisecond))
 		ta.Start(ctx)
 
 		// normally we'd expect to see three replicas for five nodes, but since one node is a virtual-kubelet,
@@ -171,7 +171,7 @@ var _ = Describe("Test typha autoscaler ", func() {
 		createHostEndpoint(ctx, c, "hep3", nil)
 		createHostEndpoint(ctx, c, "auto-hep", map[string]string{hepCreatedLabelKey: hepCreatedLabelValue})
 
-		ta = NewTyphaAutoscaler(c, name, HostEndpointReplicaCounter, statusManager, TyphaAutoscalerOptionPeriod(10*time.Millisecond))
+		ta = New(c, name, HostEndpointReplicaCounter, statusManager, OptionPeriod(10*time.Millisecond))
 		ta.Start(ctx)
 
 		verifyTyphaReplicasFor(c, name, 2)
@@ -190,7 +190,7 @@ var _ = Describe("Test typha autoscaler ", func() {
 		createNode(ctx, c, "node5", map[string]string{"kubernetes.io/os": "windows"})
 
 		// Create the autoscaler and run it
-		ta = NewTyphaAutoscaler(c, common.TyphaDeploymentName, NodeReplicaCounter, statusManager, TyphaAutoscalerOptionPeriod(10*time.Millisecond))
+		ta = New(c, common.TyphaDeploymentName, NodeReplicaCounter, statusManager, OptionPeriod(10*time.Millisecond))
 		ta.Start(ctx)
 
 		// This blocks until the first run is done.
@@ -206,7 +206,7 @@ var _ = Describe("Test typha autoscaler ", func() {
 		cancelledCtx, cancelStart := context.WithCancel(context.Background())
 		cancelStart()
 
-		ta = NewTyphaAutoscaler(c, common.TyphaDeploymentName, NodeReplicaCounter, statusManager)
+		ta = New(c, common.TyphaDeploymentName, NodeReplicaCounter, statusManager)
 		ta.Start(cancelledCtx)
 
 		// The goroutine should observe the cancelled context and exit without autoscaling.

--- a/pkg/controller/utils/certs.go
+++ b/pkg/controller/utils/certs.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Tigera, Inc. All rights reserved.
+// Copyright (c) 2021-2026 Tigera, Inc. All rights reserved.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,11 +16,14 @@ package utils
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 )
 
 func GetSecret(ctx context.Context, client client.Client, name string, ns string) (*corev1.Secret, error) {
@@ -32,4 +35,24 @@ func GetSecret(ctx context.Context, client client.Client, name string, ns string
 		return nil, nil
 	}
 	return secret, nil
+}
+
+// ParseCommonNameAndURISAN reads the common name and first URI SAN out of a BYO
+// certificate secret.
+func ParseCommonNameAndURISAN(secret *corev1.Secret) (cn, urisan string, err error) {
+	certData, ok := secret.Data[corev1.TLSCertKey]
+	if !ok {
+		return "", "", fmt.Errorf("failed to find cert data in secret")
+	}
+
+	cert, err := certificatemanagement.ParseCertificate(certData)
+	if err != nil {
+		return "", "", err
+	}
+
+	cn = cert.Subject.CommonName
+	if len(cert.URIs) > 0 {
+		urisan = cert.URIs[0].String()
+	}
+	return cn, urisan, nil
 }

--- a/pkg/enterprise/installation/core.go
+++ b/pkg/enterprise/installation/core.go
@@ -76,6 +76,9 @@ type installationRenderData struct {
 	managementCluster bool
 
 	waf wafRenderData
+
+	// nonClusterHost carries the second Typha the typha modifier renders.
+	nonClusterHost nonClusterHostRenderData
 }
 
 // installationData pulls the installation extension's render data back out of the
@@ -232,6 +235,16 @@ func (e *Extension) ExtendInputs(ctx context.Context, ci controller.Inputs) (con
 		return ci, nil, err
 	}
 
+	nonClusterHost, nonClusterHostTyphaTLS, err := buildNonClusterHostData(ctx, ci)
+	if err != nil {
+		return ci, nil, err
+	}
+	if nonClusterHost.enabled && !ci.Terminating {
+		if err := e.ensureTyphaAutoscaler(ci); err != nil {
+			return ci, nil, err
+		}
+	}
+
 	// The rbacsync controller reconciles the ClusterRoles backing the Manager UI's
 	// RBAC management feature.
 	rbacManagementEnabled, err := utils.RBACManagementEnabled(ctx, ci.Client, e.variant, e.opts.MultiTenant)
@@ -249,6 +262,7 @@ func (e *Extension) ExtendInputs(ctx context.Context, ci controller.Inputs) (con
 		managedCluster:            managementClusterConnection != nil,
 		managementCluster:         managementCluster != nil,
 		waf:                       waf,
+		nonClusterHost:            nonClusterHost,
 	}
 
 	prometheusClientCert, err := ci.CertificateManager.GetCertificate(ci.Client, monitor.PrometheusClientTLSSecretName, common.OperatorNamespace())
@@ -286,6 +300,9 @@ func (e *Extension) ExtendInputs(ctx context.Context, ci controller.Inputs) (con
 	}
 	if wafWebhookTLS != nil {
 		managed = append(managed, wafWebhookTLS)
+	}
+	if nonClusterHostTyphaTLS != nil {
+		managed = append(managed, nonClusterHostTyphaTLS)
 	}
 	return ci, managed, nil
 }

--- a/pkg/enterprise/installation/extension.go
+++ b/pkg/enterprise/installation/extension.go
@@ -19,6 +19,7 @@ import (
 
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/components"
+	"github.com/tigera/operator/pkg/controller/typhaautoscaler"
 	eoptions "github.com/tigera/operator/pkg/enterprise/options"
 	"github.com/tigera/operator/pkg/extensions"
 	"github.com/tigera/operator/pkg/imageoverride"
@@ -32,6 +33,10 @@ type Extension struct {
 	variant operatorv1.ProductVariant
 	opts    eoptions.Options
 	images  *imageoverride.Overrides
+
+	// typhaAutoscaler scales the non-cluster-host Typha deployment. Nil until the
+	// first reconcile that sees a NonClusterHost resource.
+	typhaAutoscaler *typhaautoscaler.Autoscaler
 }
 
 var _ extensions.InstallationExtension = &Extension{}
@@ -60,14 +65,15 @@ func (e *Extension) Images() *imageoverride.Overrides {
 
 // Modify dispatches over the components the installation controller renders.
 func (e *Extension) Modify(c render.Component, ri render.Inputs) render.Component {
-	switch c.(type) {
+	switch comp := c.(type) {
 	case render.NodeComponent:
 		return extensions.Decorate(c, ri, e.variant, func(objs, del []client.Object) ([]client.Object, []client.Object) {
 			return modifyNode(ri, objs, del)
 		})
 	case render.TyphaComponent:
+		cfg := comp.TyphaConfig()
 		return extensions.Decorate(c, ri, e.variant, func(objs, del []client.Object) ([]client.Object, []client.Object) {
-			return modifyTypha(ri, objs, del)
+			return modifyTypha(ri, cfg, objs, del)
 		})
 	case kubecontrollers.CalicoComponent:
 		return extensions.Decorate(c, ri, e.variant, func(objs, del []client.Object) ([]client.Object, []client.Object) {

--- a/pkg/enterprise/installation/kubecontrollers.go
+++ b/pkg/enterprise/installation/kubecontrollers.go
@@ -59,6 +59,14 @@ import (
 func modifyKubeControllersPolicy(ri render.Inputs, objs, del []client.Object) ([]client.Object, []client.Object) {
 	data := installationData(ri)
 
+	// The non-cluster-host typha policy renders here, with the other component
+	// policies, so it lands after the API server is up.
+	if data.nonClusterHost.enabled {
+		add, remove := nonClusterHostPolicy(ri)
+		objs = append(objs, add...)
+		del = append(del, remove...)
+	}
+
 	policy, ok := extensions.FindObject[*v3.NetworkPolicy](objs, kubecontrollers.KubeControllerNetworkPolicyName)
 	if !ok {
 		return objs, del

--- a/pkg/enterprise/installation/node_enterprise_test.go
+++ b/pkg/enterprise/installation/node_enterprise_test.go
@@ -50,18 +50,14 @@ func getTyphaNodeTLS(cli client.Client, certificateManager certificatemanager.Ce
 	typhaKeyPair, err := certificateManager.GetOrCreateKeyPair(cli, render.TyphaTLSSecretName, common.OperatorNamespace(), []string{render.FelixCommonName})
 	Expect(err).NotTo(HaveOccurred())
 
-	typhaNonClusterHostKeyPair, err := certificateManager.GetOrCreateKeyPair(cli, render.TyphaTLSSecretName+render.TyphaNonClusterHostSuffix, common.OperatorNamespace(), []string{render.FelixCommonName + render.TyphaNonClusterHostSuffix})
-	Expect(err).NotTo(HaveOccurred())
-
 	trustedBundle := certificateManager.CreateTrustedBundle(nodeKeyPair, typhaKeyPair)
 
 	return &render.TyphaNodeTLS{
-		TrustedBundle:             trustedBundle,
-		TyphaSecret:               typhaKeyPair,
-		TyphaSecretNonClusterHost: typhaNonClusterHostKeyPair,
-		TyphaCommonName:           render.TyphaCommonName,
-		NodeSecret:                nodeKeyPair,
-		NodeCommonName:            render.FelixCommonName,
+		TrustedBundle:   trustedBundle,
+		TyphaSecret:     typhaKeyPair,
+		TyphaCommonName: render.TyphaCommonName,
+		NodeSecret:      nodeKeyPair,
+		NodeCommonName:  render.FelixCommonName,
 	}
 }
 

--- a/pkg/enterprise/installation/typha.go
+++ b/pkg/enterprise/installation/typha.go
@@ -25,7 +25,7 @@ import (
 	"github.com/tigera/operator/pkg/render"
 )
 
-func modifyTypha(ri render.Inputs, objs, del []client.Object) ([]client.Object, []client.Object) {
+func modifyTypha(ri render.Inputs, cfg *render.TyphaConfiguration, objs, del []client.Object) ([]client.Object, []client.Object) {
 	if role, ok := extensions.FindObject[*rbacv1.ClusterRole](objs, render.TyphaClusterRoleName); ok {
 		role.Rules = append(role.Rules, rbacv1.PolicyRule{
 			APIGroups: []string{"projectcalico.org", "crd.projectcalico.org"},
@@ -41,6 +41,10 @@ func modifyTypha(ri render.Inputs, objs, del []client.Object) ([]client.Object, 
 			},
 			Verbs: []string{"get", "list", "watch"},
 		})
+	}
+
+	if data := installationData(ri).nonClusterHost; data.enabled {
+		objs = addNonClusterHostTypha(cfg, data, objs)
 	}
 
 	// Both Typha deployments need the interface mode, or the non-cluster-host one

--- a/pkg/enterprise/installation/typha_noncluster_host.go
+++ b/pkg/enterprise/installation/typha_noncluster_host.go
@@ -1,0 +1,260 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package installation
+
+import (
+	"context"
+	"slices"
+
+	"github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/common"
+	"github.com/tigera/operator/pkg/controller"
+	"github.com/tigera/operator/pkg/controller/k8sapi"
+	"github.com/tigera/operator/pkg/controller/typhaautoscaler"
+	"github.com/tigera/operator/pkg/controller/utils"
+	eutils "github.com/tigera/operator/pkg/enterprise/utils"
+	"github.com/tigera/operator/pkg/extensions"
+	"github.com/tigera/operator/pkg/render"
+	rmeta "github.com/tigera/operator/pkg/render/common/meta"
+	"github.com/tigera/operator/pkg/render/common/networkpolicy"
+	"github.com/tigera/operator/pkg/tls/certificatemanagement"
+)
+
+// nonClusterHostRenderData is the non-cluster-host state the typha modifiers read.
+// The zero value means the feature is off.
+type nonClusterHostRenderData struct {
+	enabled bool
+
+	// typhaSecret is the serving keypair for the pod-networked Typha that
+	// non-cluster hosts connect to.
+	typhaSecret certificatemanagement.KeyPairInterface
+
+	// nodeCommonName and nodeURISAN identify the Felix clients on non-cluster hosts.
+	nodeCommonName string
+	nodeURISAN     string
+}
+
+// buildNonClusterHostData produces the non-cluster-host Typha state from the
+// NonClusterHost resource. The keypair is returned separately for the controller to manage.
+func buildNonClusterHostData(ctx context.Context, ci controller.Inputs) (nonClusterHostRenderData, certificatemanagement.KeyPairInterface, error) {
+	if !ci.RenderInputs.Installation.Variant.IsEnterprise() {
+		return nonClusterHostRenderData{}, nil, nil
+	}
+
+	nch, err := eutils.GetNonClusterHost(ctx, ci.Client)
+	if err != nil {
+		return nonClusterHostRenderData{}, nil, extensions.Degradedf(operatorv1.ResourceReadError, "Failed to query NonClusterHost resource: %w", err)
+	}
+	if nch == nil {
+		return nonClusterHostRenderData{}, nil, nil
+	}
+
+	typhaSecret, err := ci.CertificateManager.GetOrCreateKeyPair(
+		ci.Client,
+		render.TyphaTLSSecretNameNonClusterHost,
+		common.OperatorNamespace(),
+		[]string{render.TyphaCommonName + render.TyphaNonClusterHostSuffix},
+	)
+	if err != nil {
+		return nonClusterHostRenderData{}, nil, extensions.Degradedf(operatorv1.ResourceCreateError, "error creating the non-cluster-host typha TLS certificate: %w", err)
+	}
+
+	data := nonClusterHostRenderData{
+		enabled:     true,
+		typhaSecret: typhaSecret,
+		// This is the default common name in CSR from non-cluster hosts.
+		nodeCommonName: render.FelixCommonName + render.TyphaNonClusterHostSuffix,
+	}
+
+	// Attempt to retrieve the BYO node certificates for non-cluster hosts if they are present.
+	secret, err := utils.GetSecret(ctx, ci.Client, render.NodeTLSSecretNameNonClusterHost, common.OperatorNamespace())
+	if err != nil {
+		logrus.WithError(err).Warn("failed to retrieve BYO non-cluster host node TLS secret. Using default common name instead.")
+		return data, typhaSecret, nil
+	}
+	if secret != nil {
+		cn, urisan, err := utils.ParseCommonNameAndURISAN(secret)
+		if err != nil {
+			logrus.WithError(err).Warn("failed to parse common name or URI SAN in BYO non-cluster host node TLS secret. Using default common name instead.")
+		}
+
+		data.nodeCommonName = cn
+		data.nodeURISAN = urisan
+	}
+	return data, typhaSecret, nil
+}
+
+// ensureTyphaAutoscaler starts the non-cluster-host Typha autoscaler once, then
+// re-triggers it whenever it reports degraded.
+func (e *Extension) ensureTyphaAutoscaler(ci controller.Inputs) error {
+	if e.typhaAutoscaler == nil {
+		name := common.TyphaDeploymentName + render.TyphaNonClusterHostSuffix
+		e.typhaAutoscaler = typhaautoscaler.New(ci.Client, name, typhaautoscaler.HostEndpointReplicaCounter, ci.Status)
+		e.typhaAutoscaler.Start(ci.ShutdownContext)
+		return nil
+	}
+
+	if e.typhaAutoscaler.IsDegraded() {
+		if err := e.typhaAutoscaler.TriggerRun(); err != nil {
+			return extensions.Degradedf(operatorv1.ResourceScalingError, "Failed to scale typha for noncluster hosts: %w", err)
+		}
+	}
+	return nil
+}
+
+// addNonClusterHostTypha renders a second Typha Deployment and Service, copied from
+// the in-cluster pair and moved onto the pod network.
+func addNonClusterHostTypha(cfg *render.TyphaConfiguration, data nonClusterHostRenderData, objs []client.Object) []client.Object {
+	if dep, ok := extensions.FindObject[*appsv1.Deployment](objs, common.TyphaDeploymentName); ok {
+		objs = append(objs, nonClusterHostDeployment(cfg, data, dep))
+	}
+	if svc, ok := extensions.FindObject[*corev1.Service](objs, render.TyphaServiceName); ok {
+		objs = append(objs, nonClusterHostService(svc))
+	}
+	return objs
+}
+
+func nonClusterHostDeployment(cfg *render.TyphaConfiguration, data nonClusterHostRenderData, base *appsv1.Deployment) *appsv1.Deployment {
+	dep := base.DeepCopy()
+	dep.Name += render.TyphaNonClusterHostSuffix
+
+	// Replace Typha secret annotation for NonClusterHost deployment.
+	delete(dep.Spec.Template.Annotations, cfg.TLS.TyphaSecret.HashAnnotationKey())
+	dep.Spec.Template.Annotations[data.typhaSecret.HashAnnotationKey()] = data.typhaSecret.HashAnnotationValue()
+
+	// Remove the affinity and use pod network
+	spec := &dep.Spec.Template.Spec
+	spec.Affinity = nil
+	spec.HostNetwork = false
+
+	spec.Volumes = []corev1.Volume{cfg.TLS.TrustedBundle.Volume(), data.typhaSecret.Volume()}
+	if spec.InitContainers != nil && data.typhaSecret.UseCertificateManagement() {
+		c := render.MustContainer(spec, render.TyphaContainerName)
+		spec.InitContainers = []corev1.Container{data.typhaSecret.InitContainer(common.CalicoNamespace, c.SecurityContext)}
+	}
+
+	c := render.MustContainer(spec, render.TyphaContainerName)
+	c.Env = nonClusterHostEnvVars(data, c.Env)
+	c.VolumeMounts = append(
+		cfg.TLS.TrustedBundle.VolumeMounts(rmeta.OSTypeLinux),
+		data.typhaSecret.VolumeMount(rmeta.OSTypeLinux),
+	)
+
+	// This Typha is pod-networked, so kubelet probes it on the pod IP.
+	c.LivenessProbe.HTTPGet.Host = ""
+	c.ReadinessProbe.HTTPGet.Host = ""
+	return dep
+}
+
+func nonClusterHostEnvVars(data nonClusterHostRenderData, env []corev1.EnvVar) []corev1.EnvVar {
+	env = slices.Clone(env)
+	env = replaceOrAppendEnvVar(env, "TYPHA_SERVERCERTFILE", data.typhaSecret.VolumeMountCertificateFilePath())
+	env = replaceOrAppendEnvVar(env, "TYPHA_SERVERKEYFILE", data.typhaSecret.VolumeMountKeyFilePath())
+
+	// Update Typha client common name or URISAN for non-cluster hosts.
+	// At least one of TYPHA_CLIENTCN or TYPHA_CLIENTURISAN must be set.
+	env = replaceOrAppendEnvVar(env, "TYPHA_CLIENTCN", data.nodeCommonName)
+	env = replaceOrAppendEnvVar(env, "TYPHA_CLIENTURISAN", data.nodeURISAN)
+
+	// The host-network apiserver endpoint may be unreachable from the pod network,
+	// so fall back to the pod-network endpoint.
+	env = slices.DeleteFunc(env, func(e corev1.EnvVar) bool {
+		return e.Name == "KUBERNETES_SERVICE_HOST" || e.Name == "KUBERNETES_SERVICE_PORT"
+	})
+	env = append(env, k8sapi.PodNetworkEndpoint.EnvVars()...)
+
+	// Tell the health aggregator to listen on all interfaces.
+	return append(env, corev1.EnvVar{Name: "TYPHA_HEALTHHOST", Value: "0.0.0.0"})
+}
+
+func replaceOrAppendEnvVar(envVars []corev1.EnvVar, key, value string) []corev1.EnvVar {
+	found := false
+	for i := range envVars {
+		if envVars[i].Name == key {
+			envVars[i].Value = value
+			found = true
+		}
+	}
+
+	if !found && value != "" {
+		envVars = append(envVars, corev1.EnvVar{Name: key, Value: value})
+	}
+	return envVars
+}
+
+func nonClusterHostService(base *corev1.Service) *corev1.Service {
+	svc := base.DeepCopy()
+	svc.Name += render.TyphaNonClusterHostSuffix
+	svc.Labels[render.AppLabelName] += render.TyphaNonClusterHostSuffix
+	svc.Spec.Selector[render.AppLabelName] += render.TyphaNonClusterHostSuffix
+	return svc
+}
+
+// nonClusterHostPolicy is the calico-system policy for the non-cluster-host Typha.
+func nonClusterHostPolicy(ri render.Inputs) (add, del []client.Object) {
+	egressRules := []v3.Rule{}
+	egressRules = networkpolicy.AppendDNSEgressRules(egressRules, ri.Installation.KubernetesProvider.IsOpenShift())
+	egressRules = append(egressRules, v3.Rule{
+		Action:      v3.Allow,
+		Protocol:    &networkpolicy.TCPProtocol,
+		Destination: networkpolicy.KubeAPIServerEntityRule,
+	})
+	if r, err := k8sapi.Endpoint.DestinationEntityRule(); r != nil && err == nil {
+		egressRules = append(egressRules, v3.Rule{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: *r,
+		})
+	}
+
+	healthPort := render.TyphaHealthPort(*ri.FelixConfiguration.Spec.HealthPort)
+	ingressRules := []v3.Rule{
+		{
+			Action:   v3.Allow,
+			Protocol: &networkpolicy.TCPProtocol,
+			Destination: v3.EntityRule{
+				Ports: networkpolicy.Ports(uint16(render.TyphaPort), uint16(healthPort)),
+			},
+		},
+	}
+
+	policy := &v3.NetworkPolicy{
+		TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      render.TyphaNonClusterHostNetworkPolicyName,
+			Namespace: common.CalicoNamespace,
+		},
+		Spec: v3.NetworkPolicySpec{
+			Order:    &networkpolicy.HighPrecedenceOrder,
+			Tier:     networkpolicy.CalicoTierName,
+			Selector: networkpolicy.KubernetesAppSelector(common.TyphaDeploymentName + render.TyphaNonClusterHostSuffix),
+			Types:    []v3.PolicyType{v3.PolicyTypeEgress, v3.PolicyTypeIngress},
+			Egress:   egressRules,
+			Ingress:  ingressRules,
+		},
+	}
+
+	// allow-tigera Tier was renamed to calico-system
+	deprecated := networkpolicy.DeprecatedAllowTigeraNetworkPolicyObject("typha-noncluster-host-access", common.CalicoNamespace)
+	return []client.Object{policy}, []client.Object{deprecated}
+}

--- a/pkg/enterprise/installation/typha_noncluster_host_test.go
+++ b/pkg/enterprise/installation/typha_noncluster_host_test.go
@@ -1,0 +1,216 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package installation_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/mock"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/common"
+	"github.com/tigera/operator/pkg/controller"
+	"github.com/tigera/operator/pkg/controller/k8sapi"
+	"github.com/tigera/operator/pkg/controller/status"
+	"github.com/tigera/operator/pkg/controller/utils"
+	"github.com/tigera/operator/pkg/dns"
+	"github.com/tigera/operator/pkg/enterprise"
+	eoptions "github.com/tigera/operator/pkg/enterprise/options"
+	"github.com/tigera/operator/pkg/extensions"
+	"github.com/tigera/operator/pkg/extensions/extensionstest"
+	"github.com/tigera/operator/pkg/render"
+	"github.com/tigera/operator/pkg/render/kubecontrollers"
+)
+
+var _ = Describe("non-cluster host typha", func() {
+	const nchDeploymentName = common.TyphaDeploymentName + render.TyphaNonClusterHostSuffix
+
+	var (
+		nchExt     extensions.Extensions
+		nchCtx     context.Context
+		cancel     context.CancelFunc
+		mockStatus *status.MockStatus
+	)
+
+	BeforeEach(func() {
+		// The extension owns the autoscaler goroutine, so each spec gets its own.
+		nchExt = enterprise.New(operatorv1.CalicoEnterprise, eoptions.Options{})
+		nchCtx, cancel = context.WithCancel(context.Background())
+		mockStatus = &status.MockStatus{}
+		mockStatus.On("SetDegraded", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	})
+
+	AfterEach(func() {
+		cancel()
+	})
+
+	nchControllerInputs := func(objs ...client.Object) controller.Inputs {
+		ci := newControllerInputs(operatorv1.CalicoEnterprise, objs...)
+		ci.Status = mockStatus
+		ci.ShutdownContext = nchCtx
+		ci.RenderInputs.FelixConfiguration = &v3.FelixConfiguration{
+			Spec: v3.FelixConfigurationSpec{HealthPort: ptr.To(9099)},
+		}
+		ci.RenderInputs.Installation.CNI = &operatorv1.CNISpec{Type: operatorv1.PluginCalico}
+		return ci
+	}
+
+	nonClusterHost := func() client.Object {
+		return &operatorv1.NonClusterHost{ObjectMeta: metav1.ObjectMeta{Name: utils.DefaultEnterpriseInstanceKey.Name}}
+	}
+
+	typhaNodeTLSFor := func(ci controller.Inputs) *render.TyphaNodeTLS {
+		node, err := ci.CertificateManager.GetOrCreateKeyPair(ci.Client, render.NodeTLSSecretName, common.OperatorNamespace(), []string{render.FelixCommonName})
+		Expect(err).NotTo(HaveOccurred())
+		typha, err := ci.CertificateManager.GetOrCreateKeyPair(ci.Client, render.TyphaTLSSecretName, common.OperatorNamespace(), []string{render.TyphaCommonName})
+		Expect(err).NotTo(HaveOccurred())
+
+		return &render.TyphaNodeTLS{
+			TrustedBundle:   ci.CertificateManager.CreateTrustedBundle(node, typha),
+			TyphaSecret:     typha,
+			TyphaCommonName: render.TyphaCommonName,
+			NodeSecret:      node,
+			NodeCommonName:  render.FelixCommonName,
+		}
+	}
+
+	// renderTypha renders the real typha component and runs the extension over it,
+	// exactly as the installation controller does.
+	renderTypha := func(ci controller.Inputs) []client.Object {
+		cfg := &render.TyphaConfiguration{
+			K8sServiceEp:    k8sapi.Endpoint,
+			Installation:    ci.RenderInputs.Installation,
+			TLS:             typhaNodeTLSFor(ci),
+			ClusterDomain:   dns.DefaultClusterDomain,
+			FelixHealthPort: 9099,
+		}
+		component := render.Typha(cfg)
+		Expect(component.ResolveImages(nil)).NotTo(HaveOccurred())
+		created, del := component.Objects()
+
+		stub := extensionstest.TyphaStub{
+			StubComponent: extensionstest.StubComponent{Create: created, Delete: del},
+			Cfg:           cfg,
+		}
+		out, _ := nchExt.Installation().Modify(stub, ci.RenderInputs).Objects()
+		return out
+	}
+
+	nchDeployment := func(objs []client.Object) *appsv1.Deployment {
+		dep, ok := extensions.FindObject[*appsv1.Deployment](objs, nchDeploymentName)
+		Expect(ok).To(BeTrue())
+		return dep
+	}
+
+	It("renders a second Typha deployment and service for non-cluster hosts", func() {
+		ci, _, err := nchExt.Installation().ExtendInputs(nchCtx, nchControllerInputs(nonClusterHost()))
+		Expect(err).NotTo(HaveOccurred())
+		objs := renderTypha(ci)
+
+		svc, ok := extensions.FindObject[*corev1.Service](objs, render.TyphaServiceName+render.TyphaNonClusterHostSuffix)
+		Expect(ok).To(BeTrue())
+		Expect(svc.Spec.Selector).To(HaveKeyWithValue(render.AppLabelName, nchDeploymentName))
+
+		d := nchDeployment(objs)
+		Expect(d.Spec.Template.Spec.Affinity).To(BeNil())
+		Expect(d.Spec.Template.Spec.HostNetwork).To(BeFalse())
+		Expect(d.Spec.Template.Spec.Containers).To(HaveLen(1))
+		Expect(d.Spec.Template.Spec.Containers[0].Env).To(ContainElements(
+			corev1.EnvVar{Name: "TYPHA_CLIENTCN", Value: render.FelixCommonName + render.TyphaNonClusterHostSuffix},
+			corev1.EnvVar{Name: "TYPHA_HEALTHHOST", Value: "0.0.0.0"},
+			corev1.EnvVar{Name: "TYPHA_SERVERCERTFILE", Value: "/typha-certs-noncluster-host/tls.crt"},
+			corev1.EnvVar{Name: "TYPHA_SERVERKEYFILE", Value: "/typha-certs-noncluster-host/tls.key"},
+		))
+		Expect(d.Spec.Template.Spec.Containers[0].LivenessProbe.HTTPGet.Host).To(BeEmpty())
+		Expect(d.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Host).To(BeEmpty())
+	})
+
+	It("serves the non-cluster-host Typha with its own keypair", func() {
+		ci, managed, err := nchExt.Installation().ExtendInputs(nchCtx, nchControllerInputs(nonClusterHost()))
+		Expect(err).NotTo(HaveOccurred())
+
+		names := []string{}
+		for _, kp := range managed {
+			names = append(names, kp.GetName())
+		}
+		Expect(names).To(ContainElement(render.TyphaTLSSecretNameNonClusterHost))
+
+		d := nchDeployment(renderTypha(ci))
+		Expect(d.Spec.Template.Spec.Volumes).To(ContainElement(HaveField("Name", render.TyphaTLSSecretNameNonClusterHost)))
+		Expect(d.Spec.Template.Spec.Volumes).NotTo(ContainElement(HaveField("Name", render.TyphaTLSSecretName)))
+	})
+
+	It("puts the non-cluster-host Typha on the pod network endpoint", func() {
+		k8sapi.Endpoint = k8sapi.ServiceEndpoint{Host: "proxy.local", Port: "6444"}
+		k8sapi.PodNetworkEndpoint = k8sapi.ServiceEndpoint{Host: "10.96.0.1", Port: "443"}
+		defer func() {
+			k8sapi.Endpoint = k8sapi.ServiceEndpoint{}
+			k8sapi.PodNetworkEndpoint = k8sapi.ServiceEndpoint{}
+		}()
+
+		ci, _, err := nchExt.Installation().ExtendInputs(nchCtx, nchControllerInputs(nonClusterHost()))
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(nchDeployment(renderTypha(ci)).Spec.Template.Spec.Containers[0].Env).To(ContainElements(
+			corev1.EnvVar{Name: "KUBERNETES_SERVICE_HOST", Value: "10.96.0.1"},
+			corev1.EnvVar{Name: "KUBERNETES_SERVICE_PORT", Value: "443"},
+		))
+	})
+
+	It("renders nothing extra without a NonClusterHost resource", func() {
+		ci, _, err := nchExt.Installation().ExtendInputs(nchCtx, nchControllerInputs())
+		Expect(err).NotTo(HaveOccurred())
+
+		_, ok := extensions.FindObject[*appsv1.Deployment](renderTypha(ci), nchDeploymentName)
+		Expect(ok).To(BeFalse())
+	})
+
+	It("renders the non-cluster-host policy with the other component policies", func() {
+		ci := nchControllerInputs(nonClusterHost())
+		eci, _, err := nchExt.Installation().ExtendInputs(nchCtx, ci)
+		Expect(err).NotTo(HaveOccurred())
+
+		comp := kubecontrollers.NewCalicoKubeControllersPolicy(&kubecontrollers.KubeControllersConfiguration{
+			Installation:      ci.RenderInputs.Installation,
+			ClusterDomain:     ci.RenderInputs.ClusterDomain,
+			TrustedBundle:     ci.RenderInputs.TrustedBundle,
+			MetricsPort:       9094,
+			Namespace:         common.CalicoNamespace,
+			BindingNamespaces: []string{common.CalicoNamespace},
+		}, nil)
+		create, del := comp.Objects()
+		stub := extensionstest.KubeControllersPolicyStub{
+			StubComponent: extensionstest.StubComponent{Create: create, Delete: del},
+		}
+		objs, deleted := nchExt.Installation().Modify(stub, eci.RenderInputs).Objects()
+
+		policy, ok := extensions.FindObject[*v3.NetworkPolicy](objs, render.TyphaNonClusterHostNetworkPolicyName)
+		Expect(ok).To(BeTrue())
+		Expect(policy.Namespace).To(Equal(common.CalicoNamespace))
+		Expect(policy.Spec.Ingress).To(HaveLen(1))
+
+		// The policy moved out of the allow-tigera tier, so the old object is deleted.
+		Expect(deleted).To(ContainElement(HaveField("GetName()", "allow-tigera.typha-noncluster-host-access")))
+	})
+})

--- a/pkg/enterprise/windows/windows_render_test.go
+++ b/pkg/enterprise/windows/windows_render_test.go
@@ -71,18 +71,14 @@ func getTyphaNodeTLS(cli client.Client, certificateManager certificatemanager.Ce
 	typhaKeyPair, err := certificateManager.GetOrCreateKeyPair(cli, render.TyphaTLSSecretName, common.OperatorNamespace(), []string{render.FelixCommonName})
 	Expect(err).NotTo(HaveOccurred())
 
-	typhaNonClusterHostKeyPair, err := certificateManager.GetOrCreateKeyPair(cli, render.TyphaTLSSecretName+render.TyphaNonClusterHostSuffix, common.OperatorNamespace(), []string{render.FelixCommonName + render.TyphaNonClusterHostSuffix})
-	Expect(err).NotTo(HaveOccurred())
-
 	trustedBundle := certificateManager.CreateTrustedBundle(nodeKeyPair, typhaKeyPair)
 
 	return &render.TyphaNodeTLS{
-		TrustedBundle:             trustedBundle,
-		TyphaSecret:               typhaKeyPair,
-		TyphaSecretNonClusterHost: typhaNonClusterHostKeyPair,
-		TyphaCommonName:           render.TyphaCommonName,
-		NodeSecret:                nodeKeyPair,
-		NodeCommonName:            render.FelixCommonName,
+		TrustedBundle:   trustedBundle,
+		TyphaSecret:     typhaKeyPair,
+		TyphaCommonName: render.TyphaCommonName,
+		NodeSecret:      nodeKeyPair,
+		NodeCommonName:  render.FelixCommonName,
 	}
 }
 

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -85,17 +85,13 @@ var (
 
 // TyphaNodeTLS holds configuration for Node and Typha to establish TLS.
 type TyphaNodeTLS struct {
-	TrustedBundle             certificatemanagement.TrustedBundle
-	TyphaSecret               certificatemanagement.KeyPairInterface
-	TyphaSecretNonClusterHost certificatemanagement.KeyPairInterface
-	TyphaCommonName           string
-	TyphaURISAN               string
-	NodeSecret                certificatemanagement.KeyPairInterface
-	NodeCommonName            string
-	NodeURISAN                string
-
-	NodeNonClusterHostCommonName string
-	NodeNonClusterHostURISAN     string
+	TrustedBundle   certificatemanagement.TrustedBundle
+	TyphaSecret     certificatemanagement.KeyPairInterface
+	TyphaCommonName string
+	TyphaURISAN     string
+	NodeSecret      certificatemanagement.KeyPairInterface
+	NodeCommonName  string
+	NodeURISAN      string
 }
 
 // NodeConfiguration is the public API used to provide information to the render code to

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -401,18 +401,14 @@ func getTyphaNodeTLS(cli client.Client, certificateManager certificatemanager.Ce
 	typhaKeyPair, err := certificateManager.GetOrCreateKeyPair(cli, render.TyphaTLSSecretName, common.OperatorNamespace(), []string{render.FelixCommonName})
 	Expect(err).NotTo(HaveOccurred())
 
-	typhaNonClusterHostKeyPair, err := certificateManager.GetOrCreateKeyPair(cli, render.TyphaTLSSecretName+render.TyphaNonClusterHostSuffix, common.OperatorNamespace(), []string{render.FelixCommonName + render.TyphaNonClusterHostSuffix})
-	Expect(err).NotTo(HaveOccurred())
-
 	trustedBundle := certificateManager.CreateTrustedBundle(nodeKeyPair, typhaKeyPair)
 
 	return &render.TyphaNodeTLS{
-		TrustedBundle:             trustedBundle,
-		TyphaSecret:               typhaKeyPair,
-		TyphaSecretNonClusterHost: typhaNonClusterHostKeyPair,
-		TyphaCommonName:           render.TyphaCommonName,
-		NodeSecret:                nodeKeyPair,
-		NodeCommonName:            render.FelixCommonName,
+		TrustedBundle:   trustedBundle,
+		TyphaSecret:     typhaKeyPair,
+		TyphaCommonName: render.TyphaCommonName,
+		NodeSecret:      nodeKeyPair,
+		NodeCommonName:  render.FelixCommonName,
 	}
 }
 

--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -16,7 +16,6 @@ package render
 
 import (
 	"fmt"
-	"slices"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -25,8 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
@@ -74,15 +71,10 @@ var (
 type TyphaConfiguration struct {
 	K8sServiceEp k8sapi.ServiceEndpoint
 
-	// K8sServiceEpPodNetwork is used for pod-networked Typha (i.e. the non-cluster-host
-	// deployment), where K8sServiceEp may be unreachable from pods.
-	K8sServiceEpPodNetwork k8sapi.ServiceEndpoint
-
 	Installation      *operatorv1.InstallationSpec
 	TLS               *TyphaNodeTLS
 	MigrateNamespaces bool
 	ClusterDomain     string
-	NonClusterHost    *operatorv1.NonClusterHost
 
 	// The health port that Felix is bound to. We configure Typha to bind to the port
 	// that is one less.
@@ -139,16 +131,6 @@ func (c *typhaComponent) Objects() ([]client.Object, []client.Object) {
 	}
 
 	return objs, nil
-}
-
-func NewTyphaNonClusterHostPolicy(cfg *TyphaConfiguration) Component {
-	return NewPassthrough(
-		[]client.Object{typhaNonClusterHostCalicoSystemPolicy(cfg)},
-		[]client.Object{
-			// allow-tigera Tier was renamed to calico-system
-			networkpolicy.DeprecatedAllowTigeraNetworkPolicyObject("typha-noncluster-host-access", common.CalicoNamespace),
-		},
-	)
 }
 
 func (c *typhaComponent) typhaPodDisruptionBudget() *policyv1.PodDisruptionBudget {
@@ -466,22 +448,6 @@ func (c *typhaComponent) typhaDeployment() []client.Object {
 	// fix up the other places.
 	c.applyPostOverrideFixUps(deploy)
 
-	if c.cfg.NonClusterHost != nil {
-		// Create a separate deployment to handle non-cluster host requests.
-		deployNonClusterHost := deploy.DeepCopy()
-		deployNonClusterHost.Name += TyphaNonClusterHostSuffix
-		// Replace Typha secret annotation for NonClusterHost deployment.
-		delete(deployNonClusterHost.Spec.Template.Annotations, c.cfg.TLS.TyphaSecret.HashAnnotationKey())
-		deployNonClusterHost.Spec.Template.Annotations[c.cfg.TLS.TyphaSecretNonClusterHost.HashAnnotationKey()] = c.cfg.TLS.TyphaSecretNonClusterHost.HashAnnotationValue()
-		// Remove the affinity and use pod network
-		deployNonClusterHost.Spec.Template.Spec.Affinity = nil
-		deployNonClusterHost.Spec.Template.Spec.HostNetwork = false
-		// Tune Typha container and volumes for NonClusterHost deployment.
-		deployNonClusterHost.Spec.Template.Spec.Containers = []corev1.Container{c.typhaContainerNonClusterHost()}
-		deployNonClusterHost.Spec.Template.Spec.Volumes = c.volumeNonClusterHost()
-		return []client.Object{deploy, deployNonClusterHost}
-	}
-
 	return []client.Object{deploy}
 }
 
@@ -523,25 +489,11 @@ func (c *typhaComponent) volumes() []corev1.Volume {
 	}
 }
 
-func (c *typhaComponent) volumeNonClusterHost() []corev1.Volume {
-	return []corev1.Volume{
-		c.cfg.TLS.TrustedBundle.Volume(),
-		c.cfg.TLS.TyphaSecretNonClusterHost.Volume(),
-	}
-}
-
 // typhaVolumeMounts creates the typha's volume mounts.
 func (c *typhaComponent) typhaVolumeMounts() []corev1.VolumeMount {
 	return append(
 		c.cfg.TLS.TrustedBundle.VolumeMounts(c.SupportedOSType()),
 		c.cfg.TLS.TyphaSecret.VolumeMount(c.SupportedOSType()),
-	)
-}
-
-func (c *typhaComponent) typhaVolumeMountsNonClusterHost() []corev1.VolumeMount {
-	return append(
-		c.cfg.TLS.TrustedBundle.VolumeMounts(c.SupportedOSType()),
-		c.cfg.TLS.TyphaSecretNonClusterHost.VolumeMount(c.SupportedOSType()),
 	)
 }
 
@@ -570,14 +522,6 @@ func (c *typhaComponent) typhaContainer() corev1.Container {
 		ReadinessProbe:  rp,
 		SecurityContext: securitycontext.NewNonRootContext(),
 	}
-}
-
-func (c *typhaComponent) typhaContainerNonClusterHost() corev1.Container {
-	container := c.typhaContainer()
-	container.Env = c.typhaEnvVarsNonClusterHost()
-	container.VolumeMounts = c.typhaVolumeMountsNonClusterHost()
-	container.LivenessProbe, container.ReadinessProbe = c.livenessReadinessProbes("")
-	return container
 }
 
 // typhaResources creates the typha's resource requirements.
@@ -641,48 +585,16 @@ func (c *typhaComponent) typhaEnvVars(typhaSecret certificatemanagement.KeyPairI
 	return typhaEnv
 }
 
-func replaceOrAppendEnvVar(envVars []corev1.EnvVar, key, value string) []corev1.EnvVar {
-	found := false
-	for i := range envVars {
-		if envVars[i].Name == key {
-			envVars[i].Value = value
-			found = true
-		}
-	}
-
-	if !found && value != "" {
-		envVars = append(envVars, corev1.EnvVar{Name: key, Value: value})
-	}
-	return envVars
-}
-
-func (c *typhaComponent) typhaEnvVarsNonClusterHost() []corev1.EnvVar {
-	// Update Typha client common name or URISAN for non-cluster hosts.
-	// At least one of TYPHA_CLIENTCN or TYPHA_CLIENTURISAN must be set.
-	envVars := c.typhaEnvVars(c.cfg.TLS.TyphaSecretNonClusterHost)
-	envVars = replaceOrAppendEnvVar(envVars, "TYPHA_CLIENTCN", c.cfg.TLS.NodeNonClusterHostCommonName)
-	envVars = replaceOrAppendEnvVar(envVars, "TYPHA_CLIENTURISAN", c.cfg.TLS.NodeNonClusterHostURISAN)
-
-	// NCH Typha runs pod-networked, so the host-network apiserver endpoint
-	// (e.g. MKE's proxy.local) may not be reachable. Strip the inherited env
-	// vars so we fall back to the default kubernetes Service that kubelet
-	// injects into every pod, then re-add a pod-network endpoint if one was
-	// configured explicitly.
-	envVars = slices.DeleteFunc(envVars, func(e corev1.EnvVar) bool {
-		return e.Name == "KUBERNETES_SERVICE_HOST" || e.Name == "KUBERNETES_SERVICE_PORT"
-	})
-	envVars = append(envVars, c.cfg.K8sServiceEpPodNetwork.EnvVars()...)
-
-	// Tell the health aggregator to listen on all interfaces.
-	envVars = append(envVars, corev1.EnvVar{Name: "TYPHA_HEALTHHOST", Value: "0.0.0.0"})
-	return envVars
-}
-
 // typhaHealthPort returns the liveness and readiness port to use for typha.
 func typhaHealthPort(cfg *TyphaConfiguration) int {
-	// We use the felix health port, minus one, to determine the port to use for Typha.
-	// This isn't ideal, but allows for some control of the typha port.
-	return cfg.FelixHealthPort - 1
+	return TyphaHealthPort(cfg.FelixHealthPort)
+}
+
+// TyphaHealthPort returns the health port Typha binds to, given Felix's.
+// We use the felix health port, minus one, to determine the port to use for Typha.
+// This isn't ideal, but allows for some control of the typha port.
+func TyphaHealthPort(felixHealthPort int) int {
+	return felixHealthPort - 1
 }
 
 // livenessReadinessProbes creates the typha's liveness and readiness probes.
@@ -736,13 +648,6 @@ func (c *typhaComponent) typhaServices() []client.Object {
 		},
 	}
 
-	if c.cfg.NonClusterHost != nil {
-		svcNonClusterHost := svc.DeepCopy()
-		svcNonClusterHost.Name += TyphaNonClusterHostSuffix
-		svcNonClusterHost.Labels[AppLabelName] += TyphaNonClusterHostSuffix
-		svcNonClusterHost.Spec.Selector[AppLabelName] += TyphaNonClusterHostSuffix
-		return []client.Object{svc, svcNonClusterHost}
-	}
 	return []client.Object{svc}
 }
 
@@ -810,52 +715,6 @@ func (c *typhaComponent) typhaPrometheusService() *corev1.Service {
 			Selector: map[string]string{
 				AppLabelName: TyphaK8sAppName,
 			},
-		},
-	}
-}
-
-func typhaNonClusterHostCalicoSystemPolicy(cfg *TyphaConfiguration) *v3.NetworkPolicy {
-	egressRules := []v3.Rule{}
-	egressRules = networkpolicy.AppendDNSEgressRules(egressRules, cfg.Installation.KubernetesProvider.IsOpenShift())
-	egressRules = append(egressRules, []v3.Rule{
-		{
-			Action:      v3.Allow,
-			Protocol:    &networkpolicy.TCPProtocol,
-			Destination: networkpolicy.KubeAPIServerEntityRule,
-		},
-	}...)
-
-	ingressRules := []v3.Rule{
-		{
-			Action:   v3.Allow,
-			Protocol: &networkpolicy.TCPProtocol,
-			Destination: v3.EntityRule{
-				Ports: networkpolicy.Ports(uint16(TyphaPort), uint16(typhaHealthPort(cfg))),
-			},
-		},
-	}
-
-	if r, err := cfg.K8sServiceEp.DestinationEntityRule(); r != nil && err == nil {
-		egressRules = append(egressRules, v3.Rule{
-			Action:      v3.Allow,
-			Protocol:    &networkpolicy.TCPProtocol,
-			Destination: *r,
-		})
-	}
-
-	return &v3.NetworkPolicy{
-		TypeMeta: metav1.TypeMeta{Kind: "NetworkPolicy", APIVersion: "projectcalico.org/v3"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      TyphaNonClusterHostNetworkPolicyName,
-			Namespace: common.CalicoNamespace,
-		},
-		Spec: v3.NetworkPolicySpec{
-			Order:    &networkpolicy.HighPrecedenceOrder,
-			Tier:     networkpolicy.CalicoTierName,
-			Selector: networkpolicy.KubernetesAppSelector(common.TyphaDeploymentName + TyphaNonClusterHostSuffix),
-			Types:    []v3.PolicyType{v3.PolicyTypeEgress, v3.PolicyTypeIngress},
-			Egress:   egressRules,
-			Ingress:  ingressRules,
 		},
 	}
 }

--- a/pkg/render/typha_test.go
+++ b/pkg/render/typha_test.go
@@ -63,12 +63,6 @@ var _ = Describe("Typha rendering tests", func() {
 				Type: operatorv1.PluginCalico,
 			},
 		}
-		nonclusterhost := &operatorv1.NonClusterHost{
-			Spec: operatorv1.NonClusterHostSpec{
-				Endpoint:      "https://127.0.0.1:9443",
-				TyphaEndpoint: "127.0.0.1:5473",
-			},
-		}
 		scheme := runtime.NewScheme()
 		Expect(apis.AddToScheme(scheme, false)).NotTo(HaveOccurred())
 		cli = ctrlrfake.DefaultFakeClientBuilder(scheme).Build()
@@ -81,7 +75,6 @@ var _ = Describe("Typha rendering tests", func() {
 			Installation:    installation,
 			ClusterDomain:   defaultClusterDomain,
 			FelixHealthPort: 9099,
-			NonClusterHost:  nonclusterhost,
 		}
 	})
 
@@ -149,9 +142,7 @@ var _ = Describe("Typha rendering tests", func() {
 			{name: "calico-typha", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "calico-typha", ns: "calico-system", group: "policy", version: "v1", kind: "PodDisruptionBudget"},
 			{name: "calico-typha", ns: "calico-system", group: "", version: "v1", kind: "Service"},
-			{name: "calico-typha-noncluster-host", ns: "calico-system", group: "", version: "v1", kind: "Service"},
 			{name: "calico-typha", ns: "calico-system", group: "apps", version: "v1", kind: "Deployment"},
-			{name: "calico-typha-noncluster-host", ns: "calico-system", group: "apps", version: "v1", kind: "Deployment"},
 		}
 
 		component := render.Typha(&cfg)
@@ -192,101 +183,6 @@ var _ = Describe("Typha rendering tests", func() {
 			}))
 	})
 
-	It("should render a separate Typha deployment for non-cluster hosts", func() {
-		cfg.TLS.NodeNonClusterHostCommonName = "typha-client-noncluster-host"
-		component := render.Typha(&cfg)
-		resources, _ := component.Objects()
-
-		dResource := rtest.GetResource(resources, "calico-typha-noncluster-host", "calico-system", "apps", "v1", "Deployment")
-		Expect(dResource).ToNot(BeNil())
-		d, ok := dResource.(*appsv1.Deployment)
-		Expect(ok).To(BeTrue())
-		Expect(d).NotTo(BeNil())
-
-		Expect(d.Spec.Template.Annotations).NotTo(HaveKey(cfg.TLS.TyphaSecret.HashAnnotationKey()))
-		Expect(d.Spec.Template.Annotations).To(HaveKeyWithValue(cfg.TLS.TyphaSecretNonClusterHost.HashAnnotationKey(), cfg.TLS.TyphaSecretNonClusterHost.HashAnnotationValue()))
-		Expect(d.Spec.Template.Spec.Affinity).To(BeNil())
-		Expect(d.Spec.Template.Spec.HostNetwork).To(BeFalse())
-		Expect(d.Spec.Template.Spec.Containers).To(HaveLen(1))
-		Expect(d.Spec.Template.Spec.Containers[0].Env).To(ContainElements(
-			corev1.EnvVar{Name: "TYPHA_CLIENTCN", Value: "typha-client-noncluster-host"},
-			corev1.EnvVar{Name: "TYPHA_HEALTHHOST", Value: "0.0.0.0"},
-			corev1.EnvVar{Name: "TYPHA_SERVERCERTFILE", Value: "/typha-certs-noncluster-host/tls.crt"},
-			corev1.EnvVar{Name: "TYPHA_SERVERKEYFILE", Value: "/typha-certs-noncluster-host/tls.key"},
-		))
-		Expect(d.Spec.Template.Spec.Containers[0].LivenessProbe.ProbeHandler.HTTPGet.Host).To(BeEmpty())
-		Expect(d.Spec.Template.Spec.Containers[0].ReadinessProbe.ProbeHandler.HTTPGet.Host).To(BeEmpty())
-	})
-
-	It("should strip the host-network apiserver endpoint from the non-cluster-host Typha and fall back to the default Service", func() {
-		cfg.K8sServiceEp = k8sapi.ServiceEndpoint{Host: "proxy.local", Port: "6444"}
-
-		component := render.Typha(&cfg)
-		resources, _ := component.Objects()
-
-		// NCH Typha is pod-networked; let kubelet's default service injection take over.
-		d := rtest.GetResource(resources, "calico-typha-noncluster-host", "calico-system", "apps", "v1", "Deployment").(*appsv1.Deployment)
-		for _, e := range d.Spec.Template.Spec.Containers[0].Env {
-			Expect(e.Name).ToNot(Equal("KUBERNETES_SERVICE_HOST"))
-			Expect(e.Name).ToNot(Equal("KUBERNETES_SERVICE_PORT"))
-		}
-
-		// The host-networked Typha still gets the configured endpoint.
-		dMain := rtest.GetResource(resources, "calico-typha", "calico-system", "apps", "v1", "Deployment").(*appsv1.Deployment)
-		Expect(dMain.Spec.Template.Spec.Containers[0].Env).To(ContainElements(
-			corev1.EnvVar{Name: "KUBERNETES_SERVICE_HOST", Value: "proxy.local"},
-			corev1.EnvVar{Name: "KUBERNETES_SERVICE_PORT", Value: "6444"},
-		))
-	})
-
-	It("should respect an explicit pod-network apiserver endpoint on the non-cluster-host Typha when configured", func() {
-		cfg.K8sServiceEp = k8sapi.ServiceEndpoint{Host: "proxy.local", Port: "6444"}
-		cfg.K8sServiceEpPodNetwork = k8sapi.ServiceEndpoint{Host: "10.96.0.1", Port: "443"}
-
-		component := render.Typha(&cfg)
-		resources, _ := component.Objects()
-
-		d := rtest.GetResource(resources, "calico-typha-noncluster-host", "calico-system", "apps", "v1", "Deployment").(*appsv1.Deployment)
-		Expect(d.Spec.Template.Spec.Containers[0].Env).To(ContainElements(
-			corev1.EnvVar{Name: "KUBERNETES_SERVICE_HOST", Value: "10.96.0.1"},
-			corev1.EnvVar{Name: "KUBERNETES_SERVICE_PORT", Value: "443"},
-		))
-	})
-
-	It("should use custom client common name when specified for non-cluster host Typha deployment", func() {
-		cfg.TLS.NodeNonClusterHostCommonName = "custom-nch-cn"
-		component := render.Typha(&cfg)
-		resources, _ := component.Objects()
-
-		dResource := rtest.GetResource(resources, "calico-typha-noncluster-host", "calico-system", "apps", "v1", "Deployment")
-		Expect(dResource).ToNot(BeNil())
-		d, ok := dResource.(*appsv1.Deployment)
-		Expect(ok).To(BeTrue())
-		Expect(d).NotTo(BeNil())
-
-		Expect(d.Spec.Template.Spec.Containers).To(HaveLen(1))
-		Expect(d.Spec.Template.Spec.Containers[0].Env).To(ContainElements(
-			corev1.EnvVar{Name: "TYPHA_CLIENTCN", Value: "custom-nch-cn"},
-		))
-	})
-
-	It("should use custom client uri-san when specified for non-cluster host Typha deployment", func() {
-		cfg.TLS.NodeNonClusterHostURISAN = "spiffe://custom-nch-uri-san"
-		component := render.Typha(&cfg)
-		resources, _ := component.Objects()
-
-		dResource := rtest.GetResource(resources, "calico-typha-noncluster-host", "calico-system", "apps", "v1", "Deployment")
-		Expect(dResource).ToNot(BeNil())
-		d, ok := dResource.(*appsv1.Deployment)
-		Expect(ok).To(BeTrue())
-		Expect(d).NotTo(BeNil())
-
-		Expect(d.Spec.Template.Spec.Containers).To(HaveLen(1))
-		Expect(d.Spec.Template.Spec.Containers[0].Env).To(ContainElements(
-			corev1.EnvVar{Name: "TYPHA_CLIENTURISAN", Value: "spiffe://custom-nch-uri-san"},
-		))
-	})
-
 	It("should include updates needed for migration of core components from kube-system namespace", func() {
 		expectedResources := []struct {
 			name    string
@@ -301,9 +197,7 @@ var _ = Describe("Typha rendering tests", func() {
 			{name: "calico-typha", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "calico-typha", ns: "calico-system", group: "policy", version: "v1", kind: "PodDisruptionBudget"},
 			{name: "calico-typha", ns: "calico-system", group: "", version: "v1", kind: "Service"},
-			{name: "calico-typha-noncluster-host", ns: "calico-system", group: "", version: "v1", kind: "Service"},
 			{name: "calico-typha", ns: "calico-system", group: "apps", version: "v1", kind: "Deployment"},
-			{name: "calico-typha-noncluster-host", ns: "calico-system", group: "apps", version: "v1", kind: "Deployment"},
 		}
 
 		cfg.MigrateNamespaces = true
@@ -495,9 +389,7 @@ var _ = Describe("Typha rendering tests", func() {
 			{name: "calico-typha", ns: "", group: "rbac.authorization.k8s.io", version: "v1", kind: "ClusterRoleBinding"},
 			{name: "calico-typha", ns: "calico-system", group: "policy", version: "v1", kind: "PodDisruptionBudget"},
 			{name: "calico-typha", ns: "calico-system", group: "", version: "v1", kind: "Service"},
-			{name: "calico-typha-noncluster-host", ns: "calico-system", group: "", version: "v1", kind: "Service"},
 			{name: "calico-typha", ns: "calico-system", group: "apps", version: "v1", kind: "Deployment"},
-			{name: "calico-typha-noncluster-host", ns: "calico-system", group: "apps", version: "v1", kind: "Deployment"},
 		}
 
 		component := render.Typha(&cfg)

--- a/test/utils.go
+++ b/test/utils.go
@@ -146,57 +146,6 @@ func MakeTestCA(signer string) *crypto.CA {
 	}
 }
 
-// Mock a cache.ListWatcher for nodes to use in the test as there is no other suitable
-// mock available in the fake packages.
-// Ref: https://github.com/kubernetes/client-go/issues/352#issuecomment-614740790
-type nodeListWatch struct {
-	cs kubernetes.Interface
-}
-
-func NewNodeListWatch(cs kubernetes.Interface) nodeListWatch {
-	return nodeListWatch{cs: cs}
-}
-
-func (n nodeListWatch) List(options metav1.ListOptions) (runtime.Object, error) {
-	return n.cs.CoreV1().Nodes().List(context.Background(), options)
-}
-
-func (n nodeListWatch) Watch(options metav1.ListOptions) (watch.Interface, error) {
-	return n.cs.CoreV1().Nodes().Watch(context.Background(), options)
-}
-
-// IsWatchListSemanticsUnSupported signals to the reflector that this ListerWatcher
-// does not support watch-list semantics. Without this, the reflector in client-go
-// v0.35.0+ hangs waiting for bookmark events that the fake clientset doesn't send.
-func (n nodeListWatch) IsWatchListSemanticsUnSupported() bool {
-	return true
-}
-
-// Mock a cache.ListWatcher for typha deployments to use in the test as there is no
-// other suitable mock available in the fake packages.
-// Ref: https://github.com/kubernetes/client-go/issues/352#issuecomment-614740790
-type typhaListWatch struct {
-	cs kubernetes.Interface
-}
-
-func NewTyphaListWatch(cs kubernetes.Interface) typhaListWatch {
-	return typhaListWatch{cs: cs}
-}
-
-func (t typhaListWatch) List(options metav1.ListOptions) (runtime.Object, error) {
-	return t.cs.AppsV1().Deployments("calico-system").List(context.Background(), options)
-}
-
-func (t typhaListWatch) Watch(options metav1.ListOptions) (watch.Interface, error) {
-	return t.cs.AppsV1().Deployments("calico-system").Watch(context.Background(), options)
-}
-
-// IsWatchListSemanticsUnSupported signals to the reflector that this ListerWatcher
-// does not support watch-list semantics.
-func (t typhaListWatch) IsWatchListSemanticsUnSupported() bool {
-	return true
-}
-
 func CreateNode(c kubernetes.Interface, name string, labels map[string]string, annotations map[string]string) *corev1.Node {
 	node := &corev1.Node{
 		TypeMeta: metav1.TypeMeta{Kind: "Node", APIVersion: "v1"},


### PR DESCRIPTION
## Description

Non-cluster-host typha now renders from the enterprise installation extension instead of core. What leaves core:

- the second typha deployment and service
- non-cluster-host fields on the typha/node TLS struct
- HostEndpoint informer and the second autoscaler
- reading the NonClusterHost resource, and parsing the BYO node cert

The policy for the non-cluster-host typha still renders alongside the other component policies, same as before.

The typha autoscaler moved to its own package so the enterprise extension can reach it without an import cycle, and it takes a controller-runtime client now instead of a rest.Config plus a clientset.

One behavior change worth calling out: the serving keypair for the non-cluster-host typha is only created when a NonClusterHost resource exists. Before it was created on every reconcile, in both variants.

Related: [CORE-13395](https://tigera.atlassian.net/browse/CORE-13395)

```release-note
None
```


[CORE-13395]: https://tigera.atlassian.net/browse/CORE-13395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ