### PR TITLE
Move the Enterprise apiserver watches into the extension

### DIFF
--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -54,7 +54,6 @@ import (
 	"github.com/tigera/operator/pkg/render"
 	rcertificatemanagement "github.com/tigera/operator/pkg/render/certificatemanagement"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
-	"github.com/tigera/operator/pkg/render/monitor"
 	"github.com/tigera/operator/pkg/render/webhooks"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 )
@@ -119,8 +118,6 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 	for _, secretName := range []string{
 		"calico-apiserver-certs",
 		certificatemanagement.CASecretName,
-		render.DexTLSSecretName,
-		monitor.PrometheusClientTLSSecretName,
 	} {
 		if err = utils.AddSecretsWatch(c, secretName, common.OperatorNamespace()); err != nil {
 			return fmt.Errorf("apiserver-controller failed to watch the Secret resource: %v", err)
@@ -161,18 +158,6 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 	// and also makes sure we spot when things change that might not trigger a reconciliation.
 	if err = utils.AddPeriodicReconcile(c, utils.PeriodicReconcileTime, &handler.EnqueueRequestForObject{}); err != nil {
 		return fmt.Errorf("apiserver-controller failed to create periodic reconcile watch: %w", err)
-	}
-
-	if opts.MultiTenant {
-		// On a multi-tenant management cluster the aggregated API server remains a single cluster-scoped
-		// component in calico-system, but each tenant's calico-apiserver identity must be granted Linseed
-		// access via a ClusterRoleBinding with one subject per tenant namespace. That binding is rendered by
-		// the (cluster-scoped) reconcile over the current set of tenant namespaces, so a Tenant change just
-		// needs to trigger a reconcile; the binding is then re-rendered with the up-to-date namespace set,
-		// which also drops a deleted tenant's subject.
-		if err = c.WatchObject(&operatorv1.Tenant{}, &handler.EnqueueRequestForObject{}); err != nil {
-			return fmt.Errorf("apiserver-controller failed to watch Tenant resource: %w", err)
-		}
 	}
 
 	// Watch DatastoreMigration CRs so the apiserver controller reacts promptly

--- a/pkg/enterprise/apiserver/extension.go
+++ b/pkg/enterprise/apiserver/extension.go
@@ -169,11 +169,27 @@ func (e *Extension) Watches(c ctrlruntime.Controller) error {
 	if err := utils.AddConfigMapWatch(c, rbacmanagement.ConfigMapName, common.CalicoNamespace, &handler.EnqueueRequestForObject{}); err != nil {
 		return err
 	}
+	for _, secretName := range []string{render.DexTLSSecretName, monitor.PrometheusClientTLSSecretName} {
+		if err := utils.AddSecretsWatch(c, secretName, common.OperatorNamespace()); err != nil {
+			return err
+		}
+	}
 	for _, namespace := range []string{common.OperatorNamespace(), render.APIServerNamespace} {
 		for _, secretName := range []string{render.VoltronTunnelSecretName, render.ManagerTLSSecretName} {
 			if err := utils.AddSecretsWatch(c, secretName, namespace); err != nil {
 				return err
 			}
+		}
+	}
+	if e.opts.MultiTenant {
+		// On a multi-tenant management cluster the aggregated API server remains a single cluster-scoped
+		// component in calico-system, but each tenant's calico-apiserver identity must be granted Linseed
+		// access via a ClusterRoleBinding with one subject per tenant namespace. That binding is rendered by
+		// the (cluster-scoped) reconcile over the current set of tenant namespaces, so a Tenant change just
+		// needs to trigger a reconcile; the binding is then re-rendered with the up-to-date namespace set,
+		// which also drops a deleted tenant's subject.
+		if err := c.WatchObject(&operatorv1.Tenant{}, &handler.EnqueueRequestForObject{}); err != nil {
+			return err
 		}
 	}
 	return utils.AddSecretsWatch(c, render.VoltronLinseedPublicCert, common.OperatorNamespace())


### PR DESCRIPTION
## Description

Split out of https://github.com/tigera/operator/pull/5170 to keep that review smaller, and the third of the per-controller ones. The API server controller watched Tenant plus the Dex and Prometheus client TLS secrets, none of which exist outside Enterprise. They move into the extension's watches, which takes the multi-tenant branch out of the core controller with them.

Watch registration only, so nothing about what gets rendered changes.

Related: [CORE-13395](https://tigera.atlassian.net/browse/CORE-13395)

## Release Note

```release-note
None
```


[CORE-13395]: https://tigera.atlassian.net/browse/CORE-13395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ