### PR TITLE
[CVE] Bump Go to 1.26.6 (release-v1.42)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ REPO?=tigera/operator
 PACKAGE_NAME?=github.com/tigera/operator
 LOCAL_USER_ID?=$(shell id -u $$USER)
 # The project Go version.
-GO_VERSION?=1.26.5
+GO_VERSION?=1.26.6
 # Version of Kubernetes to use for dependencies, tests, and kubectl.
 K8S_VERSION?=v1.36.3
 # The version of LLVM to use for the go-build image.

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/tigera/operator/api
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.80.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tigera/operator
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0


### PR DESCRIPTION
Clears the two stdlib findings against the operator image from the 2026-08-14 scan of `v1.42.4-40-g0d01e49fe7a5`.

The operator binary is built by the `calico/go-build` image selected by `GO_VERSION`, so its stdlib version is whatever that pin says. At 1.26.5:

| CVE | | |
|---|---|---|
| CVE-2026-39821 | 8.2 | `idna.ToASCII`/`ToUnicode` accept Punycode labels that decode to an ASCII-only label, so code that does a privilege check on the ASCII hostname can be bypassed (`xn--example-.com` passes, then decodes to `example.com`). |
| CVE-2026-46600 | 7.5 | Parsing an invalid SVCB or HTTPS resource record panics when a parameter value overflows the message buffer. |

Both are fixed in Go 1.26.6.

### Changes

- `Makefile`: `GO_VERSION?=` 1.26.5 -> 1.26.6
- `go.mod`, `api/go.mod`: `go` directive 1.26.5 -> 1.26.6

The `go` directives move with `GO_VERSION`, matching the previous bump (7d0d1ac61). No dependency changes, so `go.sum` is untouched.

`calico/go-build` already publishes `1.26.6-llvm21.1.8-k8s1.36.3`, which matches this branch's `LLVM_VERSION` and `K8S_VERSION` — no go-build change needed. (The pre-commit hook ran in that image while preparing this branch.)

### Scope

These were the last findings outstanding against the operator image from that scan. The containerd, oras-go and grpc findings were cleared by the move to helm v3.21.3 in #5172, which dropped containerd and grpc from the dependency graph outright and took oras-go to v2.6.2. This branch is rebased on that merge.

Note that `master` is still on 1.26.5, so this does not have a master counterpart to pick from; it is a release-branch-only bump driven by the scan.

**Release note:**
```release-note
Fixed CVE-2026-39821 and CVE-2026-46600 in the operator image by building with Go 1.26.6.
```