### PR TITLE
[cherry-pick][1.44]Reconfigure Linseed and linseed user when migrating from multi-index …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -400,24 +400,35 @@ cluster-create: $(BINDIR)/kubectl $(BINDIR)/kind
 	while ! KUBECONFIG=$(KIND_KUBECONFIG) $(BINDIR)/kubectl get serviceaccount default; do echo "Waiting for default serviceaccount to be created..."; sleep 2; done
 
 FV_IMAGE_REGISTRY := docker.io
+# The tag the operator renders into the Calico manifests. It must match the component
+# versions in config/calico_versions.yml, otherwise the images loaded onto the kind
+# cluster below are not the ones the FVs end up asking for.
 VERSION_TAG := release-v3.33
+# The tag the images are actually pulled from, retagged to $(VERSION_TAG) before being
+# loaded onto the kind cluster. The release-vX.YY branch tags are not published for all
+# of these images - calico/calico only ever carries master and vX.YY.Z-0.dev-* tags - so
+# this pins a build of the release-v3.33 branch. Bump it to pick up newer Calico code.
+FV_PULL_TAG ?= v3.33.0-0.dev-1463-gf2264a2c5b92
 CALICO_IMAGE := calico/calico
 NODE_IMAGE := calico/node
 WHISKER_IMAGE := calico/whisker
 
 .PHONY: calico-calico.tar
 calico-calico.tar:
-	docker pull $(FV_IMAGE_REGISTRY)/$(CALICO_IMAGE):$(VERSION_TAG)
+	docker pull $(FV_IMAGE_REGISTRY)/$(CALICO_IMAGE):$(FV_PULL_TAG)
+	docker tag $(FV_IMAGE_REGISTRY)/$(CALICO_IMAGE):$(FV_PULL_TAG) $(CALICO_IMAGE):$(VERSION_TAG)
 	docker save --output $@ $(CALICO_IMAGE):$(VERSION_TAG)
 
 .PHONY: calico-node.tar
 calico-node.tar:
-	docker pull $(FV_IMAGE_REGISTRY)/$(NODE_IMAGE):$(VERSION_TAG)
+	docker pull $(FV_IMAGE_REGISTRY)/$(NODE_IMAGE):$(FV_PULL_TAG)
+	docker tag $(FV_IMAGE_REGISTRY)/$(NODE_IMAGE):$(FV_PULL_TAG) $(NODE_IMAGE):$(VERSION_TAG)
 	docker save --output $@ $(NODE_IMAGE):$(VERSION_TAG)
 
 .PHONY: calico-whisker.tar
 calico-whisker.tar:
-	docker pull $(FV_IMAGE_REGISTRY)/$(WHISKER_IMAGE):$(VERSION_TAG)
+	docker pull $(FV_IMAGE_REGISTRY)/$(WHISKER_IMAGE):$(FV_PULL_TAG)
+	docker tag $(FV_IMAGE_REGISTRY)/$(WHISKER_IMAGE):$(FV_PULL_TAG) $(WHISKER_IMAGE):$(VERSION_TAG)
 	docker save --output $@ $(WHISKER_IMAGE):$(VERSION_TAG)
 
 IMAGE_TARS := calico-calico.tar \

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -585,10 +585,12 @@ admission policy installation; once an Installation exists it is the authority o
 	}
 
 	elasticIsMigrating := false
+	useSingleIndex := false
 	useExternalElastic := discovery.UseExternalElastic(bootConfig)
 
 	if isCloudBuild() {
 		elasticIsMigrating = discovery.ElasticIsMigrating(bootConfig)
+		useSingleIndex = discovery.UseSingleIndex(bootConfig)
 		if !elasticIsMigrating {
 			if err := verifyElasticSearch(ctx, cs, useExternalElastic); err != nil {
 				setupLog.Error(err, "Elasticsearch configuration verification failed")
@@ -629,6 +631,7 @@ admission policy installation; once an Installation exists it is the authority o
 		ElasticExternal:   useExternalElastic,
 		Cloud:             isCloudBuild(),
 		ESMigration:       elasticIsMigrating,
+		UseSingleIndex:    useSingleIndex,
 		UseV3CRDs:         v3CRDs,
 		APIDiscovery:      apiDiscovery,
 		Extensions:        extensionRegistry,

--- a/pkg/common/discovery/discovery.go
+++ b/pkg/common/discovery/discovery.go
@@ -306,3 +306,19 @@ func ElasticIsMigrating(config *corev1.ConfigMap) bool {
 	}
 	return false
 }
+
+// UseSingleIndex returns true if this single tenant management cluster is in the last phase of a migration to single-index
+// storage, during which the operator must reconfigure Linseed to use the single-index names.
+func UseSingleIndex(config *corev1.ConfigMap) bool {
+	if config == nil {
+		return false
+	}
+
+	// Load the operator bootstrap configuration from its configmap.
+	if val, ok := config.Data["USE_SINGLE_INDEX"]; ok && val != "" {
+		if strings.ToLower(val) == "true" {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -702,6 +702,12 @@ var _ = Describe("Testing core-controller installation", func() {
 				instance.Spec.Variant = operator.Calico
 				Expect(c.Update(ctx, instance)).NotTo(HaveOccurred())
 
+				// Changing the variant restarts the operator, which comes back up with the
+				// extensions for the new variant. Swap them in to stand in for that restart.
+				r.ext = calicoExtensions.Installation()
+				r.opts.Extensions = calicoExtensions
+				r.opts.Variant = operator.Calico
+
 				_, err = r.Reconcile(ctx, reconcile.Request{})
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(c.Get(ctx, types.NamespacedName{Name: "default"}, instance)).NotTo(HaveOccurred())

--- a/pkg/controller/installation/installation_controller_suite_test.go
+++ b/pkg/controller/installation/installation_controller_suite_test.go
@@ -37,6 +37,11 @@ import (
 // modifiers apply.
 var testExtensions = enterprise.New(operatorv1.CalicoEnterprise, eoptions.Options{})
 
+// calicoExtensions is what the same wiring produces for Calico. The variant is resolved
+// once at startup, so a reconciler only sees these after the operator restarts into
+// Calico; tests that cover a variant change swap them in to stand in for that restart.
+var calicoExtensions = enterprise.New(operatorv1.Calico, eoptions.Options{})
+
 func TestInstallation(t *testing.T) {
 	// Disable WatchListClient for tests. In client-go v0.35+, this feature defaults to true and
 	// causes informers to wait for bookmark events that fake clients never send, leading to timeouts.

--- a/pkg/controller/logstorage/dashboards/dashboards_controller.go
+++ b/pkg/controller/logstorage/dashboards/dashboards_controller.go
@@ -324,8 +324,7 @@ func (d DashboardsSubController) Reconcile(ctx context.Context, request reconcil
 	}
 
 	// Query the username and password this Dashboards Installer instance should use to authenticate with Elasticsearch.
-	// For multi-tenant systems, credentials are created by the elasticsearch users controller.
-	// For single-tenant system, these are created by es-kube-controllers.
+	// For cloud, credentials are created by the elasticsearch users controller.
 	key = types.NamespacedName{Name: dashboards.ElasticCredentialsSecret, Namespace: helper.InstallNamespace()}
 	credentials := corev1.Secret{}
 	if err = d.client.Get(ctx, key, &credentials); err != nil && !errors.IsNotFound(err) {

--- a/pkg/controller/logstorage/esutils/elasticsearch.go
+++ b/pkg/controller/logstorage/esutils/elasticsearch.go
@@ -230,10 +230,92 @@ var (
 	ElasticsearchUserNameDashboardInstaller = "tigera-ee-dashboards-installer"
 )
 
-func LinseedUser(clusterID, tenant string) *User {
-	username := formatName(ElasticsearchUserNameLinseed, clusterID, tenant)
+// policyActivityIndexPattern grants Linseed access to the policy activity index, where per-rule
+// evaluation timestamps are stored. The base name is hardcoded here because the operator cannot import
+// the linseed package. If it changes in linseed/pkg/backend/legacy/index.PolicyActivityIndex(), it must
+// be updated here as well.
+const policyActivityIndexPattern = "calico_policy_activity*"
+
+// LegacySingleTenantUserSuffix is the suffix es-kube-controllers appended to the single-tenant
+// Elasticsearch users. Kept for backwards compatibility: the credentials and role mappings it already
+// created only keep resolving if the operator provisions the same names.
+const LegacySingleTenantUserSuffix = "secure"
+
+// SystemUserFullName marks a user as one of ours rather than one backing a person. es-kube-controllers'
+// authorization controller sweeps Elasticsearch on every resync and deletes any user that is neither
+// marked with this full_name nor present in its OIDC user cache, so a user the operator provisions
+// without it is deleted within one resync period and then recreated on the next reconcile. Must stay in
+// sync with SystemUserFullName in kube-controllers/pkg/elasticsearch/users.
+const SystemUserFullName = "system:serviceaccount"
+
+// formatNameSingleTenant builds the single-tenant ES user name the way es-kube-controllers did:
+// <name>-<tenantID>-secure on a shared external Elasticsearch, and <name>-secure on the cluster's own,
+// where es-kube-controllers is given no tenant ID and so never qualified the name with one.
+func formatNameSingleTenant(name, tenantID string, externalElastic bool) string {
+	if !externalElastic {
+		return fmt.Sprintf("%s-%s", name, LegacySingleTenantUserSuffix)
+	}
+	return fmt.Sprintf("%s-%s-%s", name, tenantID, LegacySingleTenantUserSuffix)
+}
+
+// LinseedUser returns the Linseed user for a multi-tenant cluster, which always stores its data in
+// single-index format.
+func LinseedUser(clusterID string, tenant *operatorv1.Tenant) *User {
+	return linseedUser(formatName(ElasticsearchUserNameLinseed, clusterID, tenant.Spec.ID), singleIndexNames(tenant))
+}
+
+// LinseedUserSingleTenant returns the Linseed user for a single-tenant cluster. A single-tenant cluster
+// declares indices on its Tenant only once it has moved to single-index storage; until then its data
+// lives in the per-cluster multi-index format.
+func LinseedUserSingleTenant(tenant *operatorv1.Tenant, externalElastic bool) *User {
+	names := multiIndexNames(tenant.Spec.ID, externalElastic)
+	if len(tenant.Spec.Indices) > 0 {
+		names = singleIndexNames(tenant)
+	}
+	return linseedUser(formatNameSingleTenant(ElasticsearchUserNameLinseed, tenant.Spec.ID, externalElastic), names)
+}
+
+// singleIndexNames returns the index patterns covering the tenant's single-index storage. Each base
+// index name is wildcarded to match the write alias and the numbered indices behind it. Names are
+// skipped when empty, so a misconfigured Tenant cannot widen the pattern to "*"; a Tenant declaring
+// none leaves Linseed on its calico_ defaults.
+func singleIndexNames(tenant *operatorv1.Tenant) []string {
+	names := make([]string, 0, len(tenant.Spec.Indices))
+	for _, index := range tenant.Spec.Indices {
+		if index.BaseIndexName == "" {
+			continue
+		}
+		names = append(names, fmt.Sprintf("%s*", index.BaseIndexName))
+	}
+
+	if len(names) == 0 {
+		return []string{"calico_*"}
+	}
+	return names
+}
+
+// multiIndexNames returns the index patterns covering multi-index storage, where every cluster writes to
+// its own indices. Only a shared Elasticsearch carries the tenant ID in its index names, so only there
+// is the pattern scoped to it.
+func multiIndexNames(tenant string, externalElastic bool) []string {
+	if !externalElastic {
+		tenant = ""
+	}
+	return []string{
+		indexPattern("tigera_secure_ee_*", "*", ".*", tenant),
+
+		// Policy activity is only ever stored in single-index format, so it is named outside the
+		// tigera_secure_ee_ pattern even on clusters that have not moved to single-index storage. The
+		// wildcard covers both Linseed's default calico_policy_activity name and the
+		// calico_policy_activity_standard name pinned for clusters sharing an external Elasticsearch.
+		policyActivityIndexPattern,
+	}
+}
+
+func linseedUser(username string, indices []string) *User {
 	return &User{
 		Username: username,
+		FullName: SystemUserFullName,
 		Roles: []Role{
 			{
 				Name: username,
@@ -241,8 +323,7 @@ func LinseedUser(clusterID, tenant string) *User {
 					Cluster: []string{"monitor", "manage_index_templates", "manage_ilm"},
 					Indices: []RoleIndex{
 						{
-							// Include both single-index and multi-index name formats.
-							Names:      []string{indexPattern("tigera_secure_ee_*", "*", ".*", tenant), "calico_*"},
+							Names:      indices,
 							Privileges: []string{"create_index", "write", "manage", "read"},
 						},
 					},
@@ -253,9 +334,19 @@ func LinseedUser(clusterID, tenant string) *User {
 }
 
 func DashboardUser(clusterID, tenant string) *User {
-	username := formatName(ElasticsearchUserNameDashboardInstaller, clusterID, tenant)
+	return dashboardUser(formatName(ElasticsearchUserNameDashboardInstaller, clusterID, tenant))
+}
+
+// DashboardUserSingleTenant returns the Dashboards installer user for a single-tenant cluster, named
+// the way es-kube-controllers named it. See LinseedUserSingleTenant.
+func DashboardUserSingleTenant(tenant string, externalElastic bool) *User {
+	return dashboardUser(formatNameSingleTenant(ElasticsearchUserNameDashboardInstaller, tenant, externalElastic))
+}
+
+func dashboardUser(username string) *User {
 	return &User{
 		Username: username,
+		FullName: SystemUserFullName,
 		Roles: []Role{
 			{
 				Name: username,
@@ -276,6 +367,9 @@ func DashboardUser(clusterID, tenant string) *User {
 type User struct {
 	Username string
 	Password string
+	// FullName is the user's full_name in Elasticsearch. Set it to SystemUserFullName on the users the
+	// operator provisions - see that constant for why.
+	FullName string
 	Roles    []Role
 }
 
@@ -357,6 +451,11 @@ func (es *esClient) CreateUser(ctx context.Context, user *User) error {
 	body := map[string]interface{}{
 		"password": user.Password,
 		"roles":    user.RoleNames(),
+	}
+	// Only send full_name when we have one: this is a full replacement of the user, so sending it empty
+	// would strip the marker off a user that es-kube-controllers had created with it.
+	if user.FullName != "" {
+		body["full_name"] = user.FullName
 	}
 
 	_, err := es.client.XPackSecurityPutUser(user.Username).Body(body).Do(ctx)

--- a/pkg/controller/logstorage/esutils/elasticsearch_test.go
+++ b/pkg/controller/logstorage/esutils/elasticsearch_test.go
@@ -152,6 +152,67 @@ var (
 			})
 		})
 
+		Context("Users", func() {
+			var (
+				eClient *esClient
+				urt     *userRoundTripper
+				ctx     context.Context
+			)
+
+			BeforeEach(func() {
+				urt = &userRoundTripper{putBodies: map[string]string{}}
+				eClient = mockElasticClient(&http.Client{Transport: http.RoundTripper(urt)}, baseURI)
+				ctx = context.Background()
+			})
+
+			It("marks the Linseed user as a system user so es-kube-controllers does not sweep it", func() {
+				user := LinseedUserSingleTenant(&operatorv1.Tenant{Spec: operatorv1.TenantSpec{ID: "tenant-a"}}, true)
+				Expect(user.Username).To(Equal("tigera-ee-linseed-tenant-a-secure"))
+				Expect(user.FullName).To(Equal(SystemUserFullName))
+
+				user.Password = "any-password"
+				Expect(eClient.CreateUser(ctx, user)).NotTo(HaveOccurred())
+
+				Expect(urt.putBodies["/_security/user/tigera-ee-linseed-tenant-a-secure"]).To(MatchJSON(`{
+					"password": "any-password",
+					"roles": ["tigera-ee-linseed-tenant-a-secure"],
+					"full_name": "system:serviceaccount"
+				}`))
+			})
+
+			It("marks the Dashboards installer user as a system user too", func() {
+				user := DashboardUserSingleTenant("tenant-a", true)
+				Expect(user.Username).To(Equal("tigera-ee-dashboards-installer-tenant-a-secure"))
+				Expect(user.FullName).To(Equal(SystemUserFullName))
+
+				user.Password = "any-password"
+				Expect(eClient.CreateUser(ctx, user)).NotTo(HaveOccurred())
+
+				Expect(urt.putBodies["/_security/user/tigera-ee-dashboards-installer-tenant-a-secure"]).To(MatchJSON(`{
+					"password": "any-password",
+					"roles": ["tigera-ee-dashboards-installer-tenant-a-secure"],
+					"full_name": "system:serviceaccount"
+				}`))
+			})
+
+			It("marks the users provisioned for a multi-tenant cluster", func() {
+				tenant := &operatorv1.Tenant{Spec: operatorv1.TenantSpec{ID: "tenant-a"}}
+				Expect(LinseedUser("cluster-a", tenant).FullName).To(Equal(SystemUserFullName))
+				Expect(DashboardUser("cluster-a", "tenant-a").FullName).To(Equal(SystemUserFullName))
+			})
+
+			It("leaves full_name out of the request for a user that carries none", func() {
+				// Sending it empty would strip the marker off a user es-kube-controllers created with it.
+				user := &User{Username: "tigera-ee-test", Password: "any-password"}
+				Expect(eClient.CreateUser(ctx, user)).NotTo(HaveOccurred())
+
+				Expect(urt.putBodies["/_security/user/tigera-ee-test"]).To(MatchJSON(`{
+					"password": "any-password",
+					"roles": []
+				}`))
+			})
+		})
+
 		Context("ILM", func() {
 			var (
 				eClient     *esClient
@@ -230,6 +291,29 @@ var (
 		})
 	})
 )
+
+// userRoundTripper records the body of every PUT the Elasticsearch security API receives, keyed by path.
+type userRoundTripper struct {
+	putBodies map[string]string
+}
+
+func (t *userRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	ok := &http.Response{
+		Request:    req,
+		StatusCode: 200,
+		Body:       io.NopCloser(bytes.NewBufferString("{}")),
+	}
+
+	if req.Method != "PUT" {
+		return ok, nil
+	}
+
+	body, err := io.ReadAll(req.Body)
+	Expect(err).To(BeNil())
+	t.putBodies[req.URL.Path] = string(body)
+
+	return ok, nil
+}
 
 type testRoundTripper struct {
 	e                 error
@@ -364,7 +448,16 @@ var _ = Describe("Elasticsearch users and roles", func() {
 	})
 
 	It("should generate Linseed ElasticUser with expected username and roles", func() {
-		linseedUser := LinseedUser(clusterID, tenantID)
+		tenant := &operatorv1.Tenant{
+			Spec: operatorv1.TenantSpec{
+				ID: tenantID,
+				Indices: []operatorv1.Index{
+					{DataType: operatorv1.DataTypeFlowLogs, BaseIndexName: "calico_flowlogs_standard"},
+					{DataType: operatorv1.DataTypeDNSLogs, BaseIndexName: "calico_dnslogs_standard"},
+				},
+			},
+		}
+		linseedUser := LinseedUser(clusterID, tenant)
 		expectedLinseedESName := fmt.Sprintf("%s_%s_%s", ElasticsearchUserNameLinseed, clusterID, tenantID)
 
 		Expect(linseedUser.Username).To(Equal(expectedLinseedESName))
@@ -376,14 +469,93 @@ var _ = Describe("Elasticsearch users and roles", func() {
 			Cluster: []string{"monitor", "manage_index_templates", "manage_ilm"},
 			Indices: []RoleIndex{
 				{
-					// Include both single-index and multi-index name formats.
-					Names:      []string{indexPattern("tigera_secure_ee_*", "*", ".*", tenantID), "calico_*"},
+					// The indices declared on the Tenant, wildcarded to cover the indices behind each alias.
+					Names:      []string{"calico_flowlogs_standard*", "calico_dnslogs_standard*"},
 					Privileges: []string{"create_index", "write", "manage", "read"},
 				},
 			},
 		}
 
 		Expect(*linseedRole.Definition).To(Equal(expectedLinseedRoleDef))
+	})
+
+	It("should grant a multi-tenant Linseed user the default single-index names when the Tenant declares none", func() {
+		tenant := &operatorv1.Tenant{Spec: operatorv1.TenantSpec{ID: tenantID}}
+		linseedUser := LinseedUser(clusterID, tenant)
+
+		Expect(linseedUser.Roles[0].Definition.Indices[0].Names).To(Equal([]string{"calico_*"}))
+	})
+
+	It("should generate a single-tenant Linseed user granted the indices its cluster stores data in", func() {
+		tenant := &operatorv1.Tenant{Spec: operatorv1.TenantSpec{ID: tenantID}}
+		expectedName := fmt.Sprintf("%s-%s-%s", ElasticsearchUserNameLinseed, tenantID, LegacySingleTenantUserSuffix)
+
+		// A cluster still on multi-index storage declares no indices, and gets access to the indices
+		// named for its tenant.
+		linseedUser := LinseedUserSingleTenant(tenant, true)
+		Expect(linseedUser.Username).To(Equal(expectedName))
+		Expect(linseedUser.Roles[0].Name).To(Equal(expectedName))
+		Expect(linseedUser.Roles[0].Definition.Indices[0].Names).To(Equal([]string{
+			indexPattern("tigera_secure_ee_*", "*", ".*", tenantID),
+			"calico_policy_activity*",
+		}))
+
+		// A cluster on its own Elasticsearch is not qualified by tenant - neither its index pattern, nor
+		// its user name, which es-kube-controllers built without a tenant ID.
+		linseedUser = LinseedUserSingleTenant(tenant, false)
+		Expect(linseedUser.Username).To(Equal("tigera-ee-linseed-secure"))
+		Expect(linseedUser.Roles[0].Name).To(Equal("tigera-ee-linseed-secure"))
+		Expect(linseedUser.Roles[0].Definition.Indices[0].Names).To(Equal([]string{
+			indexPattern("tigera_secure_ee_*", "*", ".*", ""),
+			"calico_policy_activity*",
+		}))
+
+		// Once it moves to single-index storage, it gets access to the declared indices instead.
+		tenant.Spec.Indices = []operatorv1.Index{{DataType: operatorv1.DataTypeFlowLogs, BaseIndexName: "calico_flowlogs_standard"}}
+		linseedUser = LinseedUserSingleTenant(tenant, true)
+		Expect(linseedUser.Username).To(Equal(expectedName))
+		Expect(linseedUser.Roles[0].Definition.Indices[0].Names).To(Equal([]string{"calico_flowlogs_standard*"}))
+	})
+
+	It("should grant a single-tenant Linseed user the policy activity index on multi-index storage", func() {
+		// Policy activity is stored in single-index format regardless of where the rest of the cluster's
+		// data lives, so it falls outside the tigera_secure_ee_ pattern and has to be granted separately.
+		// Without it Linseed is denied indices:admin/aliases/get when ingesting policy activity logs.
+		tenant := &operatorv1.Tenant{Spec: operatorv1.TenantSpec{ID: tenantID}}
+		Expect(LinseedUserSingleTenant(tenant, false).Roles[0].Definition.Indices[0].Names).To(ContainElement("calico_policy_activity*"))
+		Expect(LinseedUserSingleTenant(tenant, true).Roles[0].Definition.Indices[0].Names).To(ContainElement("calico_policy_activity*"))
+
+		// Once the cluster moves to single-index storage the index is declared on the Tenant like any
+		// other, so it is granted from there rather than by the multi-index pattern.
+		tenant.Spec.Indices = []operatorv1.Index{
+			{DataType: operatorv1.DataTypeFlowLogs, BaseIndexName: "calico_flowlogs_standard"},
+			{DataType: operatorv1.DataTypePolicyActivity, BaseIndexName: "calico_policy_activity_standard"},
+		}
+		Expect(LinseedUserSingleTenant(tenant, true).Roles[0].Definition.Indices[0].Names).To(Equal([]string{
+			"calico_flowlogs_standard*",
+			"calico_policy_activity_standard*",
+		}))
+	})
+
+	It("should never widen the single-index pattern to all indices when a base index name is empty", func() {
+		// An index with no base index name must not be wildcarded into "*", which would grant Linseed
+		// access to every index in Elasticsearch.
+		tenant := &operatorv1.Tenant{
+			Spec: operatorv1.TenantSpec{
+				ID: tenantID,
+				Indices: []operatorv1.Index{
+					{DataType: operatorv1.DataTypeFlowLogs, BaseIndexName: "calico_flowlogs_standard"},
+					{DataType: operatorv1.DataTypeDNSLogs},
+				},
+			},
+		}
+		Expect(LinseedUser(clusterID, tenant).Roles[0].Definition.Indices[0].Names).To(Equal([]string{"calico_flowlogs_standard*"}))
+		Expect(LinseedUserSingleTenant(tenant, true).Roles[0].Definition.Indices[0].Names).To(Equal([]string{"calico_flowlogs_standard*"}))
+
+		// With no usable base index name at all, fall back to Linseed's default index names.
+		tenant.Spec.Indices = []operatorv1.Index{{DataType: operatorv1.DataTypeDNSLogs}}
+		Expect(LinseedUser(clusterID, tenant).Roles[0].Definition.Indices[0].Names).To(Equal([]string{"calico_*"}))
+		Expect(LinseedUserSingleTenant(tenant, true).Roles[0].Definition.Indices[0].Names).To(Equal([]string{"calico_*"}))
 	})
 })
 

--- a/pkg/controller/logstorage/initializer/conditions_controller.go
+++ b/pkg/controller/logstorage/initializer/conditions_controller.go
@@ -17,6 +17,7 @@ package initializer
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -44,6 +45,7 @@ func AddConditionsController(mgr manager.Manager, opts options.ControllerOptions
 		client:      mgr.GetClient(),
 		scheme:      mgr.GetScheme(),
 		multiTenant: opts.MultiTenant,
+		cloud:       opts.Cloud,
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -62,6 +64,10 @@ type LogStorageConditions struct {
 	client      client.Client
 	scheme      *runtime.Scheme
 	multiTenant bool
+
+	// cloud indicates that this is a Calico Cloud install, in which case the log-storage users
+	// controller runs in single-tenant mode too and reports status.
+	cloud bool
 }
 
 func (r *LogStorageConditions) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
@@ -91,6 +97,12 @@ func (r *LogStorageConditions) Reconcile(ctx context.Context, request reconcile.
 	ls.Status.Conditions = updateConditions(currentConditions, desiredConditions)
 
 	if err := r.client.Status().Update(ctx, ls); err != nil {
+		if errors.IsConflict(err) {
+			// The LogStorage was modified after we read it - our cached copy is stale. Requeue and
+			// recompute the conditions from the updated object instead of reporting an error.
+			reqLogger.V(3).Info("Conflict updating LogStorage status conditions, retrying")
+			return reconcile.Result{Requeue: true}, nil
+		}
 		log.WithValues("reason", err).Info("Failed to update LogStorage status conditions")
 		return reconcile.Result{}, err
 	}
@@ -112,6 +124,10 @@ func (r *LogStorageConditions) getDesiredConditions(ctx context.Context) (map[st
 		expectedInstances = append(expectedInstances, TigeraStatusLogStorageUsers)
 	} else {
 		expectedInstances = append(expectedInstances, TigeraStatusLogStorageESMetrics, TigeraStatusLogStorageKubeController, TigeraStatusLogStorageDashboards)
+		if r.cloud {
+			// In Calico Cloud, the users controller runs in single-tenant mode too.
+			expectedInstances = append(expectedInstances, TigeraStatusLogStorageUsers)
+		}
 	}
 
 	// Keep track of which instances are in which state.
@@ -197,5 +213,12 @@ func updateConditions(currentConditions, desiredConditions map[string]metav1.Con
 
 		statusConditions = append(statusConditions, desired)
 	}
+
+	// desiredConditions is a map, so iteration order is random. Sort by type to keep the stored
+	// conditions stable across reconciles - otherwise every write reorders the list, which counts
+	// as a change and triggers another reconcile.
+	sort.Slice(statusConditions, func(i, j int) bool {
+		return statusConditions[i].Type < statusConditions[j].Type
+	})
 	return statusConditions
 }

--- a/pkg/controller/logstorage/linseed/linseed_controller.go
+++ b/pkg/controller/logstorage/linseed/linseed_controller.go
@@ -62,16 +62,12 @@ import (
 var log = logf.Log.WithName("controller_logstorage_linseed")
 
 type LinseedSubController struct {
-	client          client.Client
-	scheme          *runtime.Scheme
-	status          status.StatusManager
-	clusterDomain   string
-	variant         operatorv1.ProductVariant
-	tierWatchReady  *utils.ReadyFlag
-	dpiAPIReady     *utils.ReadyFlag
-	multiTenant     bool
-	elasticExternal bool
-	cloud           bool
+	client         client.Client
+	scheme         *runtime.Scheme
+	status         status.StatusManager
+	tierWatchReady *utils.ReadyFlag
+	dpiAPIReady    *utils.ReadyFlag
+	opts           options.ControllerOptions
 }
 
 func Add(mgr manager.Manager, opts options.ControllerOptions) error {
@@ -81,16 +77,12 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 
 	// Create the reconciler
 	r := &LinseedSubController{
-		client:          mgr.GetClient(),
-		scheme:          mgr.GetScheme(),
-		clusterDomain:   opts.ClusterDomain,
-		variant:         opts.Variant,
-		tierWatchReady:  &utils.ReadyFlag{},
-		dpiAPIReady:     &utils.ReadyFlag{},
-		multiTenant:     opts.MultiTenant,
-		status:          status.New(mgr.GetClient(), "log-storage-access", opts.KubernetesVersion),
-		elasticExternal: opts.ElasticExternal,
-		cloud:           opts.Cloud,
+		client:         mgr.GetClient(),
+		scheme:         mgr.GetScheme(),
+		tierWatchReady: &utils.ReadyFlag{},
+		dpiAPIReady:    &utils.ReadyFlag{},
+		status:         status.New(mgr.GetClient(), "log-storage-access", opts.KubernetesVersion),
+		opts:           opts,
 	}
 	r.status.Run(opts.ShutdownContext)
 
@@ -202,19 +194,19 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 }
 
 func (r *LinseedSubController) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	helper := eutils.NewNamespaceHelper(r.multiTenant, render.ElasticsearchNamespace, request.Namespace)
+	helper := eutils.NewNamespaceHelper(r.opts.MultiTenant, render.ElasticsearchNamespace, request.Namespace)
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name, "installNS", helper.InstallNamespace(), "truthNS", helper.TruthNamespace())
 	reqLogger.Info("Reconciling LogStorage - Linseed")
 
 	// We skip requests without a namespace specified in multi-tenant setups.
-	if r.multiTenant && request.Namespace == "" {
+	if r.opts.MultiTenant && request.Namespace == "" {
 		return reconcile.Result{}, nil
 	}
 
 	// When running in multi-tenant mode, we need to install Linseed in tenant Namespaces. However, the LogStorage
 	// resource is still cluster-scoped (since ES is a cluster-wide resource), so we need to look elsewhere to determine
 	// which tenant namespaces require a Linseed instance. We use the tenant API to determine the set of namespaces that should have a Linseed.
-	tenant, _, err := eutils.GetTenant(ctx, r.multiTenant, r.client, request.Namespace)
+	tenant, _, err := eutils.GetTenant(ctx, r.opts.MultiTenant, r.client, request.Namespace)
 	if errors.IsNotFound(err) {
 		reqLogger.Info("No Tenant in this Namespace, skip")
 		return reconcile.Result{}, nil
@@ -312,7 +304,7 @@ func (r *LinseedSubController) Reconcile(ctx context.Context, request reconcile.
 	elasticHost := "tigera-secure-es-http.tigera-elasticsearch.svc"
 	elasticPort := "9200"
 	var esClientSecret *corev1.Secret
-	if !r.elasticExternal {
+	if !r.opts.ElasticExternal {
 		// Wait for Elasticsearch to be installed and available.
 		elasticsearch, err := esutils.GetElasticsearch(ctx, r.client)
 		if err != nil {
@@ -324,21 +316,21 @@ func (r *LinseedSubController) Reconcile(ctx context.Context, request reconcile.
 			return reconcile.Result{RequeueAfter: utils.StandardRetry}, nil
 		}
 	} else {
-		if r.multiTenant {
+		if r.opts.MultiTenant {
 			// The Tenant resource must specify the ES endpoint.
 			if tenant == nil || tenant.Spec.Elastic == nil || tenant.Spec.Elastic.URL == "" {
 				reqLogger.Error(nil, "Elasticsearch URL must be specified for this tenant")
 				r.status.SetDegraded(operatorv1.ResourceValidationError, "Elasticsearch URL must be specified for this tenant", nil, reqLogger)
 				return reconcile.Result{}, nil
 			}
-		} else if r.cloud {
+		} else if r.opts.Cloud {
 			// Calico Cloud single-tenant: there is no Tenant CR, so read it from the cloud config map.
 			cloudConfig, err := eutils.GetCloudConfig(ctx, r.client)
 			if err != nil {
 				r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to read cloud config", err, reqLogger)
 				return reconcile.Result{}, err
 			}
-			tenant = eutils.TenantFromCloudConfig(cloudConfig)
+			tenant = eutils.TenantFromCloudConfig(cloudConfig, eutils.WithStandardIndicesIf(r.opts.UseSingleIndex))
 		}
 
 		// Determine the host and port from the URL.
@@ -364,8 +356,7 @@ func (r *LinseedSubController) Reconcile(ctx context.Context, request reconcile.
 	}
 
 	// Query the username and password this Linseed instance should use to authenticate with Elasticsearch.
-	// For multi-tenant systems, credentials are created by the elasticsearch users controller.
-	// For single-tenant system, these are created by es-kube-controllers.
+	// For cloud systems, credentials are created by the elasticsearch users controller.
 	key = types.NamespacedName{Name: render.ElasticsearchLinseedUserSecret, Namespace: helper.InstallNamespace()}
 	credentials := corev1.Secret{}
 	if err = r.client.Get(ctx, key, &credentials); err != nil && !errors.IsNotFound(err) {
@@ -381,12 +372,12 @@ func (r *LinseedSubController) Reconcile(ctx context.Context, request reconcile.
 		certificatemanager.WithLogger(reqLogger),
 		certificatemanager.WithTenant(tenant),
 	}
-	cm, err := certificatemanager.Create(r.client, installationSpec, r.clusterDomain, helper.TruthNamespace(), opts...)
+	cm, err := certificatemanager.Create(r.client, installationSpec, r.opts.ClusterDomain, helper.TruthNamespace(), opts...)
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceCreateError, "Unable to create the Tigera CA", err, reqLogger)
 		return reconcile.Result{}, err
 	}
-	linseedDNSNames := dns.GetServiceDNSNames(render.LinseedServiceName, helper.InstallNamespace(), r.clusterDomain)
+	linseedDNSNames := dns.GetServiceDNSNames(render.LinseedServiceName, helper.InstallNamespace(), r.opts.ClusterDomain)
 	linseedKeyPair, err := cm.GetKeyPair(r.client, render.TigeraLinseedSecret, helper.TruthNamespace(), linseedDNSNames)
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceReadError, "Error getting Linseed KeyPair", err, reqLogger)
@@ -421,10 +412,8 @@ func (r *LinseedSubController) Reconcile(ctx context.Context, request reconcile.
 	}
 
 	// Query the username and password this Linseed instance should use to authenticate with Elasticsearch.
-	// For multi-tenant systems, credentials are created by the elasticsearch users controller.
-	// For single-tenant system, these are created by es-kube-controllers.
+	// For cloud systems, credentials are created by the elasticsearch users controller.
 	// Delay installing Linseed until available.
-	// TODO: Switch single-tenant to using operator-provisioned users.
 	key = types.NamespacedName{Name: render.ElasticsearchLinseedUserSecret, Namespace: helper.InstallNamespace()}
 	if err = r.client.Get(ctx, key, &corev1.Secret{}); err != nil && !errors.IsNotFound(err) {
 		r.status.SetDegraded(operatorv1.ResourceReadError, fmt.Sprintf("Error getting Secret %s", key), err, reqLogger)
@@ -458,31 +447,32 @@ func (r *LinseedSubController) Reconcile(ctx context.Context, request reconcile.
 		Namespace:                      helper.InstallNamespace(),
 		BindNamespaces:                 bindNamespaces,
 		TrustedBundle:                  trustedBundle,
-		ClusterDomain:                  r.clusterDomain,
+		ClusterDomain:                  r.opts.ClusterDomain,
 		KeyPair:                        linseedKeyPair,
 		TokenKeyPair:                   tokenKeyPair,
 		ESClusterConfig:                esClusterConfig,
 		HasDPIResource:                 hasDPIResource,
 		ManagementCluster:              managementCluster != nil,
 		Tenant:                         tenant,
-		ExternalElastic:                r.elasticExternal,
+		ExternalElastic:                r.opts.ElasticExternal,
 		ElasticHost:                    elasticHost,
 		ElasticPort:                    elasticPort,
 		ElasticClientSecret:            esClientSecret,
 		ElasticClientCredentialsSecret: &credentials,
 		LogStorage:                     logStorage,
-		Cloud:                          r.cloud,
+		Cloud:                          r.opts.Cloud,
+		UseSingleIndex:                 r.opts.UseSingleIndex,
 	}
 	linseedComponent := linseed.Linseed(cfg)
 
-	if err := imageset.ApplyImageSet(ctx, r.client, r.variant, linseedComponent); err != nil {
+	if err := imageset.ApplyImageSet(ctx, r.client, r.opts.Variant, linseedComponent); err != nil {
 		r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error with images from ImageSet", err, reqLogger)
 		return reconcile.Result{}, err
 	}
 
 	// In standard installs, the LogStorage owns Linseed. For multi-tenant, it's owned by the Tenant instance.
 	var hdler utils.ComponentHandler
-	if r.multiTenant {
+	if r.opts.MultiTenant {
 		hdler = utils.NewComponentHandler(reqLogger, r.client, r.scheme, tenant)
 	} else {
 		hdler = utils.NewComponentHandler(reqLogger, r.client, r.scheme, logStorage)

--- a/pkg/controller/logstorage/linseed/linseed_controller_test.go
+++ b/pkg/controller/logstorage/linseed/linseed_controller_test.go
@@ -79,11 +79,9 @@ func NewLinseedControllerWithShims(
 		client:         cli,
 		scheme:         scheme,
 		status:         status,
-		clusterDomain:  opts.ClusterDomain,
-		variant:        opts.Variant,
-		multiTenant:    opts.MultiTenant,
 		tierWatchReady: &utils.ReadyFlag{},
 		dpiAPIReady:    &utils.ReadyFlag{},
+		opts:           opts,
 	}
 	r.tierWatchReady.MarkAsReady()
 	r.dpiAPIReady.MarkAsReady()
@@ -516,8 +514,8 @@ var _ = Describe("LogStorage Linseed controller", func() {
 				Expect(cli.Delete(ctx, es)).ShouldNot(HaveOccurred())
 
 				// Set the reconcile to run in external ES mode.
-				r.elasticExternal = true
-				r.multiTenant = true
+				r.opts.ElasticExternal = true
+				r.opts.MultiTenant = true
 
 				// Set the elasticsearch configuration for the tenant.
 				tenant.Spec.Elastic = &operatorv1.TenantElasticSpec{URL: "https://external.elastic:443"}

--- a/pkg/controller/logstorage/users/users_controller.go
+++ b/pkg/controller/logstorage/users/users_controller.go
@@ -28,11 +28,13 @@ import (
 	"github.com/tigera/operator/pkg/render/logstorage/dashboards"
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/controller/logstorage/esutils"
 	"github.com/tigera/operator/pkg/controller/options"
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/crypto"
+	"github.com/tigera/operator/pkg/enterprise/cloudconfig"
 	eutils "github.com/tigera/operator/pkg/enterprise/utils"
 	"github.com/tigera/operator/pkg/render"
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
@@ -61,6 +63,11 @@ type UserController struct {
 	esClientFn      esutils.ElasticsearchClientCreator
 	multiTenant     bool
 	elasticExternal bool
+
+	// useSingleIndex indicates that this single-tenant cluster stores its data in single-index format,
+	// in which case the users provisioned here are granted access to the single-index names rather than
+	// to the per-cluster multi-index ones.
+	useSingleIndex bool
 }
 
 type UsersCleanupController struct {
@@ -74,9 +81,9 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 	if !opts.Variant.IsEnterprise() {
 		return nil
 	}
-	if !opts.MultiTenant {
-		// For now, the operator only creates users in multi-tenant mode. In single-tenant mode,
-		// user creation is handled by es-kube-controllers instead.
+	if !opts.Cloud {
+		// The operator creates users for cloud clusters. Anywhere
+		// else, user creation is handled by es-kube-controllers instead.
 		return nil
 	}
 
@@ -85,6 +92,7 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 		client:          mgr.GetClient(),
 		scheme:          mgr.GetScheme(),
 		multiTenant:     opts.MultiTenant,
+		useSingleIndex:  opts.UseSingleIndex,
 		status:          status.New(mgr.GetClient(), initializer.TigeraStatusLogStorageUsers, opts.KubernetesVersion),
 		esClientFn:      esutils.NewElasticClient,
 		elasticExternal: opts.ElasticExternal,
@@ -121,6 +129,16 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 		if err = c.WatchObject(&operatorv1.Tenant{}, &handler.EnqueueRequestForObject{}); err != nil {
 			return fmt.Errorf("log-storage-user-controller failed to watch Tenant resource: %w", err)
 		}
+	} else {
+		// In single-tenant mode the tenant configuration comes from a ConfigMap rather than a Tenant
+		// resource, and which one depends on where Elasticsearch lives. See singleTenant.
+		configMap := eutils.CloudAuthConfig
+		if opts.ElasticExternal {
+			configMap = cloudconfig.CloudConfigConfigMapName
+		}
+		if err = utils.AddConfigMapWatch(c, configMap, common.OperatorNamespace(), &handler.EnqueueRequestForObject{}); err != nil {
+			return fmt.Errorf("log-storage-user-controller failed to watch the ConfigMap resource: %w", err)
+		}
 	}
 
 	// Watch for Elasticsearch.
@@ -133,6 +151,11 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 	err = utils.AddPeriodicReconcile(c, utils.PeriodicReconcileTime, eventHandler)
 	if err != nil {
 		return fmt.Errorf("log-storage-user-controller failed to create periodic reconcile watch: %w", err)
+	}
+
+	if !opts.MultiTenant {
+		// The cleanup controller reconciles Tenant resources, which only exist in multi-tenant mode.
+		return nil
 	}
 
 	// Now that the users controller is set up, we can also set up the controller that cleans up stale users
@@ -161,6 +184,23 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 	return nil
 }
 
+// singleTenant builds the tenant configuration for a single-tenant cluster, which has no Tenant
+// resource, and returns the ConfigMap it was read from so the caller can name it when waiting.
+// Clusters sharing an external Elasticsearch are described by the cloud config; clusters on their own
+// Elasticsearch by the cloud auth config, which carries the tenant ID alone.
+func (r *UserController) singleTenant(ctx context.Context) (*operatorv1.Tenant, string, error) {
+	if !r.elasticExternal {
+		tenant, err := eutils.GetTenantFromCloudAuthConfig(ctx, r.client)
+		return tenant, eutils.CloudAuthConfig, err
+	}
+
+	cloudConfig, err := eutils.GetCloudConfig(ctx, r.client)
+	if err != nil {
+		return nil, cloudconfig.CloudConfigConfigMapName, err
+	}
+	return eutils.TenantFromCloudConfig(cloudConfig, eutils.WithStandardIndicesIf(r.useSingleIndex)), cloudconfig.CloudConfigConfigMapName, nil
+}
+
 func (r *UserController) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	helper := eutils.NewNamespaceHelper(r.multiTenant, render.ElasticsearchNamespace, request.Namespace)
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name, "installNS", helper.InstallNamespace(), "truthNS", helper.TruthNamespace())
@@ -179,6 +219,24 @@ func (r *UserController) Reconcile(ctx context.Context, request reconcile.Reques
 	} else if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceReadError, "An error occurred while querying Tenant", err, reqLogger)
 		return reconcile.Result{}, err
+	}
+
+	if !r.multiTenant {
+		// Single-tenant clusters have no Tenant resource. Build the equivalent tenant configuration
+		// from the ConfigMap describing this cluster, so that we provision the users against the right
+		// Elasticsearch.
+		var configMap string
+		tenant, configMap, err = r.singleTenant(ctx)
+		if errors.IsNotFound(err) {
+			// The ConfigMap is written out of band, and may not exist yet. Wait for it rather than
+			// retrying with backoff - we watch it, so we reconcile again once it appears.
+			r.status.SetDegraded(operatorv1.ResourceNotReady, fmt.Sprintf("Waiting for ConfigMap %s to be available", configMap), nil, reqLogger)
+			return reconcile.Result{}, nil
+		} else if err != nil {
+			r.status.SetDegraded(operatorv1.ResourceReadError, "Failed to read the tenant configuration", err, reqLogger)
+			return reconcile.Result{}, err
+		}
+		tenantID = tenant.Spec.ID
 	}
 
 	// Get LogStorage resource.
@@ -217,33 +275,26 @@ func (r *UserController) Reconcile(ctx context.Context, request reconcile.Reques
 		}
 	}
 
-	clusterIDConfigMap := corev1.ConfigMap{}
-	clusterIDConfigMapKey := client.ObjectKey{Name: "cluster-info", Namespace: "tigera-operator"}
-	err = r.client.Get(ctx, clusterIDConfigMapKey, &clusterIDConfigMap)
-	if err != nil {
-		r.status.SetDegraded(operatorv1.ResourceReadError, fmt.Sprintf("Waiting for ConfigMap %s/%s to be available", clusterIDConfigMapKey.Namespace, clusterIDConfigMapKey.Name),
-			nil, reqLogger)
-		return reconcile.Result{}, err
-	}
-
-	clusterID, ok := clusterIDConfigMap.Data["cluster-id"]
-	if !ok {
-		err = fmt.Errorf("%s/%s ConfigMap does not contain expected 'cluster-id' key",
-			clusterIDConfigMap.Namespace, clusterIDConfigMap.Name)
-		r.status.SetDegraded(operatorv1.ResourceReadError, fmt.Sprintf("%v", err), err, reqLogger)
-		return reconcile.Result{}, err
-	}
-
-	if clusterID == "" {
-		err = fmt.Errorf("%s/%s ConfigMap value for key 'cluster-id' must be non-empty",
-			clusterIDConfigMap.Namespace, clusterIDConfigMap.Name)
-		r.status.SetDegraded(operatorv1.ResourceReadError, fmt.Sprintf("%v", err), err, reqLogger)
-		return reconcile.Result{}, err
+	// Determine the names of the users to provision. In multi-tenant clusters the cluster ID forms part
+	// of the user names, and is read from the cluster-info ConfigMap written at install time.
+	// Single-tenant clusters have no such ConfigMap - their user names are derived from the tenant ID
+	// alone, matching the names es-kube-controllers used before the operator took over provisioning.
+	var linseedUser, dashboardUser *esutils.User
+	if r.multiTenant {
+		clusterID, err := eutils.GetClusterID(ctx, r.client)
+		if err != nil {
+			r.status.SetDegraded(operatorv1.ResourceReadError, "Waiting for the cluster ID to be available", err, reqLogger)
+			return reconcile.Result{}, err
+		}
+		linseedUser = esutils.LinseedUser(clusterID, tenant)
+		dashboardUser = esutils.DashboardUser(clusterID, tenantID)
+	} else {
+		linseedUser = esutils.LinseedUserSingleTenant(tenant, r.elasticExternal)
+		dashboardUser = esutils.DashboardUserSingleTenant(tenantID, r.elasticExternal)
 	}
 
 	// Query any existing username and password for this Linseed instance. If one already exists, we'll simply
 	// use that. Otherwise, generate a new one.
-	linseedUser := esutils.LinseedUser(clusterID, tenantID)
 	linseedUserSecret := corev1.Secret{}
 	var credentialSecrets []client.Object
 	key := types.NamespacedName{Name: render.ElasticsearchLinseedUserSecret, Namespace: helper.TruthNamespace()}
@@ -258,14 +309,19 @@ func (r *UserController) Reconcile(ctx context.Context, request reconcile.Reques
 
 		// Make sure we install the generated credentials into the truth namespace.
 		credentialSecrets = append(credentialSecrets, &linseedUserSecret)
+	} else if string(linseedUserSecret.Data["username"]) != linseedUser.Username {
+		// The credentials exist, but reference a different Elasticsearch user than the one we provision -
+		// e.g. because they were created by es-kube-controllers before the operator took over user
+		// provisioning. Point them at our user, keeping the existing password.
+		linseedUserSecret.StringData = map[string]string{"username": linseedUser.Username}
+		credentialSecrets = append(credentialSecrets, &linseedUserSecret)
 	}
 
 	// Query any existing username and password for this Dashboards instance. If one already exists, we'll simply
 	// use that. Otherwise, generate a new one.
 	keyDashboardCred := types.NamespacedName{Name: dashboards.ElasticCredentialsSecret, Namespace: helper.TruthNamespace()}
-	dashboardUser := esutils.DashboardUser(clusterID, tenantID)
 	dashboardUserSecret := corev1.Secret{}
-	if err = r.client.Get(ctx, key, &dashboardUserSecret); err != nil && !errors.IsNotFound(err) {
+	if err = r.client.Get(ctx, keyDashboardCred, &dashboardUserSecret); err != nil && !errors.IsNotFound(err) {
 		r.status.SetDegraded(operatorv1.ResourceReadError, fmt.Sprintf("Error getting Secret %s", keyDashboardCred), err, reqLogger)
 		return reconcile.Result{}, err
 	} else if errors.IsNotFound(err) {
@@ -275,6 +331,10 @@ func (r *UserController) Reconcile(ctx context.Context, request reconcile.Reques
 		dashboardUserSecret.StringData = map[string]string{"username": dashboardUser.Username, "password": crypto.GeneratePassword(16)}
 
 		// Make sure we install the generated credentials into the truth namespace.
+		credentialSecrets = append(credentialSecrets, &dashboardUserSecret)
+	} else if string(dashboardUserSecret.Data["username"]) != dashboardUser.Username {
+		// As above - point the existing credentials at the user we provision.
+		dashboardUserSecret.StringData = map[string]string{"username": dashboardUser.Username}
 		credentialSecrets = append(credentialSecrets, &dashboardUserSecret)
 	}
 
@@ -299,7 +359,7 @@ func (r *UserController) Reconcile(ctx context.Context, request reconcile.Reques
 
 	// Add a finalizer to the Tenant instance if it exists so that we can clean up the Linseed user when the Tenant
 	// is deleted. The finalizer will be removed by the user cleanup controller when the user is deleted from ES.
-	if tenant != nil && tenant.GetDeletionTimestamp().IsZero() && !stringsutil.StringInSlice(userCleanupFinalizer, tenant.GetFinalizers()) {
+	if r.multiTenant && tenant != nil && tenant.GetDeletionTimestamp().IsZero() && !stringsutil.StringInSlice(userCleanupFinalizer, tenant.GetFinalizers()) {
 		tenant.SetFinalizers(append(tenant.GetFinalizers(), userCleanupFinalizer))
 		if err = r.client.Update(ctx, tenant); err != nil {
 			r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error adding finalizer to Tenant", err, reqLogger)
@@ -386,21 +446,9 @@ func (r *UsersCleanupController) cleanupStaleUsers(ctx context.Context, logger l
 		return fmt.Errorf("failed to fetch TenantList")
 	}
 
-	clusterIDConfigMap := corev1.ConfigMap{}
-	err = r.client.Get(ctx, client.ObjectKey{Name: "cluster-info", Namespace: "tigera-operator"}, &clusterIDConfigMap)
+	clusterID, err := eutils.GetClusterID(ctx, r.client)
 	if err != nil {
-		return fmt.Errorf("failed to fetch cluster-info configmap")
-	}
-
-	clusterID, ok := clusterIDConfigMap.Data["cluster-id"]
-	if !ok {
-		return fmt.Errorf("%s/%s ConfigMap does not contain expected 'cluster-id' key",
-			clusterIDConfigMap.Namespace, clusterIDConfigMap.Name)
-	}
-
-	if clusterID == "" {
-		return fmt.Errorf("%s/%s ConfigMap value for key 'cluster-id' must be non-empty",
-			clusterIDConfigMap.Namespace, clusterIDConfigMap.Name)
+		return err
 	}
 
 	var t operatorv1.Tenant
@@ -421,7 +469,7 @@ func (r *UsersCleanupController) cleanupStaleUsers(ctx context.Context, logger l
 			return fmt.Errorf("failed to fetch users from Elasticsearch")
 		}
 
-		lu := esutils.LinseedUser(clusterID, t.Spec.ID)
+		lu := esutils.LinseedUser(clusterID, &t)
 		dashboardsUser := esutils.DashboardUser(clusterID, t.Spec.ID)
 		for _, user := range allESUsers {
 			if user.Username == lu.Username || user.Username == dashboardsUser.Username {

--- a/pkg/controller/logstorage/users/users_controller_test.go
+++ b/pkg/controller/logstorage/users/users_controller_test.go
@@ -18,20 +18,30 @@ import (
 	"context"
 	"testing"
 
+	esv1 "github.com/elastic/cloud-on-k8s/v2/pkg/apis/elasticsearch/v1"
 	corev1 "k8s.io/api/core/v1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/stretchr/testify/mock"
 	apiv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/common"
 	tigeraelastic "github.com/tigera/operator/pkg/controller/logstorage/elastic"
 	"github.com/tigera/operator/pkg/controller/logstorage/esutils"
+	"github.com/tigera/operator/pkg/controller/status"
 	ctrlrfake "github.com/tigera/operator/pkg/ctrlruntime/client/fake"
+	"github.com/tigera/operator/pkg/enterprise/cloudconfig"
+	eutils "github.com/tigera/operator/pkg/enterprise/utils"
+	"github.com/tigera/operator/pkg/render"
+	"github.com/tigera/operator/pkg/render/logstorage/dashboards"
 )
 
 var _ = Describe("LogStorage cleanup controller", func() {
@@ -61,17 +71,20 @@ var _ = Describe("LogStorage cleanup controller", func() {
 		tenantID1 := "tenant1"
 		tenantID2 := "tenant2"
 
-		staleLinseedUser := esutils.LinseedUser(clusterID1, tenantID1)
+		tenant1 := &operatorv1.Tenant{Spec: operatorv1.TenantSpec{ID: tenantID1}}
+		tenant2 := &operatorv1.Tenant{Spec: operatorv1.TenantSpec{ID: tenantID2}}
+
+		staleLinseedUser := esutils.LinseedUser(clusterID1, tenant1)
 		staleDashboardsUser := esutils.DashboardUser(clusterID1, tenantID1)
 
 		esTestUsers := []esutils.User{
 			*staleLinseedUser,
 			*staleDashboardsUser,
-			*esutils.LinseedUser(clusterID1, tenantID2),
+			*esutils.LinseedUser(clusterID1, tenant2),
 			*esutils.DashboardUser(clusterID1, tenantID2),
-			*esutils.LinseedUser(clusterID2, tenantID1),
+			*esutils.LinseedUser(clusterID2, tenant1),
 			*esutils.DashboardUser(clusterID2, tenantID1),
-			*esutils.LinseedUser(clusterID2, tenantID2),
+			*esutils.LinseedUser(clusterID2, tenant2),
 			*esutils.DashboardUser(clusterID2, tenantID2),
 		}
 
@@ -108,5 +121,214 @@ var _ = Describe("LogStorage cleanup controller", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(testESClient.AssertExpectations(t))
+	})
+})
+
+// fakeESClient records the users provisioned against Elasticsearch.
+type fakeESClient struct {
+	created []*esutils.User
+}
+
+func (f *fakeESClient) SetILMPolicies(context.Context, *operatorv1.LogStorage, bool) error {
+	return nil
+}
+
+func (f *fakeESClient) CreateUser(_ context.Context, user *esutils.User) error {
+	f.created = append(f.created, user)
+	return nil
+}
+
+func (f *fakeESClient) DeleteUser(context.Context, *esutils.User) error { return nil }
+
+func (f *fakeESClient) GetUsers(context.Context) ([]esutils.User, error) { return nil, nil }
+
+var _ = Describe("LogStorage users controller", func() {
+	const (
+		tenantID = "tenant-a"
+	)
+
+	var (
+		cli      client.Client
+		ctx      context.Context
+		scheme   *runtime.Scheme
+		esClient *fakeESClient
+		r        *UserController
+
+		// cloudConfigMap describes a single-tenant cluster sharing an external Elasticsearch.
+		cloudConfigMap *corev1.ConfigMap
+	)
+
+	BeforeEach(func() {
+		scheme = runtime.NewScheme()
+		Expect(operatorv1.AddToScheme(scheme)).NotTo(HaveOccurred())
+		Expect(corev1.AddToScheme(scheme)).NotTo(HaveOccurred())
+		Expect(esv1.AddToScheme(scheme)).NotTo(HaveOccurred())
+		cli = ctrlrfake.DefaultFakeClientBuilder(scheme).Build()
+		ctx = context.Background()
+
+		ls := &operatorv1.LogStorage{}
+		ls.Name = "tigera-secure"
+		ls.Status.State = operatorv1.TigeraStatusReady
+		Expect(cli.Create(ctx, ls)).NotTo(HaveOccurred())
+
+		// Note that no cluster-info ConfigMap is created here: single-tenant clusters don't have one,
+		// and the controller must not require it.
+		cloudConfigMap = cloudconfig.NewCloudConfig(tenantID, "tenant-a-name", "es.example.com", "kb.example.com", false).ConfigMap()
+		Expect(cli.Create(ctx, cloudConfigMap)).NotTo(HaveOccurred())
+
+		mockStatus := &status.MockStatus{}
+		mockStatus.On("OnCRFound").Return()
+		mockStatus.On("ReadyToMonitor")
+		mockStatus.On("ClearDegraded")
+		mockStatus.On("ClearWarning", mock.Anything).Return()
+		mockStatus.On("SetDegraded", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+
+		esClient = &fakeESClient{}
+		r = &UserController{
+			client: cli,
+			scheme: scheme,
+			status: mockStatus,
+			esClientFn: func(_ client.Client, _ context.Context, _ string, _ bool) (esutils.ElasticClient, error) {
+				return esClient, nil
+			},
+			multiTenant:     false,
+			elasticExternal: true,
+			useSingleIndex:  true,
+		}
+	})
+
+	// singleTenant builds the Tenant that the controller derives from the cloud config ConfigMap created above.
+	singleTenant := func(opts ...eutils.TenantOption) *operatorv1.Tenant {
+		return eutils.TenantFromCloudConfig(cloudconfig.NewCloudConfig(tenantID, "tenant-a-name", "es.example.com", "kb.example.com", false), opts...)
+	}
+
+	// secretValue reads a value from a Secret. The fake client doesn't convert StringData into Data
+	// the way the API server does, so we may find the value in either field.
+	secretValue := func(name, namespace, key string) string {
+		s := &corev1.Secret{}
+		ExpectWithOffset(1, cli.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, s)).NotTo(HaveOccurred())
+		if v, ok := s.StringData[key]; ok {
+			return v
+		}
+		return string(s.Data[key])
+	}
+
+	It("should provision users for a single-tenant cluster using single-index storage", func() {
+		_, err := r.Reconcile(ctx, reconcile.Request{})
+		Expect(err).NotTo(HaveOccurred())
+
+		// The Linseed user should be created in ES with the name es-kube-controllers used, and with
+		// privileges on the single-index calico_* indices.
+		expected := esutils.LinseedUserSingleTenant(singleTenant(eutils.WithStandardIndices()), true)
+		Expect(expected.Username).To(Equal("tigera-ee-linseed-tenant-a-secure"))
+		Expect(esClient.created).To(HaveLen(2))
+		Expect(esClient.created[0].Username).To(Equal(expected.Username))
+		Expect(esClient.created[0].FullName).To(Equal(esutils.SystemUserFullName))
+		Expect(esClient.created[0].Roles).To(Equal(expected.Roles))
+		Expect(esClient.created[0].Roles[0].Name).To(Equal(expected.Username))
+		Expect(esClient.created[0].Roles[0].Definition.Indices[0].Names).To(ContainElement("calico_flowlogs_standard*"))
+		Expect(esClient.created[0].Roles[0].Definition.Indices[0].Names).To(HaveLen(len(operatorv1.DataTypes)))
+		Expect(esClient.created[1].Username).To(Equal("tigera-ee-dashboards-installer-tenant-a-secure"))
+		Expect(esClient.created[1].FullName).To(Equal(esutils.SystemUserFullName))
+
+		// The credentials should be written to the Elasticsearch namespace for Linseed to consume.
+		Expect(secretValue(render.ElasticsearchLinseedUserSecret, render.ElasticsearchNamespace, "username")).To(Equal(expected.Username))
+		Expect(secretValue(render.ElasticsearchLinseedUserSecret, render.ElasticsearchNamespace, "password")).NotTo(BeEmpty())
+		Expect(secretValue(dashboards.ElasticCredentialsSecret, render.ElasticsearchNamespace, "username")).To(Equal(esutils.DashboardUserSingleTenant(tenantID, true).Username))
+	})
+
+	It("should re-point existing credentials at the operator provisioned user", func() {
+		// es-kube-controllers uses a different naming convention for the ES user.
+		Expect(cli.Create(ctx, &corev1.Secret{
+			ObjectMeta: apiv1.ObjectMeta{Name: render.ElasticsearchLinseedUserSecret, Namespace: common.OperatorNamespace()},
+			Data:       map[string][]byte{"username": []byte("tigera-ee-linseed"), "password": []byte("existing-password")},
+		})).NotTo(HaveOccurred())
+
+		_, err := r.Reconcile(ctx, reconcile.Request{})
+		Expect(err).NotTo(HaveOccurred())
+
+		expected := esutils.LinseedUserSingleTenant(singleTenant(eutils.WithStandardIndices()), true)
+		Expect(secretValue(render.ElasticsearchLinseedUserSecret, common.OperatorNamespace(), "username")).To(Equal(expected.Username))
+		Expect(secretValue(render.ElasticsearchLinseedUserSecret, render.ElasticsearchNamespace, "username")).To(Equal(expected.Username))
+
+		// The existing password is preserved, and used for the user we provision.
+		Expect(secretValue(render.ElasticsearchLinseedUserSecret, common.OperatorNamespace(), "password")).To(Equal("existing-password"))
+		Expect(esClient.created[0].Username).To(Equal(expected.Username))
+		Expect(esClient.created[0].Password).To(Equal("existing-password"))
+	})
+
+	It("should grant the Linseed user the multi-index names when not using single-index storage", func() {
+		r.useSingleIndex = false
+
+		_, err := r.Reconcile(ctx, reconcile.Request{})
+		Expect(err).NotTo(HaveOccurred())
+
+		// The user keeps its name, but is only granted access to this tenant's multi-index format indices.
+		expected := esutils.LinseedUserSingleTenant(singleTenant(), true)
+		Expect(esClient.created[0].Username).To(Equal(expected.Username))
+		Expect(esClient.created[0].Roles[0].Definition.Indices[0].Names).To(Equal([]string{"tigera_secure_ee_*.tenant-a.*.*", "calico_policy_activity*"}))
+	})
+
+	Context("single-tenant cluster on its own Elasticsearch", func() {
+		BeforeEach(func() {
+			// The two single-tenant flavours are mutually exclusive: a cluster on its own Elasticsearch
+			// has no cloud config ConfigMap, and is described by the cloud auth ConfigMap instead.
+			Expect(cli.Delete(ctx, cloudConfigMap)).NotTo(HaveOccurred())
+			Expect(cli.Create(ctx, &corev1.ConfigMap{
+				ObjectMeta: apiv1.ObjectMeta{Name: eutils.CloudAuthConfig, Namespace: common.OperatorNamespace()},
+				Data:       map[string]string{"tenantID": tenantID},
+			})).NotTo(HaveOccurred())
+
+			// On its own Elasticsearch the controller waits for the ES cluster to be operational.
+			es := &esv1.Elasticsearch{}
+			es.Name = "tigera-secure"
+			es.Namespace = render.ElasticsearchNamespace
+			es.Status.Phase = esv1.ElasticsearchReadyPhase
+			Expect(cli.Create(ctx, es)).NotTo(HaveOccurred())
+
+			r.elasticExternal = false
+		})
+
+		It("should read the tenant from the cloud auth ConfigMap", func() {
+			tenant, configMap, err := r.singleTenant(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configMap).To(Equal(eutils.CloudAuthConfig))
+			Expect(tenant.Spec.ID).To(Equal(tenantID))
+
+			// The cloud auth config carries the tenant ID alone, so no indices are declared even though
+			// useSingleIndex is set - a cluster on its own Elasticsearch does not migrate.
+			Expect(tenant.Spec.Indices).To(BeEmpty())
+			Expect(tenant.Spec.Elastic).To(BeNil())
+		})
+
+		It("should provision users against the internal Elasticsearch", func() {
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).NotTo(HaveOccurred())
+
+			// es-kube-controllers is given no tenant ID on a cluster running its own Elasticsearch, so the
+			// users it provisioned there carry no tenant qualifier - and neither do ours.
+			Expect(esClient.created).To(HaveLen(2))
+			Expect(esClient.created[0].Username).To(Equal("tigera-ee-linseed-secure"))
+			Expect(esClient.created[1].Username).To(Equal("tigera-ee-dashboards-installer-secure"))
+
+			// Indices in the cluster's own Elasticsearch carry no tenant qualifier, so neither does the
+			// pattern the Linseed user is granted.
+			Expect(esClient.created[0].Roles[0].Definition.Indices[0].Names).To(Equal([]string{"tigera_secure_ee_*.*.*", "calico_policy_activity*"}))
+
+			Expect(secretValue(render.ElasticsearchLinseedUserSecret, render.ElasticsearchNamespace, "username")).To(Equal("tigera-ee-linseed-secure"))
+			Expect(secretValue(render.ElasticsearchLinseedUserSecret, render.ElasticsearchNamespace, "password")).NotTo(BeEmpty())
+		})
+
+		It("should wait when the cloud auth ConfigMap does not exist yet", func() {
+			Expect(cli.Delete(ctx, &corev1.ConfigMap{
+				ObjectMeta: apiv1.ObjectMeta{Name: eutils.CloudAuthConfig, Namespace: common.OperatorNamespace()},
+			})).NotTo(HaveOccurred())
+
+			// Waiting, not erroring - the ConfigMap is written out of band and we watch for it.
+			result, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+			Expect(esClient.created).To(BeEmpty())
+		})
 	})
 })

--- a/pkg/controller/options/options.go
+++ b/pkg/controller/options/options.go
@@ -62,6 +62,10 @@ type ControllerOptions struct {
 	// LSS configuration and internal elasticsearch running. Only meaningful when Cloud is set.
 	ESMigration bool
 
+	// UseSingleIndex is enabled in the last phase of an index migration for a single tenant cluster,
+	// during which the operator reconfigures log storage to use the single-index names.
+	UseSingleIndex bool
+
 	// Whether or not to use crd.projectcalico.org/v1 or projectcalico.org/v3 for Calico CRDs.
 	UseV3CRDs bool
 

--- a/pkg/enterprise/kubecontrollers/es_kube_controllers_test.go
+++ b/pkg/enterprise/kubecontrollers/es_kube_controllers_test.go
@@ -182,6 +182,23 @@ var _ = Describe("es-kube-controllers rendering tests", func() {
 			}))
 	})
 
+	It("should not enable the elasticsearchconfiguration controller in Calico Cloud", func() {
+		instance.Variant = operatorv1.CalicoEnterprise
+		cfg.KubeControllersGatewaySecret = &testutils.KubeControllersUserSecret
+		cfg.MetricsPort = 9094
+		cfg.Cloud = true
+
+		component := NewElasticsearchKubeControllers(&cfg)
+		Expect(component.ResolveImages(nil)).To(BeNil())
+		resources, _ := component.Objects()
+
+		dp := rtest.GetResource(resources, EsKubeController, common.CalicoNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+		envs := dp.Spec.Template.Spec.Containers[0].Env
+		Expect(envs).To(ContainElement(corev1.EnvVar{
+			Name: "ENABLED_CONTROLLERS", Value: "authorization",
+		}))
+	})
+
 	It("should render all es-calico-kube-controllers resources for a default configuration using CalicoEnterprise and ClusterType is Management", func() {
 		expectedResources := []struct {
 			name    string

--- a/pkg/enterprise/kubecontrollers/kubecontrollers.go
+++ b/pkg/enterprise/kubecontrollers/kubecontrollers.go
@@ -83,7 +83,13 @@ func NewElasticsearchKubeControllers(cfg *rkc.KubeControllersConfiguration) rend
 
 	if !cfg.Tenant.MultiTenant() {
 		// Zero and single tenant clusters need elasticsearch configuration.
-		cfg.EnabledControllers = append(cfg.EnabledControllers, "authorization", "elasticsearchconfiguration")
+		cfg.EnabledControllers = append(cfg.EnabledControllers, "authorization")
+		if !cfg.Cloud {
+			// In Calico Cloud, the operator's log-storage users controller provisions the Elasticsearch
+			// users itself, so that they get the RBAC for the indices the cluster actually stores its
+			// data in. Running this controller as well would have it overwrite those users.
+			cfg.EnabledControllers = append(cfg.EnabledControllers, "elasticsearchconfiguration")
+		}
 		if cfg.ManagementCluster != nil && cfg.Tenant == nil {
 			cfg.ManagedClusterWatchBinding = true
 			// Enterprise requires the managedcluster controller to push licenses.

--- a/pkg/enterprise/utils/cloudconfig.go
+++ b/pkg/enterprise/utils/cloudconfig.go
@@ -32,6 +32,28 @@ import (
 // (e.g. the tenantID) for a single-tenant cloud management cluster backed by internal Elasticsearch.
 const CloudAuthConfig = "cloud-auth-config"
 
+// ClusterInfoConfigMap is the name of the ConfigMap holding this cluster's ID. It is written at
+// install time, and only exists in multi-tenant management clusters.
+const ClusterInfoConfigMap = "cluster-info"
+
+// GetClusterID reads the cluster ID from the cluster-info ConfigMap.
+func GetClusterID(ctx context.Context, cli client.Client) (string, error) {
+	cm := &corev1.ConfigMap{}
+	key := client.ObjectKey{Name: ClusterInfoConfigMap, Namespace: common.OperatorNamespace()}
+	if err := cli.Get(ctx, key, cm); err != nil {
+		return "", fmt.Errorf("failed to read ConfigMap %s/%s: %w", key.Namespace, key.Name, err)
+	}
+
+	clusterID, ok := cm.Data["cluster-id"]
+	if !ok {
+		return "", fmt.Errorf("%s/%s ConfigMap does not contain expected 'cluster-id' key", key.Namespace, key.Name)
+	} else if clusterID == "" {
+		return "", fmt.Errorf("%s/%s ConfigMap value for key 'cluster-id' must be non-empty", key.Namespace, key.Name)
+	}
+
+	return clusterID, nil
+}
+
 func GetTenantFromCloudAuthConfig(ctx context.Context, cli client.Client) (*v1.Tenant, error) {
 	cm := &corev1.ConfigMap{}
 	if err := cli.Get(ctx, types.NamespacedName{Name: CloudAuthConfig, Namespace: common.OperatorNamespace()}, cm); err != nil {

--- a/pkg/enterprise/utils/tenant.go
+++ b/pkg/enterprise/utils/tenant.go
@@ -16,6 +16,7 @@ package utils
 
 import (
 	"fmt"
+	"sort"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -23,11 +24,71 @@ import (
 	"github.com/tigera/operator/pkg/enterprise/cloudconfig"
 )
 
-// ToTenant converts the given CloudConfig structure to a Tenant object.
+// TenantOption customizes the Tenant that TenantFromCloudConfig returns.
+type TenantOption func(*v1.Tenant)
+
+// WithStandardIndices declares the standard single-index base names on the Tenant. Only clusters
+// that have migrated to single-index storage should ask for them: index base names are otherwise
+// left off the artificial single-tenant Tenant, and components fall back to their default names.
+//
+// Data types the Tenant already declares are left alone, so that applying this option more than
+// once - or alongside one that declares its own indices - neither duplicates an index nor
+// overrides an explicit base index name.
+func WithStandardIndices() TenantOption {
+	return func(tenant *v1.Tenant) {
+		declared := make(map[v1.DataType]bool, len(tenant.Spec.Indices))
+		for _, index := range tenant.Spec.Indices {
+			declared[index.DataType] = true
+		}
+
+		for dataType := range v1.DataTypes {
+			if declared[dataType] {
+				continue
+			}
+			tenant.Spec.Indices = append(tenant.Spec.Indices, v1.Index{DataType: dataType, BaseIndexName: cloudStandardIndices[dataType]})
+		}
+
+		// DataTypes is a map, so iteration order is random. Sort by data type to keep the generated
+		// index list - and therefore the env vars rendered from it - stable across reconciles.
+		sort.Slice(tenant.Spec.Indices, func(i, j int) bool {
+			return tenant.Spec.Indices[i].DataType < tenant.Spec.Indices[j].DataType
+		})
+	}
+}
+
+// WithStandardIndicesIf applies WithStandardIndices only if useSingleIndex is set, for callers that
+// carry that flag around as a bool.
+func WithStandardIndicesIf(useSingleIndex bool) TenantOption {
+	if !useSingleIndex {
+		return func(*v1.Tenant) {}
+	}
+	return WithStandardIndices()
+}
+
+// cloudStandardIndices maps each data type to the standard index base name used by clusters that
+// have migrated to single-index storage.
+var cloudStandardIndices = map[v1.DataType]string{
+	v1.DataTypeAlerts:               "calico_alerts_standard",
+	v1.DataTypeAuditLogs:            "calico_auditlogs_standard",
+	v1.DataTypeBGPLogs:              "calico_bgplogs_standard",
+	v1.DataTypeComplianceBenchmarks: "calico_compliance_benchmarks_results_standard",
+	v1.DataTypeComplianceReports:    "calico_compliance_reports_standard",
+	v1.DataTypeComplianceSnapshots:  "calico_compliance_snapshots_standard",
+	v1.DataTypeDNSLogs:              "calico_dnslogs_standard",
+	v1.DataTypeFlowLogs:             "calico_flowlogs_standard",
+	v1.DataTypeL7Logs:               "calico_l7logs_standard",
+	v1.DataTypeRuntimeReports:       "calico_runtime_reports_standard",
+	v1.DataTypeThreatFeedsDomainSet: "calico_threatfeeds_domainnameset_standard",
+	v1.DataTypeThreatFeedsIPSet:     "calico_threatfeeds_ipset_standard",
+	v1.DataTypeWAFLogs:              "calico_waflogs_standard",
+	v1.DataTypePolicyActivity:       "calico_policy_activity_standard",
+}
+
+// TenantFromCloudConfig converts the given CloudConfig structure to a Tenant object.
 // This allows controllers that have been converted to support multi-tenancy to still leverage
 // the single-tenant CloudConfig structure using the same code path as in multi-tenancy.
-func TenantFromCloudConfig(c *cloudconfig.CloudConfig) *v1.Tenant {
-	return &v1.Tenant{
+func TenantFromCloudConfig(c *cloudconfig.CloudConfig, opts ...TenantOption) *v1.Tenant {
+	tenant := &v1.Tenant{
 		// We don't specify a Namespace for this tenant because it represents a singular tenant installed
 		// in this management cluster. The signals to the render code that this is a single-tenant cluster and not
 		// a cluster capable of multi-tenancy.
@@ -42,4 +103,10 @@ func TenantFromCloudConfig(c *cloudconfig.CloudConfig) *v1.Tenant {
 			},
 		},
 	}
+
+	for _, opt := range opts {
+		opt(tenant)
+	}
+
+	return tenant
 }

--- a/pkg/enterprise/utils/tenant_test.go
+++ b/pkg/enterprise/utils/tenant_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	v1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/enterprise/cloudconfig"
+)
+
+var _ = Describe("TenantFromCloudConfig", func() {
+	var cloudConfig *cloudconfig.CloudConfig
+
+	BeforeEach(func() {
+		cloudConfig = cloudconfig.NewCloudConfig("abc123", "tenant1", "externalES.com", "externalKibana.com", true)
+	})
+
+	It("should return a single-tenant Tenant with the Elastic configuration from the CloudConfig", func() {
+		tenant := TenantFromCloudConfig(cloudConfig)
+		Expect(tenant.Name).To(Equal("default"))
+		Expect(tenant.Namespace).To(BeEmpty())
+		Expect(tenant.MultiTenant()).To(BeFalse())
+		Expect(tenant.Spec.ID).To(Equal("abc123"))
+		Expect(tenant.Spec.Name).To(Equal("tenant1"))
+		Expect(tenant.Spec.Elastic.URL).To(Equal("https://externalES.com:443"))
+		Expect(tenant.Spec.Elastic.KibanaURL).To(Equal("https://externalKibana.com:443"))
+		Expect(tenant.Spec.Elastic.MutualTLS).To(BeTrue())
+	})
+
+	It("should not declare any indices when not using single-index storage", func() {
+		Expect(TenantFromCloudConfig(cloudConfig).Spec.Indices).To(BeEmpty())
+	})
+
+	It("should declare the standard index for every data type when using single-index storage", func() {
+		indices := TenantFromCloudConfig(cloudConfig, WithStandardIndices()).Spec.Indices
+		Expect(indices).To(HaveLen(len(v1.DataTypes)))
+		for _, index := range indices {
+			Expect(index.BaseIndexName).To(Equal(cloudStandardIndices[index.DataType]))
+			Expect(index.BaseIndexName).ToNot(BeEmpty())
+		}
+	})
+
+	It("should declare indices in a stable order", func() {
+		expected := TenantFromCloudConfig(cloudConfig, WithStandardIndices()).Spec.Indices
+		for i := 0; i < 10; i++ {
+			Expect(TenantFromCloudConfig(cloudConfig, WithStandardIndices()).Spec.Indices).To(Equal(expected))
+		}
+	})
+
+	It("should not duplicate indices when applied more than once", func() {
+		once := TenantFromCloudConfig(cloudConfig, WithStandardIndices()).Spec.Indices
+		twice := TenantFromCloudConfig(cloudConfig, WithStandardIndices(), WithStandardIndices()).Spec.Indices
+
+		Expect(twice).To(HaveLen(len(v1.DataTypes)))
+		Expect(twice).To(Equal(once))
+	})
+
+	It("should leave an index the Tenant already declares alone", func() {
+		// An explicitly declared base index name wins over the standard one, and is not duplicated.
+		declareFlowLogs := func(tenant *v1.Tenant) {
+			tenant.Spec.Indices = []v1.Index{{DataType: v1.DataTypeFlowLogs, BaseIndexName: "custom_flowlogs"}}
+		}
+
+		indices := TenantFromCloudConfig(cloudConfig, declareFlowLogs, WithStandardIndices()).Spec.Indices
+		Expect(indices).To(HaveLen(len(v1.DataTypes)))
+
+		var flowLogs []v1.Index
+		for _, index := range indices {
+			if index.DataType == v1.DataTypeFlowLogs {
+				flowLogs = append(flowLogs, index)
+			}
+		}
+		Expect(flowLogs).To(ConsistOf(v1.Index{DataType: v1.DataTypeFlowLogs, BaseIndexName: "custom_flowlogs"}))
+	})
+})

--- a/pkg/render/logstorage/linseed/linseed.go
+++ b/pkg/render/logstorage/linseed/linseed.go
@@ -117,6 +117,7 @@ type Config struct {
 	// Tenant configuration, if running for a particular tenant.
 	Tenant          *operatorv1.Tenant
 	ExternalElastic bool
+	UseSingleIndex  bool
 
 	// Secret containing client certificate and key for connecting to the Elastic cluster. If configured,
 	// mTLS is used between Linseed and the external Elastic cluster.
@@ -425,6 +426,13 @@ func (l *linseed) linseedDeployment() *appsv1.Deployment {
 
 			if l.cfg.Tenant.Spec.ControlPlaneReplicas != nil {
 				replicas = l.cfg.Tenant.Spec.ControlPlaneReplicas
+			}
+		} else if l.cfg.UseSingleIndex {
+			// For single-tenant clusters migrating to single-index storage,
+			// use the elastic-single-index backend and configure index base names.
+			envVars = append(envVars, corev1.EnvVar{Name: "BACKEND", Value: "elastic-single-index"})
+			for _, index := range l.cfg.Tenant.Spec.Indices {
+				envVars = append(envVars, index.EnvVar())
 			}
 		}
 	}

--- a/test/load_images_on_kind_cluster.sh
+++ b/test/load_images_on_kind_cluster.sh
@@ -15,5 +15,5 @@ KIND_NODES="${KIND_CLUSTER_NAME}-control-plane ${KIND_CLUSTER_NAME}-worker ${KIN
 
 for NODE in ${KIND_NODES}
 do
-  load_image ${NODE} ${@:2}
+  load_image ${NODE} ${@}
 done


### PR DESCRIPTION
…to single-index (#5132)

* (bootstrap): Add knob to reconfigure Linseed indices for a single tenant cluster

This will be set operator bootstrap config map and enabled when migrating from multi-index format to single-index format. Linseed will reconfigure its environment variables to set the correct backend for the indices it is using and also set the base index name used for Cloud.

* (logstorage-users): Provision Elasticsearch users from the operator while migrating to single-index storage

Single-tenant clusters migrating to single-index storage need Linseed to hold RBAC for the new calico_* indices. es-kube-controllers cannot grant that, so during the migration the operator's log-storage users controller takes over user provisioning and es-kube-controllers stops running its elasticsearch configuration controller.

- Run the users controller in single-tenant mode when IndexMigration is set, building the tenant configuration from the cloud config ConfigMap since single-tenant clusters have no Tenant resource.
- Name the single-tenant Linseed and Dashboards users the way es-kube-controllers named them (<name>-<tenantID>-secure), and repoint existing credential secrets at those users while keeping their passwords, so credentials provisioned before the migration keep resolving.
- Declare the standard single-index names on the Tenant that CloudConfig.ToTenant builds, gated on the caller opting in, so that clusters which are not migrating keep falling back to their existing index names. Sort the declared indices, as they are generated from a map.
- Report the users TigeraStatus in the log-storage conditions aggregate while migrating.

* (logstorage-conditions): Stop the log-storage conditions controller from writing on every reconcile

updateConditions built its result by ranging over the desiredConditions map, so the order of LogStorage.Status.Conditions was randomized on every reconcile. Conditions is an atomic list, so a reorder is a real change to the stored object: each reconcile bumped the resourceVersion, and since this controller also watches LogStorage, that re-enqueued itself. The write loop ran continuously, and reconciles fired faster than the informer cache could converge - so reconciles read a stale tigera-secure and their status updates were rejected with "the object has been modified".

Sort the conditions by type so the stored list is stable - an unchanged reconcile then computes a list identical to the stored one, which the API server discards without bumping the resourceVersion - and requeue instead of erroring when an update does hit a conflict.

* (fix): Use CalicoEnterprise instead of TigeraEnterprise

* (logstorage-users): Provision Elasticsearch users for all single tenant clusters

Calico Cloud single-tenant clusters had their Elasticsearch users provisioned by es-kube-controllers, and the operator only took over while migrating to single-index storage. Take over for all of them, and grant Linseed access to the indices its cluster actually stores data in rather than to both name formats.

- Run the log-storage users controller for every Calico Cloud single-tenant cluster, and stop es-kube-controllers running its elasticsearch configuration controller there so that it does not overwrite the users we own. Wait for the cloud config ConfigMap rather than erroring when it is not there yet.
- Derive the Linseed role's index privileges from the tenant: the declared base index names when the cluster stores data in single-index format, the multi-index names otherwise - dropping the tenant qualifier for clusters on their own Elasticsearch, whose indices do not carry it.
- Report the users TigeraStatus in the log-storage conditions aggregate for Calico Cloud rather than only while migrating.
- Rename the index migration knob to USE_SINGLE_INDEX / UseSingleIndex, matching the naming already used by the linseed controller and render code.
- Move CloudStandardIndices out of the API module and unexport it, as it is only consumed when building the single-tenant Tenant from the cloud config.

* (logstorage-users): Address review feedback on Linseed index privileges

- Skip indices with an empty base index name when building the Linseed role's index privileges. A Tenant declaring an index without a base name - whether misconfigured, or carrying a DataType added later without a mapping - would otherwise be wildcarded into "*", granting Linseed access to every index in Elasticsearch. Fall back to Linseed's default calico_ names when no usable base index name remains, which is what a Tenant declaring no indices at all already got.
- Fix a comment on the single-tenant Linseed backend, which described the branch as migrating to multi-tenant style indices when it is gated by UseSingleIndex and migrating to single-index storage.

* (fix): grant Linseed access to the policy activity index

Policy activity is only ever stored in single-index format, so it is named outside the tigera_secure_ee_ pattern even on clusters that have not moved to single-index storage. The multi-index role we provision granted only that pattern, and since the role name matches the user name, putting it replaced the definition es-kube-controllers wrote - which did include the index. Linseed was then denied indices:admin/aliases/get when ingesting policy activity logs.

Grant calico_policy_activity* alongside the multi-index pattern. The wildcard covers both Linseed's default index name and the calico_policy_activity_standard name pinned for clusters sharing an external Elasticsearch.

* (fix): mark operator-provisioned Elasticsearch users as system users

es-kube-controllers' authorization controller sweeps Elasticsearch on every resync and deletes any user that is neither marked with the "system:serviceaccount" full_name nor present in its OIDC user cache. The operator's User struct had no full_name field at all, so the Linseed and Dashboards installer users it provisions were created with an empty one and swept within a resync period, then recreated on the next reconcile - leaving the user flapping while both components are enabled.

Add FullName to User, set it on both users, and send full_name in the create request. It is only sent when non-empty: the request replaces the user document, so sending it empty would strip the marker off a user that es-kube-controllers had already created with it.

* (test): Make WithStandardIndices idempotent and cover it

WithStandardIndices appended an entry for every data type without checking what the Tenant already declared, so applying it more than once - or alongside an option that declares its own indices - duplicated entries. Skip data types that are already present, letting an explicitly declared base index name win over the standard one rather than being duplicated or overridden.

No current caller hits this: TenantFromCloudConfig always starts from a tenant with no indices, and every call site passes at most one option. This is hardening of a shared helper, not a behaviour change for any caller.

Cover both cases - applying the option twice, and applying it after an option that already declared an index. Both specs fail against the previous implementation.



---------

## Description

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Release Note

<!-- Writing a release note:

- By default, your PR will be set to require a release note and a docs PR!
- If you do not need a release note, swap the `release-note-required` label for
  the `release-note-not-required` label
- Likewise, if you do not need a docs PR, swap `docs-pr-required` for `docs-not-required`
- If you're not certain if you need a release note or docs PR, please check
  with your reviewer or team lead.

-->

```release-note
TBD
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
