### PR TITLE
Move the tiers controller Enterprise namespaces behind an extension

### DIFF
--- a/pkg/controller/tiers/tiers_controller.go
+++ b/pkg/controller/tiers/tiers_controller.go
@@ -30,7 +30,6 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -43,11 +42,8 @@ import (
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/ctrlruntime"
-	eutils "github.com/tigera/operator/pkg/enterprise/utils"
 	"github.com/tigera/operator/pkg/render"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
-	"github.com/tigera/operator/pkg/render/logstorage/eck"
-	"github.com/tigera/operator/pkg/render/logstorage/kibana"
 	"github.com/tigera/operator/pkg/render/tiers"
 )
 
@@ -79,10 +75,8 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 		{Name: tiers.ClusterDNSPolicyName, Namespace: "kube-system"},
 	})
 
-	if opts.MultiTenant {
-		if err = c.WatchObject(&operatorv1.Tenant{}, &handler.EnqueueRequestForObject{}); err != nil {
-			return fmt.Errorf("tiers-controller failed to watch Tenant resource: %w", err)
-		}
+	if err := opts.Extensions.Tiers().Watches(c); err != nil {
+		return fmt.Errorf("tiers-controller failed to register extension watches: %w", err)
 	}
 
 	if err := utils.AddInstallationWatch(c); err != nil {
@@ -169,27 +163,12 @@ func (r *ReconcileTiers) prepareTiersConfig(ctx context.Context, reqLogger logr.
 	namespaces := []string{
 		common.CalicoNamespace,
 	}
-	if r.opts.Variant.IsEnterprise() {
-		namespaces = append(namespaces,
-			render.DexNamespace,
-			render.ElasticsearchNamespace,
-			render.IntrusionDetectionNamespace,
-			kibana.Namespace,
-			eck.OperatorNamespace,
-			render.PacketCaptureNamespace,
-			common.TigeraPrometheusNamespace,
-			"tigera-skraper",
-		)
+	extraNamespaces, err := r.opts.Extensions.Tiers().DNSClientNamespaces(ctx, r.client)
+	if err != nil {
+		r.status.SetDegraded(operatorv1.ResourceReadError, "Error querying namespaces that need DNS access", err, reqLogger)
+		return nil, &reconcile.Result{RequeueAfter: utils.StandardRetry}
 	}
-	if r.opts.MultiTenant {
-		// For multi-tenant clusters, we need to include well-known namespaces as well as per-tenant namespaces.
-		tenantNamespaces, err := eutils.TenantNamespaces(ctx, r.client, nil)
-		if err != nil {
-			r.status.SetDegraded(operatorv1.ResourceReadError, "Error querying tenant namespaces", err, reqLogger)
-			return nil, &reconcile.Result{RequeueAfter: utils.StandardRetry}
-		}
-		namespaces = append(namespaces, tenantNamespaces...)
-	}
+	namespaces = append(namespaces, extraNamespaces...)
 	tiersConfig.CalicoNamespaces = namespaces
 
 	// node-local-dns is not supported on openshift

--- a/pkg/enterprise/register.go
+++ b/pkg/enterprise/register.go
@@ -20,6 +20,7 @@ import (
 	"github.com/tigera/operator/pkg/enterprise/clusterconnection"
 	"github.com/tigera/operator/pkg/enterprise/installation"
 	eoptions "github.com/tigera/operator/pkg/enterprise/options"
+	"github.com/tigera/operator/pkg/enterprise/tiers"
 	"github.com/tigera/operator/pkg/enterprise/windows"
 	"github.com/tigera/operator/pkg/extensions"
 )
@@ -36,6 +37,7 @@ func New(variant operatorv1.ProductVariant, o eoptions.Options) extensions.Exten
 			Windows:           windows.New(variant),
 			APIServer:         apiserver.New(variant, o),
 			ClusterConnection: clusterconnection.New(variant),
+			Tiers:             tiers.New(o),
 		})
 	}
 

--- a/pkg/enterprise/tiers/extension.go
+++ b/pkg/enterprise/tiers/extension.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tiers
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/common"
+	"github.com/tigera/operator/pkg/ctrlruntime"
+	eoptions "github.com/tigera/operator/pkg/enterprise/options"
+	eutils "github.com/tigera/operator/pkg/enterprise/utils"
+	"github.com/tigera/operator/pkg/extensions"
+	"github.com/tigera/operator/pkg/render"
+	"github.com/tigera/operator/pkg/render/logstorage/eck"
+	"github.com/tigera/operator/pkg/render/logstorage/kibana"
+)
+
+// Extension is the Enterprise hook into the tiers controller.
+type Extension struct {
+	opts eoptions.Options
+}
+
+func New(o eoptions.Options) extensions.TiersExtension {
+	return &Extension{opts: o}
+}
+
+func (e *Extension) Watches(c ctrlruntime.Controller) error {
+	if !e.opts.MultiTenant {
+		return nil
+	}
+	return c.WatchObject(&operatorv1.Tenant{}, &handler.EnqueueRequestForObject{})
+}
+
+func (e *Extension) DNSClientNamespaces(ctx context.Context, cli client.Client) ([]string, error) {
+	namespaces := []string{
+		render.DexNamespace,
+		render.ElasticsearchNamespace,
+		render.IntrusionDetectionNamespace,
+		kibana.Namespace,
+		eck.OperatorNamespace,
+		render.PacketCaptureNamespace,
+		common.TigeraPrometheusNamespace,
+		"tigera-skraper",
+	}
+	if !e.opts.MultiTenant {
+		return namespaces, nil
+	}
+
+	// For multi-tenant clusters, we need to include well-known namespaces as well as per-tenant namespaces.
+	tenantNamespaces, err := eutils.TenantNamespaces(ctx, cli, nil)
+	if err != nil {
+		return nil, err
+	}
+	return append(namespaces, tenantNamespaces...), nil
+}

--- a/pkg/enterprise/tiers/extension_test.go
+++ b/pkg/enterprise/tiers/extension_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tiers_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/apis"
+	"github.com/tigera/operator/pkg/enterprise"
+	eoptions "github.com/tigera/operator/pkg/enterprise/options"
+	"github.com/tigera/operator/pkg/extensions"
+	"github.com/tigera/operator/pkg/render"
+)
+
+func TestTiers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "pkg/enterprise/tiers Suite")
+}
+
+var _ = Describe("DNSClientNamespaces", func() {
+	var scheme *runtime.Scheme
+	var ctx context.Context
+
+	BeforeEach(func() {
+		scheme = runtime.NewScheme()
+		Expect(apis.AddToScheme(scheme, false)).NotTo(HaveOccurred())
+		ctx = context.Background()
+	})
+
+	tiersExt := func(multiTenant bool) extensions.TiersExtension {
+		return enterprise.New(operatorv1.CalicoEnterprise, eoptions.Options{MultiTenant: multiTenant}).Tiers()
+	}
+
+	It("returns the Enterprise namespaces on a single-tenant cluster", func() {
+		cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+		ns, err := tiersExt(false).DNSClientNamespaces(ctx, cli)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ns).To(ContainElement(render.ElasticsearchNamespace))
+		Expect(ns).NotTo(ContainElement("tenant-a"))
+	})
+
+	It("adds the tenant namespaces on a multi-tenant cluster", func() {
+		cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+			&operatorv1.Tenant{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "tenant-a"}},
+			&operatorv1.Tenant{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "tenant-b"}},
+		).Build()
+		ns, err := tiersExt(true).DNSClientNamespaces(ctx, cli)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ns).To(ContainElement(render.ElasticsearchNamespace))
+		Expect(ns).To(ContainElements("tenant-a", "tenant-b"))
+	})
+
+	It("returns nothing when the variant is Calico", func() {
+		cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+		ns, err := enterprise.New(operatorv1.Calico, eoptions.Options{}).Tiers().DNSClientNamespaces(ctx, cli)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ns).To(BeEmpty())
+	})
+})

--- a/pkg/extensions/extensions.go
+++ b/pkg/extensions/extensions.go
@@ -21,6 +21,7 @@ type Set struct {
 	Windows           WindowsExtension
 	APIServer         APIServerExtension
 	ClusterConnection ClusterConnectionExtension
+	Tiers             TiersExtension
 }
 
 // Extensions is the variant behavior the operator runs with. The zero value extends
@@ -61,4 +62,11 @@ func (e Extensions) ClusterConnection() ClusterConnectionExtension {
 		return noopClusterConnection{}
 	}
 	return e.set.ClusterConnection
+}
+
+func (e Extensions) Tiers() TiersExtension {
+	if e.set.Tiers == nil {
+		return noopTiers{}
+	}
+	return e.set.Tiers
 }

--- a/pkg/extensions/tiers.go
+++ b/pkg/extensions/tiers.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extensions
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/tigera/operator/pkg/ctrlruntime"
+)
+
+// TiersExtension is the variant's hook into the tiers controller.
+type TiersExtension interface {
+	// Watches registers the variant's watches.
+	Watches(c ctrlruntime.Controller) error
+
+	// DNSClientNamespaces are the variant's namespaces that run product code and so
+	// need access to the DNS service.
+	DNSClientNamespaces(ctx context.Context, cli client.Client) ([]string, error)
+}
+
+// noopTiers runs the core operator's behavior unchanged.
+type noopTiers struct{}
+
+func (noopTiers) Watches(ctrlruntime.Controller) error {
+	return nil
+}
+
+func (noopTiers) DNSClientNamespaces(context.Context, client.Client) ([]string, error) {
+	return nil, nil
+}


### PR DESCRIPTION
## Description

Split out of https://github.com/tigera/operator/pull/5170 to keep that review smaller. The tiers controller had a hardcoded list of Enterprise namespaces that need DNS access, guarded by a variant check, plus a multi-tenant branch that queried tenant namespaces. Both come from the extension now, as one list the core controller appends to, and the Tenant watch goes with them.

Same namespaces on both variants, no rendering change.

Related: [CORE-13395](https://tigera.atlassian.net/browse/CORE-13395)

## Release Note

```release-note
None
```


[CORE-13395]: https://tigera.atlassian.net/browse/CORE-13395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ