### PR TITLE
Treat an unset clusterRoutingMode as the mode Calico defaults to

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1960,10 +1960,8 @@ func birdProgramClusterRoutesValue(mode operatorv1.ClusterRoutingMode) string {
 }
 
 // felixProgramsIPIPClusterRoutes and felixProgramsNoEncapClusterRoutes say whether Felix, rather
-// than confd and BIRD, is the configured owner of the cluster routes for IPIP and for
-// unencapsulated IP Pools respectively.  Both return false when the mode is unset: the operator
-// then writes neither field and Calico's own defaults decide, which is not something to encode
-// here -- it varies by Calico version.
+// than confd and BIRD, is the owner of the cluster routes for IPIP and for unencapsulated IP Pools
+// respectively.
 func felixProgramsIPIPClusterRoutes(install *operatorv1.Installation) bool {
 	mode := clusterRoutingMode(install)
 	return mode == operatorv1.ClusterRoutingModeFelix || mode == operatorv1.ClusterRoutingModeFelixIPIPOnly
@@ -1973,9 +1971,26 @@ func felixProgramsNoEncapClusterRoutes(install *operatorv1.Installation) bool {
 	return clusterRoutingMode(install) == operatorv1.ClusterRoutingModeFelix
 }
 
+// clusterRoutingMode returns the cluster routing mode in effect: the configured one, or -- when the
+// field is unset, which is the common case -- the mode that Calico's own defaults amount to.  Since
+// Calico v3.33 those defaults give Felix the cluster routes for IPIP IP Pools and leave the
+// unencapsulated ones with BIRD, which is exactly FelixIPIPOnly.
+//
+// Returning the effective mode rather than "" does tie this to the Calico version the operator
+// ships with, which is why it previously returned "".  But every caller has to reach some
+// conclusion about who owns the routes, and "nobody knows, so assume BIRD" is not a neutral answer:
+// it rejects a configuration that works, namely IPIP with BGP disabled on a cluster that has simply
+// taken Calico's default.  The operator is released against a known Calico version, so encoding
+// that version's defaults here is well defined.  Revisit when the no-encap default moves.
+//
+// This is deliberately not used to decide whether to *write* programClusterRoutes into
+// FelixConfiguration and BGPConfiguration.  Those writes stay gated on the field being explicitly
+// set (see setClusterRoutingOnFelixConfiguration and setClusterRoutingOnBGPConfiguration), so that
+// leaving it unset continues to mean "whatever Calico's defaults are" rather than pinning today's
+// defaults into the datastore.
 func clusterRoutingMode(install *operatorv1.Installation) operatorv1.ClusterRoutingMode {
 	if install.Spec.CalicoNetwork == nil || install.Spec.CalicoNetwork.ClusterRoutingMode == nil {
-		return ""
+		return operatorv1.ClusterRoutingModeFelixIPIPOnly
 	}
 	return *install.Spec.CalicoNetwork.ClusterRoutingMode
 }

--- a/pkg/controller/installation/validation_test.go
+++ b/pkg/controller/installation/validation_test.go
@@ -268,6 +268,8 @@ var _ = Describe("Installation validation tests", func() {
 	It("should prevent IPIP with BGP disabled in BIRD cluster routing mode", func() {
 		disabled := operator.BGPDisabled
 		instance.Spec.CalicoNetwork.BGP = &disabled
+		clusterRoutingMode := operator.ClusterRoutingModeBIRD
+		instance.Spec.CalicoNetwork.ClusterRoutingMode = &clusterRoutingMode
 		instance.Spec.CalicoNetwork.IPPools = []operator.IPPool{
 			{
 				CIDR:          "192.168.0.0/24",
@@ -283,6 +285,8 @@ var _ = Describe("Installation validation tests", func() {
 	It("should prevent IPIP cross-subnet with BGP disabled in BIRD cluster routing mode", func() {
 		disabled := operator.BGPDisabled
 		instance.Spec.CalicoNetwork.BGP = &disabled
+		clusterRoutingMode := operator.ClusterRoutingModeBIRD
+		instance.Spec.CalicoNetwork.ClusterRoutingMode = &clusterRoutingMode
 		instance.Spec.CalicoNetwork.IPPools = []operator.IPPool{
 			{
 				CIDR:          "192.168.0.0/24",
@@ -298,6 +302,8 @@ var _ = Describe("Installation validation tests", func() {
 	It("should prevent no-encap with BGP disabled in BIRD cluster routing mode", func() {
 		disabled := operator.BGPDisabled
 		instance.Spec.CalicoNetwork.BGP = &disabled
+		clusterRoutingMode := operator.ClusterRoutingModeBIRD
+		instance.Spec.CalicoNetwork.ClusterRoutingMode = &clusterRoutingMode
 		instance.Spec.CalicoNetwork.IPPools = []operator.IPPool{
 			{
 				CIDR:          "192.168.0.0/24",
@@ -402,6 +408,41 @@ var _ = Describe("Installation validation tests", func() {
 		instance.Spec.CalicoNetwork.BGP = &disabled
 		clusterRoutingMode := operator.ClusterRoutingModeFelixIPIPOnly
 		instance.Spec.CalicoNetwork.ClusterRoutingMode = &clusterRoutingMode
+		instance.Spec.CalicoNetwork.IPPools = []operator.IPPool{
+			{
+				CIDR:          "192.168.0.0/24",
+				Encapsulation: operator.EncapsulationNone,
+				NATOutgoing:   operator.NATOutgoingEnabled,
+				NodeSelector:  "all()",
+			},
+		}
+		err := validateCustomResource(instance)
+		Expect(err).To(HaveOccurred())
+	})
+
+	// An unset clusterRoutingMode means Calico's own defaults, which since v3.33 are the same
+	// split as FelixIPIPOnly: Felix owns the IPIP cluster routes, BIRD keeps the unencapsulated
+	// ones.  So the two cases below must match the FelixIPIPOnly ones above.
+	It("should allow IPIP with BGP disabled when the cluster routing mode is unset", func() {
+		disabled := operator.BGPDisabled
+		instance.Spec.CalicoNetwork.BGP = &disabled
+		instance.Spec.CalicoNetwork.ClusterRoutingMode = nil
+		instance.Spec.CalicoNetwork.IPPools = []operator.IPPool{
+			{
+				CIDR:          "192.168.0.0/24",
+				Encapsulation: operator.EncapsulationIPIP,
+				NATOutgoing:   operator.NATOutgoingEnabled,
+				NodeSelector:  "all()",
+			},
+		}
+		err := validateCustomResource(instance)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should prevent no-encap with BGP disabled when the cluster routing mode is unset", func() {
+		disabled := operator.BGPDisabled
+		instance.Spec.CalicoNetwork.BGP = &disabled
+		instance.Spec.CalicoNetwork.ClusterRoutingMode = nil
 		instance.Spec.CalicoNetwork.IPPools = []operator.IPPool{
 			{
 				CIDR:          "192.168.0.0/24",


### PR DESCRIPTION
## Description

**Type:** bug fix. **Note:** master is currently frozen, so this is raised for review rather than
immediate merge.

`clusterRoutingMode()` returned `""` for an unset `clusterRoutingMode`, so
`felixProgramsIPIPClusterRoutes()` returned false and the Installation validation concluded that
BIRD owned the IPIP cluster routes. Since Calico v3.33 that is wrong: Calico's own defaults give
Felix the cluster routes for IPIP IP Pools, and leave the unencapsulated ones with BIRD.

The visible effect is that a cluster which has simply taken Calico's default — the common case,
since the operator writes neither `programClusterRoutes` field when `clusterRoutingMode` is unset —
**cannot disable BGP even when it only has IPIP pools**. The Installation is accepted by the API
server but the operator degrades without touching the DaemonSet:

```
$ kubectl patch installation default --type=merge \
    -p '{"spec":{"calicoNetwork":{"bgp":"Disabled"}}}'
installation.operator.tigera.io/default patched

$ kubectl get tigerastatus calico -o jsonpath='{.status.conditions[0]}'
Degraded=True InvalidConfigurationError
  Invalid Installation provided: with BIRD cluster routing mode, IPIP encapsulation requires
  that BGP is enabled
```

This returns `FelixIPIPOnly` for an unset mode instead — exactly the split Calico's defaults
produce — so both predicates come out right: Felix owns IPIP, BIRD keeps no-encap.

### The trade-off

Returning the effective mode ties the operator to the Calico version it ships with, which is why
the unset case previously returned `""` (see the comment being replaced, from #5150). The trade is
deliberate: every caller has to reach *some* conclusion about who owns the routes, and answering
"nobody knows, so assume BIRD" is not a neutral default — it rejects a configuration that works.
The operator is released against a known Calico version, so encoding that version's defaults is
well defined. It will need revisiting when the no-encap default moves.

Deciding whether to **write** the `programClusterRoutes` fields is unaffected:
`setClusterRoutingOnFelixConfiguration` and `setClusterRoutingOnBGPConfiguration` test the field for
nil directly rather than going through this helper, so an unset mode still writes neither field, and
still means "whatever Calico's defaults are" rather than pinning today's defaults into the
datastore.

## Testing

- Three validation tests named for BIRD cluster routing mode were relying on unset meaning BIRD;
  they now set that mode explicitly, so they test what their names claim.
- Two new tests pin the changed behaviour: unset + IPIP + BGP disabled is allowed, unset + no-encap
  + BGP disabled is still rejected.
- `go test ./pkg/controller/installation/`: 306 passed, same 14 pre-existing failures as on clean
  master (`Installation CRD CEL validation`, which needs envtest binaries not present locally —
  318/304/14 before, 320/306/14 after).
- Found while writing a Calico-side system test for the BIRD-to-Felix cluster route migration,
  which needs to disable BGP on an IPIP cluster and was blocked by this.

## Related issues/PRs

Follows tigera/operator#5150, which added `FelixIPIPOnly`. Related to projectcalico/calico#13470.

## Release Note

```release-note
Fixed a bug that prevented BGP being disabled on a cluster with only IPIP IP Pools when clusterRoutingMode was left unset.
```