### PR TITLE
Move the tenant secrets controller into its own package

### DIFF
--- a/internal/controller/secrets_controllers.go
+++ b/internal/controller/secrets_controllers.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/tigera/operator/pkg/controller/options"
 	"github.com/tigera/operator/pkg/controller/secrets"
+	"github.com/tigera/operator/pkg/controller/tenantsecrets"
 )
 
 // LogStorageReconciler reconciles a LogStorage object
@@ -40,7 +41,7 @@ func (r *SecretsReconciler) SetupWithManager(mgr ctrl.Manager, opts options.Cont
 	if err := secrets.AddClusterCAController(mgr, opts); err != nil {
 		return err
 	}
-	if err := secrets.AddTenantController(mgr, opts); err != nil {
+	if err := tenantsecrets.AddTenantController(mgr, opts); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/controller/tenantsecrets/tenant_controller.go
+++ b/pkg/controller/tenantsecrets/tenant_controller.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package secrets
+package tenantsecrets
 
 import (
 	"context"

--- a/pkg/controller/tenantsecrets/tenant_controller_test.go
+++ b/pkg/controller/tenantsecrets/tenant_controller_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package secrets
+package tenantsecrets
 
 import (
 	"bytes"

--- a/pkg/controller/tenantsecrets/tenantsecrets_suite_test.go
+++ b/pkg/controller/tenantsecrets/tenantsecrets_suite_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2023-2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tenantsecrets
+
+import (
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	uzap "go.uber.org/zap"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func TestTenantSecrets(t *testing.T) {
+	logf.SetLogger(zap.New(zap.WriteTo(ginkgo.GinkgoWriter), zap.UseDevMode(true), zap.Level(uzap.NewAtomicLevelAt(uzap.DebugLevel))))
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
+	reporterConfig.JUnitReport = "../../../report/ut/tenantsecrets_controller_suite.xml"
+	ginkgo.RunSpecs(t, "pkg/controller/tenantsecrets Suite", suiteConfig, reporterConfig)
+}


### PR DESCRIPTION
## Description

Pure move, split out of https://github.com/tigera/operator/pull/5170 to keep that review smaller. The tenant secrets controller only runs in multi-tenant mode, so it gets its own package rather than sharing one with the cluster CA controller. That way the whole package can be dropped on the OSS side instead of picking a file out of a shared one.

No behaviour change - same controller, same wiring, new package.

Related: [CORE-13395](https://tigera.atlassian.net/browse/CORE-13395)

## Release Note

```release-note
None
```


[CORE-13395]: https://tigera.atlassian.net/browse/CORE-13395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ