### PR TITLE
Move the operator's startup checks for Enterprise into pkg/enterprise

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/cloudflare/cfssl/log"
 	"github.com/go-logr/logr"
-	"github.com/tigera/operator/pkg/enterprise/cloudconfig"
 
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 
@@ -48,10 +47,6 @@ import (
 	"github.com/tigera/operator/pkg/imports/admission"
 	"github.com/tigera/operator/pkg/imports/crds"
 	"github.com/tigera/operator/pkg/render"
-	"github.com/tigera/operator/pkg/render/intrusiondetection/dpi"
-	"github.com/tigera/operator/pkg/render/istio"
-	"github.com/tigera/operator/pkg/render/logstorage"
-	"github.com/tigera/operator/pkg/render/logstorage/eck"
 	operatortls "github.com/tigera/operator/pkg/tls"
 	"github.com/tigera/operator/version"
 
@@ -62,6 +57,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -443,18 +439,11 @@ admission policy installation; once an Installation exists it is the authority o
 		}
 	}
 
-	// The enterprise controllers can't register without their APIs. Exiting lets the kubelet
+	// The variant's controllers can't register without their APIs. Exiting lets the kubelet
 	// retry us once the CRDs are installed.
-	if variant.IsEnterprise() {
-		enterpriseAPIs, err := discovery.EnterpriseAPIsExist(cs)
-		if err != nil {
-			setupLog.Error(err, "Failed to determine whether the Enterprise APIs are available")
-			os.Exit(1)
-		}
-		if !enterpriseAPIs {
-			setupLog.Error(fmt.Errorf("the Calico Enterprise CRDs are not installed"), "Cannot run as Calico Enterprise")
-			os.Exit(1)
-		}
+	if err := enterprise.VerifyAPIsExist(variant, cs); err != nil {
+		setupLog.Error(err, "Cannot run as the configured variant")
+		os.Exit(1)
 	}
 
 	// Start a goroutine to handle termination.
@@ -555,18 +544,10 @@ admission policy installation; once an Installation exists it is the authority o
 
 	// The operator MUST not run within one of the Namespaces that it itself manages. Perform an early check here
 	// to make sure that we're not doing so, and exit if we are.
-	badNamespaces := []string{
-		common.CalicoNamespace,
-		"calico-apiserver",
-		render.ElasticsearchNamespace,
-		render.IntrusionDetectionNamespace,
-		dpi.DeepPacketInspectionNamespace,
-		eck.OperatorNamespace,
-		render.LogCollectorNamespace,
-		render.CSIDaemonSetNamespace,
-		render.ManagerNamespace,
-		istio.IstioNamespace,
-	}
+	// Components share namespaces, so dedupe before the error lists them.
+	badNamespaces := sets.New(common.CalicoNamespace, render.CSIDaemonSetNamespace).
+		Insert(enterprise.ProtectedNamespaces()...).
+		UnsortedList()
 	for _, ns := range badNamespaces {
 		if common.OperatorNamespace() == ns {
 			log.Error("Operator must not be run within a Namespace managed by the operator, please select a different namespace")
@@ -591,11 +572,9 @@ admission policy installation; once an Installation exists it is the authority o
 	if isCloudBuild() {
 		elasticIsMigrating = discovery.ElasticIsMigrating(bootConfig)
 		useSingleIndex = discovery.UseSingleIndex(bootConfig)
-		if !elasticIsMigrating {
-			if err := verifyElasticSearch(ctx, cs, useExternalElastic); err != nil {
-				setupLog.Error(err, "Elasticsearch configuration verification failed")
-				os.Exit(1)
-			}
+		if err := enterprise.VerifyElasticsearch(ctx, cs, variant, elasticIsMigrating, useExternalElastic); err != nil {
+			setupLog.Error(err, "Elasticsearch configuration verification failed")
+			os.Exit(1)
 		}
 	}
 
@@ -637,12 +616,6 @@ admission policy installation; once an Installation exists it is the authority o
 		Extensions:        extensionRegistry,
 	}
 
-	// Before we start any controllers, make sure our options are valid.
-	if err := verifyConfiguration(ctx, clientset, options); err != nil {
-		setupLog.Error(err, "Invalid configuration")
-		os.Exit(1)
-	}
-
 	err = controller.AddToManager(mgr, options)
 	if err != nil {
 		setupLog.Error(err, "unable to create controllers")
@@ -660,30 +633,6 @@ admission policy installation; once an Installation exists it is the authority o
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
-}
-
-func verifyElasticSearch(ctx context.Context, cs kubernetes.Interface, isElasticsearchExternal bool) error {
-	if isElasticsearchExternal {
-		// There should not be an internal-es cert.
-		_, err := cs.CoreV1().Secrets(render.ElasticsearchNamespace).Get(ctx, render.TigeraElasticsearchInternalCertSecret, metav1.GetOptions{})
-		if err != nil {
-			if errors.IsNotFound(err) {
-				return nil
-			}
-			return fmt.Errorf("unexpected error encountered when confirming elastic is not currently internal: %w", err)
-		}
-		return fmt.Errorf("refusing to run: operator configured as external-es but secret/%s found which suggests its internal-es", render.TigeraElasticsearchInternalCertSecret)
-	}
-
-	// There should not be an external-es cert.
-	_, err := cs.CoreV1().Secrets(render.ElasticsearchNamespace).Get(ctx, logstorage.ExternalCertsSecret, metav1.GetOptions{})
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil
-		}
-		return fmt.Errorf("unexpected error encountered when confirming elastic is not currently external: %w", err)
-	}
-	return fmt.Errorf("refusing to run: operator configured as internal-es but configmap/%s found which suggests its external-es", cloudconfig.CloudConfigConfigMapName)
 }
 
 // setKubernetesServiceEnv configured the environment with the location of the Kubernetes API
@@ -873,35 +822,5 @@ func executePreDeleteHook(ctx context.Context, c client.Client) error {
 		}
 		log.Info("Waiting for Installation to be fully deleted")
 		time.Sleep(5 * time.Second)
-	}
-}
-
-// verifyConfiguration verifies that the final configuration of the operator is correct before starting any controllers.
-func verifyConfiguration(ctx context.Context, cs kubernetes.Interface, opts options.ControllerOptions) error {
-	if opts.ESMigration {
-		// During the final phase of an ES migration both internal and external ES exist
-		// simultaneously, so the internal/external cert exclusivity checks below do not apply.
-		return nil
-	}
-
-	if opts.ElasticExternal {
-		// There should not be an internal-es cert
-		if _, err := cs.CoreV1().Secrets(render.ElasticsearchNamespace).Get(ctx, render.TigeraElasticsearchInternalCertSecret, metav1.GetOptions{}); err != nil {
-			if errors.IsNotFound(err) {
-				return nil
-			}
-			return fmt.Errorf("unexpected error encountered when confirming elastic is not currently internal: %v", err)
-		}
-		return fmt.Errorf("refusing to run: configured as external ES but secret/%s found which suggests internal ES", render.TigeraElasticsearchInternalCertSecret)
-	} else {
-		// There should not be an external-es cert
-		_, err := cs.CoreV1().Secrets(render.ElasticsearchNamespace).Get(ctx, logstorage.ExternalCertsSecret, metav1.GetOptions{})
-		if err != nil {
-			if errors.IsNotFound(err) {
-				return nil
-			}
-			return fmt.Errorf("unexpected error encountered when confirming elastic is not currently external: %v", err)
-		}
-		return fmt.Errorf("refusing to run: configured as internal-es but secret/%s found which suggests external ES", logstorage.ExternalCertsSecret)
 	}
 }

--- a/pkg/common/discovery/discovery.go
+++ b/pkg/common/discovery/discovery.go
@@ -32,7 +32,7 @@ import (
 const gkeNodeLabelPrefix = "cloud.google.com/gke-"
 
 // EnterpriseAPIsExist reports whether the cluster serves the Calico Enterprise APIs.
-func EnterpriseAPIsExist(clientset *kubernetes.Clientset) (bool, error) {
+func EnterpriseAPIsExist(clientset kubernetes.Interface) (bool, error) {
 	resources, err := clientset.Discovery().ServerResourcesForGroupVersion("operator.tigera.io/v1")
 	if err != nil {
 		return false, err

--- a/pkg/enterprise/startup.go
+++ b/pkg/enterprise/startup.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enterprise
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/common/discovery"
+	"github.com/tigera/operator/pkg/render"
+	"github.com/tigera/operator/pkg/render/intrusiondetection/dpi"
+	"github.com/tigera/operator/pkg/render/istio"
+	"github.com/tigera/operator/pkg/render/logstorage"
+	"github.com/tigera/operator/pkg/render/logstorage/eck"
+)
+
+// VerifyAPIsExist reports whether the Enterprise CRDs the extension controllers need are installed.
+func VerifyAPIsExist(variant operatorv1.ProductVariant, cs kubernetes.Interface) error {
+	if !variant.IsEnterprise() {
+		return nil
+	}
+
+	exist, err := discovery.EnterpriseAPIsExist(cs)
+	if err != nil {
+		return fmt.Errorf("failed to determine whether the Enterprise APIs are available: %w", err)
+	}
+	if !exist {
+		return fmt.Errorf("the Calico Enterprise CRDs are not installed")
+	}
+	return nil
+}
+
+// VerifyElasticsearch rejects a cluster whose Elasticsearch certificates contradict the
+// internal or external mode the operator is configured for.
+func VerifyElasticsearch(ctx context.Context, cs kubernetes.Interface, variant operatorv1.ProductVariant, migrating, external bool) error {
+	if !variant.IsEnterprise() {
+		return nil
+	}
+
+	// A migration's final phase has both certificates present, so exclusivity does not hold.
+	if migrating {
+		return nil
+	}
+
+	if external {
+		if _, err := cs.CoreV1().Secrets(render.ElasticsearchNamespace).Get(ctx, render.TigeraElasticsearchInternalCertSecret, metav1.GetOptions{}); err != nil {
+			if errors.IsNotFound(err) {
+				return nil
+			}
+			return fmt.Errorf("unexpected error encountered when confirming elastic is not currently internal: %w", err)
+		}
+		return fmt.Errorf("refusing to run: configured as external ES but secret/%s found which suggests internal ES", render.TigeraElasticsearchInternalCertSecret)
+	}
+
+	if _, err := cs.CoreV1().Secrets(render.ElasticsearchNamespace).Get(ctx, logstorage.ExternalCertsSecret, metav1.GetOptions{}); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("unexpected error encountered when confirming elastic is not currently external: %w", err)
+	}
+	return fmt.Errorf("refusing to run: configured as internal ES but secret/%s found which suggests external ES", logstorage.ExternalCertsSecret)
+}
+
+// ProtectedNamespaces returns the Enterprise namespaces the operator manages and so
+// must not run in itself.
+func ProtectedNamespaces() []string {
+	return []string{
+		render.ElasticsearchNamespace,
+		render.IntrusionDetectionNamespace,
+		dpi.DeepPacketInspectionNamespace,
+		eck.OperatorNamespace,
+		render.LogCollectorNamespace,
+		render.ManagerNamespace,
+		istio.IstioNamespace,
+	}
+}

--- a/pkg/enterprise/startup_test.go
+++ b/pkg/enterprise/startup_test.go
@@ -60,6 +60,7 @@ var _ = Describe("VerifyAPIsExist", func() {
 		cs := fake.NewSimpleClientset()
 		cs.Resources = []*metav1.APIResourceList{enterpriseAPIs}
 
+		//nolint:staticcheck // SA1019: the deprecated spelling is what this covers
 		Expect(enterprise.VerifyAPIsExist(operatorv1.TigeraSecureEnterprise, cs)).To(Succeed())
 	})
 

--- a/pkg/enterprise/startup_test.go
+++ b/pkg/enterprise/startup_test.go
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enterprise_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/enterprise"
+	"github.com/tigera/operator/pkg/render"
+	"github.com/tigera/operator/pkg/render/logstorage"
+)
+
+var _ = Describe("VerifyAPIsExist", func() {
+	enterpriseAPIs := &metav1.APIResourceList{
+		GroupVersion: "operator.tigera.io/v1",
+		APIResources: []metav1.APIResource{
+			{Kind: "LogStorage"},
+		},
+	}
+	calicoAPIs := &metav1.APIResourceList{
+		GroupVersion: "operator.tigera.io/v1",
+		APIResources: []metav1.APIResource{
+			{Kind: "Installation"},
+		},
+	}
+
+	It("accepts an Enterprise install whose CRDs are served", func() {
+		cs := fake.NewSimpleClientset()
+		cs.Resources = []*metav1.APIResourceList{enterpriseAPIs}
+
+		Expect(enterprise.VerifyAPIsExist(operatorv1.CalicoEnterprise, cs)).To(Succeed())
+	})
+
+	It("rejects an Enterprise install whose CRDs are absent", func() {
+		cs := fake.NewSimpleClientset()
+		cs.Resources = []*metav1.APIResourceList{calicoAPIs}
+
+		Expect(enterprise.VerifyAPIsExist(operatorv1.CalicoEnterprise, cs)).To(MatchError(ContainSubstring("CRDs are not installed")))
+	})
+
+	It("accepts the deprecated Enterprise variant", func() {
+		cs := fake.NewSimpleClientset()
+		cs.Resources = []*metav1.APIResourceList{enterpriseAPIs}
+
+		Expect(enterprise.VerifyAPIsExist(operatorv1.TigeraSecureEnterprise, cs)).To(Succeed())
+	})
+
+	It("leaves Calico alone when the Enterprise CRDs are absent", func() {
+		cs := fake.NewSimpleClientset()
+		cs.Resources = []*metav1.APIResourceList{calicoAPIs}
+
+		Expect(enterprise.VerifyAPIsExist(operatorv1.Calico, cs)).To(Succeed())
+	})
+})
+
+var _ = Describe("VerifyElasticsearch", func() {
+	internalCert := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      render.TigeraElasticsearchInternalCertSecret,
+			Namespace: render.ElasticsearchNamespace,
+		},
+	}
+	externalCert := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      logstorage.ExternalCertsSecret,
+			Namespace: render.ElasticsearchNamespace,
+		},
+	}
+
+	It("rejects an external configuration that still has the internal certificate", func() {
+		cs := fake.NewSimpleClientset(internalCert)
+
+		err := enterprise.VerifyElasticsearch(ctx, cs, operatorv1.CalicoEnterprise, false, true)
+		Expect(err).To(MatchError(ContainSubstring("configured as external ES")))
+	})
+
+	It("rejects an internal configuration that still has the external certificate", func() {
+		cs := fake.NewSimpleClientset(externalCert)
+
+		err := enterprise.VerifyElasticsearch(ctx, cs, operatorv1.CalicoEnterprise, false, false)
+		Expect(err).To(MatchError(ContainSubstring("configured as internal ES")))
+	})
+
+	It("accepts an external configuration with only the external certificate", func() {
+		cs := fake.NewSimpleClientset(externalCert)
+
+		Expect(enterprise.VerifyElasticsearch(ctx, cs, operatorv1.CalicoEnterprise, false, true)).To(Succeed())
+	})
+
+	It("accepts an internal configuration with only the internal certificate", func() {
+		cs := fake.NewSimpleClientset(internalCert)
+
+		Expect(enterprise.VerifyElasticsearch(ctx, cs, operatorv1.CalicoEnterprise, false, false)).To(Succeed())
+	})
+
+	It("accepts both certificates while a migration is in flight", func() {
+		cs := fake.NewSimpleClientset(internalCert, externalCert)
+
+		Expect(enterprise.VerifyElasticsearch(ctx, cs, operatorv1.CalicoEnterprise, true, true)).To(Succeed())
+	})
+
+	It("leaves Calico alone when a contradictory certificate exists", func() {
+		cs := fake.NewSimpleClientset(externalCert)
+
+		Expect(enterprise.VerifyElasticsearch(ctx, cs, operatorv1.Calico, false, false)).To(Succeed())
+	})
+})
+
+var _ = Describe("ProtectedNamespaces", func() {
+	It("covers the Enterprise namespaces the operator manages", func() {
+		Expect(enterprise.ProtectedNamespaces()).To(ContainElements(
+			render.ElasticsearchNamespace,
+			render.ManagerNamespace,
+			render.LogCollectorNamespace,
+		))
+	})
+
+	It("claims no namespace the operator does not manage", func() {
+		Expect(enterprise.ProtectedNamespaces()).NotTo(ContainElements("kube-system", "default"))
+	})
+})

--- a/pkg/enterprise/suite_test.go
+++ b/pkg/enterprise/suite_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enterprise_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var ctx = context.Background()
+
+func TestEnterprise(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "pkg/enterprise Suite")
+}


### PR DESCRIPTION
## Description

Continues moving Enterprise-only logic behind the extensions boundary, this time the startup checks that run before any controller starts. Three of them move into the Enterprise package as plain functions that main calls:

- verifying the Enterprise CRDs are installed
- the Elasticsearch internal/external certificate check
- which namespaces the operator refuses to install itself into

All three now have unit tests, where they previously had none.

Small behavior changes that fell out of it:

- The Elasticsearch certificate check ran twice on cloud builds, from two near-duplicate copies of the same code. It runs once now.
- Calico installs ran that check too, where it was always a no-op since the secrets only exist for Enterprise. Skipped there now.
- Dropped "calico-apiserver" from the refused namespaces, since nothing uses that namespace anymore.

Related: [CORE-13395](https://tigera.atlassian.net/browse/CORE-13395)

## Release Note

```release-note
None
```


[CORE-13395]: https://tigera.atlassian.net/browse/CORE-13395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ