### PR TITLE
Move two Enterprise-only CR reads behind variant extensions

### DIFF
--- a/pkg/controller/applicationlayer/applicationlayer_controller.go
+++ b/pkg/controller/applicationlayer/applicationlayer_controller.go
@@ -28,6 +28,7 @@ import (
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/controller/utils/imageset"
 	"github.com/tigera/operator/pkg/ctrlruntime"
+	"github.com/tigera/operator/pkg/enterprise/policysync"
 	"github.com/tigera/operator/pkg/render"
 	"github.com/tigera/operator/pkg/render/applicationlayer"
 	"github.com/tigera/operator/pkg/render/applicationlayer/ruleset"
@@ -487,7 +488,7 @@ func (r *ReconcileApplicationLayer) isSidecarInjectionEnabled(applicationLayerSp
 }
 
 func (r *ReconcileApplicationLayer) getPolicySyncPathPrefix(fcSpec *v3.FelixConfigurationSpec, al *operatorv1.ApplicationLayer, istioNeeds bool) string {
-	alNeeds := utils.ApplicationLayerRequiresPolicySync(al)
+	alNeeds := policysync.ApplicationLayerRequires(al)
 	return utils.DesiredPolicySyncPathPrefix(fcSpec.PolicySyncPathPrefix, alNeeds, istioNeeds)
 }
 

--- a/pkg/controller/istio/istio_controller.go
+++ b/pkg/controller/istio/istio_controller.go
@@ -40,7 +40,7 @@ import (
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/controller/utils/imageset"
 	"github.com/tigera/operator/pkg/ctrlruntime"
-	eutils "github.com/tigera/operator/pkg/enterprise/utils"
+	"github.com/tigera/operator/pkg/extensions"
 	"github.com/tigera/operator/pkg/render"
 	"github.com/tigera/operator/pkg/render/gatewayapi"
 	"github.com/tigera/operator/pkg/render/istio"
@@ -120,6 +120,7 @@ func newReconciler(mgr manager.Manager, opts options.ControllerOptions) *Reconci
 		scheme:   mgr.GetScheme(),
 		status:   status.New(mgr.GetClient(), "istio", opts.KubernetesVersion),
 		provider: opts.DetectedProvider,
+		ext:      opts.Extensions,
 	}
 
 	r.status.Run(opts.ShutdownContext)
@@ -132,6 +133,7 @@ type ReconcileIstio struct {
 	scheme   *runtime.Scheme
 	status   status.StatusManager
 	provider operatorv1.Provider
+	ext      extensions.Extensions
 }
 
 func (r *ReconcileIstio) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
@@ -373,13 +375,8 @@ func (r *ReconcileIstio) configureIstioDSCPMark(instance *operatorv1.Istio, fc *
 	return true, nil
 }
 
-// configurePolicySyncPathPrefix reconciles FelixConfiguration.policySyncPathPrefix
-// for the Istio side. The L7 ambient waypoint pod's l7-collector sidecar
-// dials Felix's nodeagent socket, which Felix only opens when this field
-// is set. The applicationlayer controller writes this same field for the
-// Dikastes/sidecar/WAF flow; both controllers consult each other's state
-// (via utils.{ApplicationLayerRequiresPolicySync,IstioRequiresPolicySync})
-// so that deleting one CR does not strand the other.
+// configurePolicySyncPathPrefix reconciles FelixConfiguration.policySyncPathPrefix,
+// which the variant extension shares with this controller.
 func (r *ReconcileIstio) configurePolicySyncPathPrefix(ctx context.Context, instance *operatorv1.Istio, fc *v3.FelixConfiguration, remove bool) (bool, error) {
 	var istioNeeds bool
 	if !remove {
@@ -398,11 +395,10 @@ func (r *ReconcileIstio) configurePolicySyncPathPrefix(ctx context.Context, inst
 		istioNeeds = utils.IstioRequiresPolicySync(instance, variant)
 	}
 
-	al, err := eutils.GetApplicationLayer(ctx, r.Client)
+	alNeeds, err := r.ext.Istio().PolicySyncRequired(ctx, r.Client)
 	if err != nil {
 		return false, err
 	}
-	alNeeds := utils.ApplicationLayerRequiresPolicySync(al)
 
 	desired := utils.DesiredPolicySyncPathPrefix(fc.Spec.PolicySyncPathPrefix, alNeeds, istioNeeds)
 	if fc.Spec.PolicySyncPathPrefix == desired {

--- a/pkg/controller/utils/policy_sync.go
+++ b/pkg/controller/utils/policy_sync.go
@@ -25,34 +25,6 @@ import (
 // ambient waypoint l7-collector, EGW).
 const DefaultPolicySyncPrefix = "/var/run/nodeagent"
 
-// ApplicationLayerRequiresPolicySync reports whether the given
-// ApplicationLayer CR has any feature enabled that requires
-// policySyncPathPrefix to be set on FelixConfiguration. A nil receiver
-// returns false (the AL CR is absent or being deleted).
-func ApplicationLayerRequiresPolicySync(al *operatorv1.ApplicationLayer) bool {
-	if al == nil {
-		return false
-	}
-	spec := &al.Spec
-	if spec.LogCollection != nil && spec.LogCollection.CollectLogs != nil &&
-		*spec.LogCollection.CollectLogs == operatorv1.L7LogCollectionEnabled {
-		return true
-	}
-	if spec.WebApplicationFirewall != nil &&
-		*spec.WebApplicationFirewall == operatorv1.WAFEnabled {
-		return true
-	}
-	if spec.ApplicationLayerPolicy != nil &&
-		*spec.ApplicationLayerPolicy == operatorv1.ApplicationLayerPolicyEnabled {
-		return true
-	}
-	if spec.SidecarInjection != nil &&
-		*spec.SidecarInjection == operatorv1.SidecarEnabled {
-		return true
-	}
-	return false
-}
-
 // IstioRequiresPolicySync reports whether an Istio CR is active in a way
 // that requires policySyncPathPrefix to be set. The L7 ambient waypoint
 // resources (l7-collector sidecar + EnvoyFilter) are rendered when the

--- a/pkg/controller/utils/policy_sync_test.go
+++ b/pkg/controller/utils/policy_sync_test.go
@@ -23,47 +23,6 @@ import (
 )
 
 var _ = Describe("policySyncPathPrefix coordination predicates", func() {
-	Describe("ApplicationLayerRequiresPolicySync", func() {
-		It("returns false for a nil receiver", func() {
-			Expect(utils.ApplicationLayerRequiresPolicySync(nil)).To(BeFalse())
-		})
-
-		It("returns false when no feature is enabled", func() {
-			Expect(utils.ApplicationLayerRequiresPolicySync(&operatorv1.ApplicationLayer{})).To(BeFalse())
-		})
-
-		It("returns true when LogCollection is enabled", func() {
-			enabled := operatorv1.L7LogCollectionEnabled
-			al := &operatorv1.ApplicationLayer{
-				Spec: operatorv1.ApplicationLayerSpec{
-					LogCollection: &operatorv1.LogCollectionSpec{CollectLogs: &enabled},
-				},
-			}
-			Expect(utils.ApplicationLayerRequiresPolicySync(al)).To(BeTrue())
-		})
-
-		It("returns true when WAF is enabled", func() {
-			enabled := operatorv1.WAFEnabled
-			Expect(utils.ApplicationLayerRequiresPolicySync(&operatorv1.ApplicationLayer{
-				Spec: operatorv1.ApplicationLayerSpec{WebApplicationFirewall: &enabled},
-			})).To(BeTrue())
-		})
-
-		It("returns true when ApplicationLayerPolicy is enabled", func() {
-			enabled := operatorv1.ApplicationLayerPolicyEnabled
-			Expect(utils.ApplicationLayerRequiresPolicySync(&operatorv1.ApplicationLayer{
-				Spec: operatorv1.ApplicationLayerSpec{ApplicationLayerPolicy: &enabled},
-			})).To(BeTrue())
-		})
-
-		It("returns true when SidecarInjection is enabled", func() {
-			enabled := operatorv1.SidecarEnabled
-			Expect(utils.ApplicationLayerRequiresPolicySync(&operatorv1.ApplicationLayer{
-				Spec: operatorv1.ApplicationLayerSpec{SidecarInjection: &enabled},
-			})).To(BeTrue())
-		})
-	})
-
 	Describe("IstioRequiresPolicySync", func() {
 		It("returns false when the Istio CR is absent", func() {
 			Expect(utils.IstioRequiresPolicySync(nil, operatorv1.CalicoEnterprise)).To(BeFalse())

--- a/pkg/enterprise/apiserver/extension.go
+++ b/pkg/enterprise/apiserver/extension.go
@@ -807,23 +807,19 @@ func (c *apiServer) auditVolumes() []corev1.Volume {
 }
 
 func (c *apiServer) multiTenantSecretsRBAC() []client.Object {
-	return render.TunnelSecretRBAC(render.APIServerSecretsRBACName, render.APIServerServiceAccountName, managementCluster(c.data.managementCluster), true)
+	return render.TunnelSecretRBAC(render.APIServerSecretsRBACName, render.APIServerServiceAccountName, tunnelSecretName(c.data.managementCluster), true)
 }
 
 func (c *apiServer) secretsRBAC() []client.Object {
-	return render.TunnelSecretRBAC(render.APIServerSecretsRBACName, render.APIServerServiceAccountName, managementCluster(c.data.managementCluster), false)
+	return render.TunnelSecretRBAC(render.APIServerSecretsRBACName, render.APIServerServiceAccountName, tunnelSecretName(c.data.managementCluster), false)
 }
 
-// managementCluster converts the CR to the setup the renderers take.
-func managementCluster(mc *operatorv1.ManagementCluster) *render.ManagementCluster {
-	if mc == nil {
-		return nil
+// tunnelSecretName is the configured tunnel CA secret, or the default when none is set.
+func tunnelSecretName(mc *operatorv1.ManagementCluster) string {
+	if mc != nil && mc.Spec.TLS != nil && mc.Spec.TLS.SecretName != "" {
+		return mc.Spec.TLS.SecretName
 	}
-	var tunnelSecretName string
-	if mc.Spec.TLS != nil {
-		tunnelSecretName = mc.Spec.TLS.SecretName
-	}
-	return render.NewManagementCluster(mc.Spec.Address, tunnelSecretName)
+	return render.VoltronTunnelSecretName
 }
 
 // linseedAccessClusterRole is a minimal, least-privilege ClusterRole granting the calico-apiserver

--- a/pkg/enterprise/apiserver/extension.go
+++ b/pkg/enterprise/apiserver/extension.go
@@ -807,11 +807,23 @@ func (c *apiServer) auditVolumes() []corev1.Volume {
 }
 
 func (c *apiServer) multiTenantSecretsRBAC() []client.Object {
-	return render.TunnelSecretRBAC(render.APIServerSecretsRBACName, render.APIServerServiceAccountName, c.data.managementCluster, true)
+	return render.TunnelSecretRBAC(render.APIServerSecretsRBACName, render.APIServerServiceAccountName, managementCluster(c.data.managementCluster), true)
 }
 
 func (c *apiServer) secretsRBAC() []client.Object {
-	return render.TunnelSecretRBAC(render.APIServerSecretsRBACName, render.APIServerServiceAccountName, c.data.managementCluster, false)
+	return render.TunnelSecretRBAC(render.APIServerSecretsRBACName, render.APIServerServiceAccountName, managementCluster(c.data.managementCluster), false)
+}
+
+// managementCluster converts the CR to the setup the renderers take.
+func managementCluster(mc *operatorv1.ManagementCluster) *render.ManagementCluster {
+	if mc == nil {
+		return nil
+	}
+	var tunnelSecretName string
+	if mc.Spec.TLS != nil {
+		tunnelSecretName = mc.Spec.TLS.SecretName
+	}
+	return render.NewManagementCluster(mc.Spec.Address, tunnelSecretName)
 }
 
 // linseedAccessClusterRole is a minimal, least-privilege ClusterRole granting the calico-apiserver

--- a/pkg/enterprise/apiserver/webhooks.go
+++ b/pkg/enterprise/apiserver/webhooks.go
@@ -43,7 +43,7 @@ const (
 
 // modifyWebhooks layers audit logging, the mutating webhooks, the extra RBAC, and
 // management-cluster support onto the rendered objects.
-func modifyWebhooks(cfg *webhooks.Configuration, mcCR *operatorv1.ManagementCluster, multiTenant bool, create, del []client.Object) ([]client.Object, []client.Object) {
+func modifyWebhooks(cfg *webhooks.Configuration, mc *operatorv1.ManagementCluster, multiTenant bool, create, del []client.Object) ([]client.Object, []client.Object) {
 	dep := extensions.MustFindObject[*appsv1.Deployment](create, webhooks.WebhooksName)
 	enableAuditLogging(dep, cfg.Installation)
 
@@ -54,17 +54,16 @@ func modifyWebhooks(cfg *webhooks.Configuration, mcCR *operatorv1.ManagementClus
 	cr.Rules = append(cr.Rules, enterpriseRules()...)
 
 	mwc := mutatingWebhookConfiguration(cfg)
-	if mcCR == nil {
+	if mc == nil {
 		// Not a management cluster, so clean up the tunnel secret RBAC.
 		return append(create, mwc), append(del, tunnelSecretRBACMeta()...)
 	}
-	mc := managementCluster(mcCR)
 
 	ctr := render.MustContainer(&dep.Spec.Template.Spec, webhooks.WebhooksName)
 	ctr.Args = append(ctr.Args, managedClusterArgs(mc, multiTenant)...)
 	mwc.Webhooks = append(mwc.Webhooks, managedClusterWebhook(cfg))
 	create = append(create, mwc)
-	create = append(create, render.TunnelSecretRBAC(webhooks.WebhooksSecretsRBACName, webhooks.WebhooksName, mc, multiTenant)...)
+	create = append(create, render.TunnelSecretRBAC(webhooks.WebhooksSecretsRBACName, webhooks.WebhooksName, tunnelSecretName(mc), multiTenant)...)
 
 	return create, del
 }
@@ -206,13 +205,14 @@ func enterpriseRules() []rbacv1.PolicyRule {
 
 // managedClusterArgs are the flags the ManagedCluster webhook needs to generate the
 // installation manifest with the correct tunnel address and certs.
-func managedClusterArgs(mc *render.ManagementCluster, multiTenant bool) []string {
+func managedClusterArgs(mc *operatorv1.ManagementCluster, multiTenant bool) []string {
 	var args []string
-	if mc.Address != "" {
-		args = append(args, fmt.Sprintf("--mcm-management-cluster-addr=%s", mc.Address))
+	if mc.Spec.Address != "" {
+		args = append(args, fmt.Sprintf("--mcm-management-cluster-addr=%s", mc.Spec.Address))
 	}
-	args = append(args, fmt.Sprintf("--mcm-tunnel-secret-name=%s", mc.TunnelSecretName))
-	if mc.TunnelSecretName == render.ManagerTLSSecretName {
+	secretName := tunnelSecretName(mc)
+	args = append(args, fmt.Sprintf("--mcm-tunnel-secret-name=%s", secretName))
+	if secretName == render.ManagerTLSSecretName {
 		args = append(args, "--mcm-management-cluster-ca-type=Public")
 	}
 	if multiTenant {

--- a/pkg/enterprise/apiserver/webhooks.go
+++ b/pkg/enterprise/apiserver/webhooks.go
@@ -43,7 +43,7 @@ const (
 
 // modifyWebhooks layers audit logging, the mutating webhooks, the extra RBAC, and
 // management-cluster support onto the rendered objects.
-func modifyWebhooks(cfg *webhooks.Configuration, managementCluster *operatorv1.ManagementCluster, multiTenant bool, create, del []client.Object) ([]client.Object, []client.Object) {
+func modifyWebhooks(cfg *webhooks.Configuration, mcCR *operatorv1.ManagementCluster, multiTenant bool, create, del []client.Object) ([]client.Object, []client.Object) {
 	dep := extensions.MustFindObject[*appsv1.Deployment](create, webhooks.WebhooksName)
 	enableAuditLogging(dep, cfg.Installation)
 
@@ -54,16 +54,17 @@ func modifyWebhooks(cfg *webhooks.Configuration, managementCluster *operatorv1.M
 	cr.Rules = append(cr.Rules, enterpriseRules()...)
 
 	mwc := mutatingWebhookConfiguration(cfg)
-	if managementCluster == nil {
+	if mcCR == nil {
 		// Not a management cluster, so clean up the tunnel secret RBAC.
 		return append(create, mwc), append(del, tunnelSecretRBACMeta()...)
 	}
+	mc := managementCluster(mcCR)
 
 	ctr := render.MustContainer(&dep.Spec.Template.Spec, webhooks.WebhooksName)
-	ctr.Args = append(ctr.Args, managedClusterArgs(managementCluster, multiTenant)...)
+	ctr.Args = append(ctr.Args, managedClusterArgs(mc, multiTenant)...)
 	mwc.Webhooks = append(mwc.Webhooks, managedClusterWebhook(cfg))
 	create = append(create, mwc)
-	create = append(create, render.TunnelSecretRBAC(webhooks.WebhooksSecretsRBACName, webhooks.WebhooksName, managementCluster, multiTenant)...)
+	create = append(create, render.TunnelSecretRBAC(webhooks.WebhooksSecretsRBACName, webhooks.WebhooksName, mc, multiTenant)...)
 
 	return create, del
 }
@@ -205,13 +206,13 @@ func enterpriseRules() []rbacv1.PolicyRule {
 
 // managedClusterArgs are the flags the ManagedCluster webhook needs to generate the
 // installation manifest with the correct tunnel address and certs.
-func managedClusterArgs(mc *operatorv1.ManagementCluster, multiTenant bool) []string {
+func managedClusterArgs(mc *render.ManagementCluster, multiTenant bool) []string {
 	var args []string
-	if mc.Spec.Address != "" {
-		args = append(args, fmt.Sprintf("--mcm-management-cluster-addr=%s", mc.Spec.Address))
+	if mc.Address != "" {
+		args = append(args, fmt.Sprintf("--mcm-management-cluster-addr=%s", mc.Address))
 	}
-	args = append(args, fmt.Sprintf("--mcm-tunnel-secret-name=%s", render.TunnelSecretName(mc)))
-	if mc.Spec.TLS != nil && mc.Spec.TLS.SecretName == render.ManagerTLSSecretName {
+	args = append(args, fmt.Sprintf("--mcm-tunnel-secret-name=%s", mc.TunnelSecretName))
+	if mc.TunnelSecretName == render.ManagerTLSSecretName {
 		args = append(args, "--mcm-management-cluster-ca-type=Public")
 	}
 	if multiTenant {

--- a/pkg/enterprise/istio/extension.go
+++ b/pkg/enterprise/istio/extension.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package istio
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/tigera/operator/pkg/enterprise/policysync"
+	"github.com/tigera/operator/pkg/enterprise/utils"
+	"github.com/tigera/operator/pkg/extensions"
+)
+
+// Extension is the Calico Enterprise behavior for the istio controller.
+type Extension struct{}
+
+var _ extensions.IstioExtension = &Extension{}
+
+// New returns the istio extension.
+func New() *Extension {
+	return &Extension{}
+}
+
+// PolicySyncRequired reports whether the ApplicationLayer flow needs the policy-sync
+// socket, so deleting the Istio CR does not strand it.
+func (e *Extension) PolicySyncRequired(ctx context.Context, c client.Client) (bool, error) {
+	al, err := utils.GetApplicationLayer(ctx, c)
+	if err != nil {
+		return false, err
+	}
+	return policysync.ApplicationLayerRequires(al), nil
+}

--- a/pkg/enterprise/policysync/policysync.go
+++ b/pkg/enterprise/policysync/policysync.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policysync
+
+import (
+	operatorv1 "github.com/tigera/operator/api/v1"
+)
+
+// ApplicationLayerRequires reports whether any enabled ApplicationLayer feature needs
+// policySyncPathPrefix set. A nil CR returns false.
+func ApplicationLayerRequires(al *operatorv1.ApplicationLayer) bool {
+	if al == nil {
+		return false
+	}
+	spec := &al.Spec
+	if spec.LogCollection != nil && spec.LogCollection.CollectLogs != nil &&
+		*spec.LogCollection.CollectLogs == operatorv1.L7LogCollectionEnabled {
+		return true
+	}
+	if spec.WebApplicationFirewall != nil &&
+		*spec.WebApplicationFirewall == operatorv1.WAFEnabled {
+		return true
+	}
+	if spec.ApplicationLayerPolicy != nil &&
+		*spec.ApplicationLayerPolicy == operatorv1.ApplicationLayerPolicyEnabled {
+		return true
+	}
+	if spec.SidecarInjection != nil &&
+		*spec.SidecarInjection == operatorv1.SidecarEnabled {
+		return true
+	}
+	return false
+}

--- a/pkg/enterprise/policysync/policysync_test.go
+++ b/pkg/enterprise/policysync/policysync_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policysync_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/enterprise/policysync"
+)
+
+var _ = Describe("ApplicationLayerRequires", func() {
+	It("returns false for a nil receiver", func() {
+		Expect(policysync.ApplicationLayerRequires(nil)).To(BeFalse())
+	})
+
+	It("returns false when no feature is enabled", func() {
+		Expect(policysync.ApplicationLayerRequires(&operatorv1.ApplicationLayer{})).To(BeFalse())
+	})
+
+	It("returns true when LogCollection is enabled", func() {
+		enabled := operatorv1.L7LogCollectionEnabled
+		al := &operatorv1.ApplicationLayer{
+			Spec: operatorv1.ApplicationLayerSpec{
+				LogCollection: &operatorv1.LogCollectionSpec{CollectLogs: &enabled},
+			},
+		}
+		Expect(policysync.ApplicationLayerRequires(al)).To(BeTrue())
+	})
+
+	It("returns true when WAF is enabled", func() {
+		enabled := operatorv1.WAFEnabled
+		Expect(policysync.ApplicationLayerRequires(&operatorv1.ApplicationLayer{
+			Spec: operatorv1.ApplicationLayerSpec{WebApplicationFirewall: &enabled},
+		})).To(BeTrue())
+	})
+
+	It("returns true when ApplicationLayerPolicy is enabled", func() {
+		enabled := operatorv1.ApplicationLayerPolicyEnabled
+		Expect(policysync.ApplicationLayerRequires(&operatorv1.ApplicationLayer{
+			Spec: operatorv1.ApplicationLayerSpec{ApplicationLayerPolicy: &enabled},
+		})).To(BeTrue())
+	})
+
+	It("returns true when SidecarInjection is enabled", func() {
+		enabled := operatorv1.SidecarEnabled
+		Expect(policysync.ApplicationLayerRequires(&operatorv1.ApplicationLayer{
+			Spec: operatorv1.ApplicationLayerSpec{SidecarInjection: &enabled},
+		})).To(BeTrue())
+	})
+})

--- a/pkg/enterprise/policysync/suite_test.go
+++ b/pkg/enterprise/policysync/suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policysync_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestPolicySync(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "pkg/enterprise/policysync Suite")
+}

--- a/pkg/enterprise/register.go
+++ b/pkg/enterprise/register.go
@@ -19,6 +19,7 @@ import (
 	"github.com/tigera/operator/pkg/enterprise/apiserver"
 	"github.com/tigera/operator/pkg/enterprise/clusterconnection"
 	"github.com/tigera/operator/pkg/enterprise/installation"
+	"github.com/tigera/operator/pkg/enterprise/istio"
 	eoptions "github.com/tigera/operator/pkg/enterprise/options"
 	"github.com/tigera/operator/pkg/enterprise/tiers"
 	"github.com/tigera/operator/pkg/enterprise/windows"
@@ -38,6 +39,7 @@ func New(variant operatorv1.ProductVariant, o eoptions.Options) extensions.Exten
 			APIServer:         apiserver.New(variant, o),
 			ClusterConnection: clusterconnection.New(variant),
 			Tiers:             tiers.New(o),
+			Istio:             istio.New(),
 		})
 	}
 

--- a/pkg/extensions/extensions.go
+++ b/pkg/extensions/extensions.go
@@ -22,6 +22,7 @@ type Set struct {
 	APIServer         APIServerExtension
 	ClusterConnection ClusterConnectionExtension
 	Tiers             TiersExtension
+	Istio             IstioExtension
 }
 
 // Extensions is the variant behavior the operator runs with. The zero value extends
@@ -69,4 +70,11 @@ func (e Extensions) Tiers() TiersExtension {
 		return noopTiers{}
 	}
 	return e.set.Tiers
+}
+
+func (e Extensions) Istio() IstioExtension {
+	if e.set.Istio == nil {
+		return noopIstio{}
+	}
+	return e.set.Istio
 }

--- a/pkg/extensions/istio.go
+++ b/pkg/extensions/istio.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extensions
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// IstioExtension is the variant's hook into the istio controller.
+type IstioExtension interface {
+	// PolicySyncRequired reports whether a variant feature needs Felix's policy-sync
+	// socket, which the istio controller shares the FelixConfiguration field with.
+	PolicySyncRequired(ctx context.Context, c client.Client) (bool, error)
+}
+
+// noopIstio needs nothing of the shared FelixConfiguration field.
+type noopIstio struct{}
+
+func (noopIstio) PolicySyncRequired(context.Context, client.Client) (bool, error) {
+	return false, nil
+}

--- a/pkg/render/tunnel_secret_rbac.go
+++ b/pkg/render/tunnel_secret_rbac.go
@@ -22,39 +22,21 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// ManagementCluster is the management-cluster setup the renderers need. A nil value
-// means the cluster does not manage others.
-type ManagementCluster struct {
-	// Address is the tunnel endpoint managed clusters dial.
-	Address string
-
-	// TunnelSecretName is the tunnel CA secret, already defaulted.
-	TunnelSecretName string
-}
-
-// NewManagementCluster defaults the tunnel CA secret when the caller has no override.
-func NewManagementCluster(address, tunnelSecretName string) *ManagementCluster {
-	if tunnelSecretName == "" {
-		tunnelSecretName = VoltronTunnelSecretName
-	}
-	return &ManagementCluster{Address: address, TunnelSecretName: tunnelSecretName}
-}
-
 // TunnelSecretRBAC returns RBAC objects granting get access to the tunnel CA secret.
 // For multi-tenant management clusters, this returns a ClusterRole/ClusterRoleBinding so the
 // service account can read per-tenant secrets across namespaces. For single-tenant clusters,
-// this returns a namespace-scoped Role/RoleBinding in calico-system.
-func TunnelSecretRBAC(rbacName string, serviceAccountName string, mc *ManagementCluster, multiTenant bool) []client.Object {
-	secretName := VoltronTunnelSecretName
-	if mc != nil {
-		secretName = mc.TunnelSecretName
+// this returns a namespace-scoped Role/RoleBinding in calico-system. An empty secret name
+// selects the default tunnel CA secret.
+func TunnelSecretRBAC(rbacName string, serviceAccountName string, tunnelSecretName string, multiTenant bool) []client.Object {
+	if tunnelSecretName == "" {
+		tunnelSecretName = VoltronTunnelSecretName
 	}
 	rules := []rbacv1.PolicyRule{
 		{
 			APIGroups:     []string{""},
 			Resources:     []string{"secrets"},
 			Verbs:         []string{"get"},
-			ResourceNames: []string{secretName},
+			ResourceNames: []string{tunnelSecretName},
 		},
 	}
 

--- a/pkg/render/tunnel_secret_rbac.go
+++ b/pkg/render/tunnel_secret_rbac.go
@@ -17,28 +17,38 @@ package render
 import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// TunnelSecretName returns the name of the tunnel CA secret based on the ManagementCluster spec.
-// If the ManagementCluster has a custom TLS secret name configured, that is returned; otherwise
-// the default VoltronTunnelSecretName is used.
-func TunnelSecretName(mc *operatorv1.ManagementCluster) string {
-	if mc != nil && mc.Spec.TLS != nil && mc.Spec.TLS.SecretName != "" {
-		return mc.Spec.TLS.SecretName
+// ManagementCluster is the management-cluster setup the renderers need. A nil value
+// means the cluster does not manage others.
+type ManagementCluster struct {
+	// Address is the tunnel endpoint managed clusters dial.
+	Address string
+
+	// TunnelSecretName is the tunnel CA secret, already defaulted.
+	TunnelSecretName string
+}
+
+// NewManagementCluster defaults the tunnel CA secret when the caller has no override.
+func NewManagementCluster(address, tunnelSecretName string) *ManagementCluster {
+	if tunnelSecretName == "" {
+		tunnelSecretName = VoltronTunnelSecretName
 	}
-	return VoltronTunnelSecretName
+	return &ManagementCluster{Address: address, TunnelSecretName: tunnelSecretName}
 }
 
 // TunnelSecretRBAC returns RBAC objects granting get access to the tunnel CA secret.
 // For multi-tenant management clusters, this returns a ClusterRole/ClusterRoleBinding so the
 // service account can read per-tenant secrets across namespaces. For single-tenant clusters,
 // this returns a namespace-scoped Role/RoleBinding in calico-system.
-func TunnelSecretRBAC(rbacName string, serviceAccountName string, mc *operatorv1.ManagementCluster, multiTenant bool) []client.Object {
-	secretName := TunnelSecretName(mc)
+func TunnelSecretRBAC(rbacName string, serviceAccountName string, mc *ManagementCluster, multiTenant bool) []client.Object {
+	secretName := VoltronTunnelSecretName
+	if mc != nil {
+		secretName = mc.TunnelSecretName
+	}
 	rules := []rbacv1.PolicyRule{
 		{
 			APIGroups:     []string{""},


### PR DESCRIPTION
## Description

Split out of https://github.com/tigera/operator/pull/5170 to keep that review smaller. Two places in core read an Enterprise-only CR to decide what to render:

- the istio controller fetched the ApplicationLayer CR to work out whether policySyncPathPrefix was needed, and now asks its extension instead
- the webhooks and apiserver renders took the ManagementCluster CR directly, and now take the tunnel address and secret name as plain values

Same rendering on both variants. The Typha read that started out in this PR went in separately with https://github.com/tigera/operator/pull/5189.

Related: [CORE-13395](https://tigera.atlassian.net/browse/CORE-13395)

## Release Note

```release-note
None
```



[CORE-13395]: https://tigera.atlassian.net/browse/CORE-13395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ