### PR TITLE
Move guardian's Enterprise trusted certificates behind the extension

### DIFF
--- a/pkg/controller/clusterconnection/clusterconnection_controller.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller.go
@@ -53,7 +53,6 @@ import (
 	"github.com/tigera/operator/pkg/render"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
 	"github.com/tigera/operator/pkg/render/goldmane"
-	"github.com/tigera/operator/pkg/render/monitor"
 	"github.com/tigera/operator/pkg/render/whisker"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 )
@@ -97,8 +96,6 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 	go utils.WaitToAddClusterInformationWatch(c, opts.K8sClientset, log, clusterInfoWatchReady)
 
 	for _, secretName := range []string{
-		render.PacketCaptureServerCert,
-		monitor.PrometheusServerTLSSecretName,
 		goldmane.GoldmaneKeyPairSecret,
 		certificatemanagement.TrustedBundleName("guardian", false),
 		render.CalicoAPIServerTLSSecretName,
@@ -252,13 +249,25 @@ func (r *ReconcileConnection) Reconcile(ctx context.Context, request reconcile.R
 		return reconcile.Result{}, err
 	}
 
+	includeSystem := managementClusterConnection.Spec.TLS.CA == operatorv1.CATypePublic
+	trustedBundle, err := certificateManager.CreateNamedTrustedBundleFromSecrets(render.GuardianDeploymentName, r.cli,
+		common.OperatorNamespace(), includeSystem, render.CalicoAPIServerTLSSecretName, goldmane.GoldmaneKeyPairSecret)
+	if err != nil {
+		r.status.SetDegraded(operatorv1.ResourceCreateError, "Unable to create the trusted bundle", err, reqLogger)
+	}
+
 	// Run the variant extension: it validates the configuration (a cluster cannot be
-	// both a management and a managed cluster) and produces the Enterprise-specific
-	// Guardian inputs the controller reads back below (the managed cluster version and
-	// the license-gated egress policy flag). For the core operator this is a no-op and
-	// the render inputs carries no extension data, so the OSS defaults apply.
+	// both a management and a managed cluster), adds the certificates the variant needs
+	// Guardian to trust, and produces the Enterprise-specific Guardian inputs the
+	// controller reads back below (the managed cluster version and the license-gated
+	// egress policy flag). For the core operator this is a no-op and the render inputs
+	// carries no extension data, so the OSS defaults apply.
 	ci := controller.Inputs{
-		RenderInputs:       render.Inputs{Installation: installationSpec, ClusterDomain: r.opts.ClusterDomain},
+		RenderInputs: render.Inputs{
+			Installation:  installationSpec,
+			ClusterDomain: r.opts.ClusterDomain,
+			TrustedBundle: trustedBundle,
+		},
 		Client:             r.cli,
 		CertificateManager: certificateManager,
 	}
@@ -275,15 +284,6 @@ func (r *ReconcileConnection) Reconcile(ctx context.Context, request reconcile.R
 		return reconcile.Result{}, err
 	}
 	guardianData, haveGuardianData := render.GuardianRenderDataFromInputs(ci.RenderInputs)
-
-	includeSystem := managementClusterConnection.Spec.TLS.CA == operatorv1.CATypePublic
-
-	trustedBundle, err := certificateManager.CreateNamedTrustedBundleFromSecrets(render.GuardianDeploymentName, r.cli,
-		common.OperatorNamespace(), includeSystem,
-		render.CalicoAPIServerTLSSecretName, render.PacketCaptureServerCert, monitor.PrometheusServerTLSSecretName, goldmane.GoldmaneKeyPairSecret)
-	if err != nil {
-		r.status.SetDegraded(operatorv1.ResourceCreateError, "Unable to create the trusted bundle", err, reqLogger)
-	}
 
 	// In the OSS (Whisker) path Guardian connects with its own client keypair. The
 	// Enterprise path uses the tunnel secret instead, so when the extension supplied

--- a/pkg/enterprise/clusterconnection/extension.go
+++ b/pkg/enterprise/clusterconnection/extension.go
@@ -111,14 +111,19 @@ func (e *Extension) validate(ctx context.Context, ci controller.Inputs) error {
 	return nil
 }
 
-// ExtendInputs computes the Enterprise-specific Guardian inputs the controller
-// reads back: the managed cluster version (CNXVersion) and whether the license
-// permits the domain-based egress network policy. It creates no certificates, so it
-// returns no managed keypairs. The OSS controller path supplies its own defaults
-// when this hook is absent.
+// ExtendInputs adds the certificates Guardian must trust, the managed cluster version,
+// and the license-gated egress policy flag.
 func (e *Extension) ExtendInputs(ctx context.Context, ci controller.Inputs) (controller.Inputs, []certificatemanagement.KeyPairInterface, error) {
 	if err := e.validate(ctx, ci); err != nil {
 		return ci, nil, err
+	}
+
+	for _, secretName := range []string{render.PacketCaptureServerCert, monitor.PrometheusServerTLSSecretName} {
+		cert, err := ci.CertificateManager.GetCertificate(ci.Client, secretName, common.OperatorNamespace())
+		if err != nil {
+			return ci, nil, extensions.Degradedf(operatorv1.ResourceReadError, "failed to retrieve secret %s: %w", secretName, err)
+		}
+		ci.RenderInputs.TrustedBundle.AddCertificates(cert)
 	}
 
 	clusterInformation, err := utils.FetchClusterInformation(ctx, ci.Client)

--- a/pkg/enterprise/clusterconnection/extension_test.go
+++ b/pkg/enterprise/clusterconnection/extension_test.go
@@ -33,9 +33,12 @@ import (
 	"github.com/tigera/operator/pkg/apis"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/controller"
+	"github.com/tigera/operator/pkg/controller/certificatemanager"
 	ctrlrfake "github.com/tigera/operator/pkg/ctrlruntime/client/fake"
 	"github.com/tigera/operator/pkg/extensions"
 	"github.com/tigera/operator/pkg/render"
+	"github.com/tigera/operator/pkg/render/monitor"
+	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 )
 
 var _ = Describe("clusterconnection enterprise controller extension", func() {
@@ -44,11 +47,15 @@ var _ = Describe("clusterconnection enterprise controller extension", func() {
 	// controllerInputs builds a Inputs selecting the enterprise
 	// clusterconnection hook against the given client.
 	controllerInputs := func() controller.Inputs {
+		cm, err := certificatemanager.Create(cli, nil, "", common.OperatorNamespace(), certificatemanager.AllowCACreation())
+		Expect(err).NotTo(HaveOccurred())
 		return controller.Inputs{
 			RenderInputs: render.Inputs{
-				Installation: &operatorv1.InstallationSpec{Variant: operatorv1.CalicoEnterprise},
+				Installation:  &operatorv1.InstallationSpec{Variant: operatorv1.CalicoEnterprise},
+				TrustedBundle: cm.CreateTrustedBundle(),
 			},
-			Client: cli,
+			Client:             cli,
+			CertificateManager: cm,
 		}
 	}
 
@@ -157,6 +164,21 @@ var _ = Describe("clusterconnection enterprise controller extension", func() {
 			data, ok := render.GuardianRenderDataFromInputs(ri)
 			Expect(ok).To(BeTrue())
 			Expect(data.IncludeEgressNetworkPolicy).To(BeTrue())
+		})
+
+		It("adds the enterprise certificates guardian must trust", func() {
+			var trusted []client.Object
+			for _, name := range []string{render.PacketCaptureServerCert, monitor.PrometheusServerTLSSecretName} {
+				secret, err := certificatemanagement.CreateSelfSignedSecret(name, common.OperatorNamespace(), name, nil)
+				Expect(err).NotTo(HaveOccurred())
+				trusted = append(trusted, secret)
+			}
+			cli = newClient(append(trusted, clusterInformation())...)
+
+			eci, _, err := ext.ClusterConnection().ExtendInputs(ctx, controllerInputs())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(eci.RenderInputs.TrustedBundle.HashAnnotations()).To(HaveKey(ContainSubstring(render.PacketCaptureServerCert)))
+			Expect(eci.RenderInputs.TrustedBundle.HashAnnotations()).To(HaveKey(ContainSubstring(monitor.PrometheusServerTLSSecretName)))
 		})
 
 		It("errors when ClusterInformation is missing", func() {


### PR DESCRIPTION
## Description

Split out of https://github.com/tigera/operator/pull/5170 to keep that review smaller, and the second of the per-controller ones. The cluster connection controller built Guardian's trusted bundle from a fixed list that included the packet capture and Prometheus server certificates, neither of which exists outside Enterprise.

- the controller builds the bundle from the core secrets, and the extension adds what the variant needs Guardian to trust
- the watches on those two secrets move to the extension along with them
- the bundle gets created earlier in the reconcile so the extension has something to add to

No behavior change on either variant.

Related: [CORE-13395](https://tigera.atlassian.net/browse/CORE-13395)

## Release Note

```release-note
None
```


[CORE-13395]: https://tigera.atlassian.net/browse/CORE-13395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ