### PR TITLE
Move Enterprise-only webhook rendering into the extension

### DIFF
--- a/pkg/enterprise/apiserver/extension_test.go
+++ b/pkg/enterprise/apiserver/extension_test.go
@@ -30,6 +30,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
@@ -1031,6 +1032,113 @@ var _ = Describe("webhooks enterprise modifier", func() {
 
 		_, ok := extensions.FindObject[*rbacv1.ClusterRole](del, webhooks.WebhooksSecretsRBACName)
 		Expect(ok).To(BeTrue())
+	})
+
+	It("runs the webhook container as root so it can write audit logs", func() {
+		create, _ := renderWebhooks()
+
+		dp, ok := extensions.FindObject[*appsv1.Deployment](create, webhooks.WebhooksName)
+		Expect(ok).To(BeTrue())
+		ctr := dp.Spec.Template.Spec.Containers[0]
+		Expect(*ctr.SecurityContext.RunAsUser).To(Equal(int64(0)))
+		Expect(*ctr.SecurityContext.RunAsNonRoot).To(BeFalse())
+		Expect(*ctr.SecurityContext.Privileged).To(BeFalse())
+	})
+
+	It("marks the security context privileged on OpenShift", func() {
+		ci := apiServerControllerInputs(operatorv1.CalicoEnterprise, nil)
+		ci.RenderInputs.Installation.KubernetesProvider = operatorv1.ProviderOpenShift
+		eci, _, err := ext.APIServer().ExtendInputs(ctx, ci)
+		Expect(err).NotTo(HaveOccurred())
+
+		create, _ := renderWebhooksWith(ext, ci, eci.RenderInputs, apiServerKeyPair(ci))
+
+		dp, ok := extensions.FindObject[*appsv1.Deployment](create, webhooks.WebhooksName)
+		Expect(ok).To(BeTrue())
+		Expect(*dp.Spec.Template.Spec.Containers[0].SecurityContext.Privileged).To(BeTrue())
+	})
+
+	It("mounts the audit log directory off the host", func() {
+		create, _ := renderWebhooks()
+
+		dp, ok := extensions.FindObject[*appsv1.Deployment](create, webhooks.WebhooksName)
+		Expect(ok).To(BeTrue())
+		podSpec := dp.Spec.Template.Spec
+		Expect(podSpec.Containers[0].VolumeMounts).To(ContainElement(corev1.VolumeMount{
+			Name:      "audit-logs",
+			MountPath: "/var/log/calico/audit",
+		}))
+		Expect(podSpec.Volumes).To(ContainElement(corev1.Volume{
+			Name: "audit-logs",
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/var/log/calico/audit",
+					Type: ptr.To(corev1.HostPathDirectoryOrCreate),
+				},
+			},
+		}))
+	})
+
+	It("registers the audit logging webhook against every v3 resource", func() {
+		create, _ := renderWebhooks()
+
+		vwc, ok := extensions.FindObject[*admregv1.ValidatingWebhookConfiguration](create, "api.projectcalico.org")
+		Expect(ok).To(BeTrue())
+		Expect(vwc.Webhooks).To(ContainElement(HaveField("Name", "audit-logging.api.projectcalico.org")))
+
+		hook := vwc.Webhooks[len(vwc.Webhooks)-1]
+		Expect(*hook.ClientConfig.Service.Path).To(Equal("/audit"))
+		Expect(*hook.FailurePolicy).To(Equal(admregv1.Ignore))
+		Expect(hook.Rules).To(HaveLen(1))
+		Expect(hook.Rules[0].Rule.Resources).To(Equal([]string{"*"}))
+		Expect(hook.Rules[0].Operations).To(ConsistOf(
+			admregv1.Create, admregv1.Update, admregv1.Delete, admregv1.Connect,
+		))
+	})
+
+	It("registers the UISettings mutating webhook", func() {
+		create, _ := renderWebhooks()
+
+		hooks := mutatingWebhooks(create)
+		Expect(hooks).To(HaveLen(1))
+		Expect(hooks[0].Name).To(Equal("uisettings.api.projectcalico.org"))
+		Expect(*hooks[0].ClientConfig.Service.Path).To(Equal("/uisettings"))
+		Expect(*hooks[0].FailurePolicy).To(Equal(admregv1.Fail))
+		Expect(*hooks[0].TimeoutSeconds).To(Equal(int32(10)))
+		Expect(hooks[0].Rules).To(HaveLen(1))
+		Expect(hooks[0].Rules[0].Rule.Resources).To(Equal([]string{"uisettings"}))
+	})
+
+	It("grants the webhook the Enterprise-only permissions", func() {
+		create, _ := renderWebhooks()
+
+		cr, ok := extensions.FindObject[*rbacv1.ClusterRole](create, webhooks.WebhooksName)
+		Expect(ok).To(BeTrue())
+		Expect(cr.Rules).To(ContainElements(
+			rbacv1.PolicyRule{
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{"managedclusters"},
+				Verbs:     []string{"list", "watch", "update"},
+			},
+			rbacv1.PolicyRule{
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{"uisettingsgroups"},
+				Verbs:     []string{"get"},
+			},
+		))
+	})
+
+	It("queues the mutating webhook configuration for deletion when the operator runs as Calico", func() {
+		ci := apiServerControllerInputs(operatorv1.Calico, nil)
+		eci, _, err := calicoExt.APIServer().ExtendInputs(ctx, ci)
+		Expect(err).NotTo(HaveOccurred())
+
+		create, del := renderWebhooksWith(calicoExt, ci, eci.RenderInputs, apiServerKeyPair(ci))
+
+		_, ok := extensions.FindObject[*admregv1.MutatingWebhookConfiguration](del, "api.projectcalico.org")
+		Expect(ok).To(BeTrue())
+		_, ok = extensions.FindObject[*admregv1.MutatingWebhookConfiguration](create, "api.projectcalico.org")
+		Expect(ok).To(BeFalse())
 	})
 })
 

--- a/pkg/enterprise/apiserver/webhooks.go
+++ b/pkg/enterprise/apiserver/webhooks.go
@@ -44,15 +44,14 @@ const (
 // modifyWebhooks layers audit logging, the mutating webhooks, the extra RBAC, and
 // management-cluster support onto the rendered objects.
 func modifyWebhooks(cfg *webhooks.Configuration, managementCluster *operatorv1.ManagementCluster, multiTenant bool, create, del []client.Object) ([]client.Object, []client.Object) {
-	if dep, ok := extensions.FindObject[*appsv1.Deployment](create, webhooks.WebhooksName); ok {
-		enableAuditLogging(dep, cfg.Installation)
-	}
-	if vwc, ok := extensions.FindObject[*admregv1.ValidatingWebhookConfiguration](create, webhookConfigName); ok {
-		vwc.Webhooks = append(vwc.Webhooks, auditLoggingWebhook(cfg))
-	}
-	if cr, ok := extensions.FindObject[*rbacv1.ClusterRole](create, webhooks.WebhooksName); ok {
-		cr.Rules = append(cr.Rules, enterpriseRules()...)
-	}
+	dep := extensions.MustFindObject[*appsv1.Deployment](create, webhooks.WebhooksName)
+	enableAuditLogging(dep, cfg.Installation)
+
+	vwc := extensions.MustFindObject[*admregv1.ValidatingWebhookConfiguration](create, webhookConfigName)
+	vwc.Webhooks = append(vwc.Webhooks, auditLoggingWebhook(cfg))
+
+	cr := extensions.MustFindObject[*rbacv1.ClusterRole](create, webhooks.WebhooksName)
+	cr.Rules = append(cr.Rules, enterpriseRules()...)
 
 	mwc := mutatingWebhookConfiguration(cfg)
 	if managementCluster == nil {
@@ -60,10 +59,8 @@ func modifyWebhooks(cfg *webhooks.Configuration, managementCluster *operatorv1.M
 		return append(create, mwc), append(del, tunnelSecretRBACMeta()...)
 	}
 
-	if dep, ok := extensions.FindObject[*appsv1.Deployment](create, webhooks.WebhooksName); ok {
-		ctr := render.MustContainer(&dep.Spec.Template.Spec, webhooks.WebhooksName)
-		ctr.Args = append(ctr.Args, managedClusterArgs(managementCluster, multiTenant)...)
-	}
+	ctr := render.MustContainer(&dep.Spec.Template.Spec, webhooks.WebhooksName)
+	ctr.Args = append(ctr.Args, managedClusterArgs(managementCluster, multiTenant)...)
 	mwc.Webhooks = append(mwc.Webhooks, managedClusterWebhook(cfg))
 	create = append(create, mwc)
 	create = append(create, render.TunnelSecretRBAC(webhooks.WebhooksSecretsRBACName, webhooks.WebhooksName, managementCluster, multiTenant)...)

--- a/pkg/enterprise/apiserver/webhooks.go
+++ b/pkg/enterprise/apiserver/webhooks.go
@@ -19,6 +19,7 @@ import (
 
 	admregv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -28,33 +29,181 @@ import (
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/extensions"
 	"github.com/tigera/operator/pkg/render"
+	"github.com/tigera/operator/pkg/render/common/securitycontext"
 	"github.com/tigera/operator/pkg/render/webhooks"
 )
 
-// modifyWebhooks adds the management-cluster behavior the base render omits: the
-// ManagedCluster webhook, its flags, and the tunnel secret RBAC.
+const (
+	// webhookConfigName is shared by the validating and mutating webhook configurations.
+	webhookConfigName = "api.projectcalico.org"
+
+	webhookAuditLogVolumeName = "audit-logs"
+	webhookAuditLogPath       = "/var/log/calico/audit"
+)
+
+// modifyWebhooks layers audit logging, the mutating webhooks, the extra RBAC, and
+// management-cluster support onto the rendered objects.
 func modifyWebhooks(cfg *webhooks.Configuration, managementCluster *operatorv1.ManagementCluster, multiTenant bool, create, del []client.Object) ([]client.Object, []client.Object) {
+	if dep, ok := extensions.FindObject[*appsv1.Deployment](create, webhooks.WebhooksName); ok {
+		enableAuditLogging(dep, cfg.Installation)
+	}
+	if vwc, ok := extensions.FindObject[*admregv1.ValidatingWebhookConfiguration](create, webhookConfigName); ok {
+		vwc.Webhooks = append(vwc.Webhooks, auditLoggingWebhook(cfg))
+	}
+	if cr, ok := extensions.FindObject[*rbacv1.ClusterRole](create, webhooks.WebhooksName); ok {
+		cr.Rules = append(cr.Rules, enterpriseRules()...)
+	}
+
+	mwc := mutatingWebhookConfiguration(cfg)
 	if managementCluster == nil {
 		// Not a management cluster, so clean up the tunnel secret RBAC.
-		return create, append(del, tunnelSecretRBACMeta()...)
+		return append(create, mwc), append(del, tunnelSecretRBACMeta()...)
 	}
 
 	if dep, ok := extensions.FindObject[*appsv1.Deployment](create, webhooks.WebhooksName); ok {
 		ctr := render.MustContainer(&dep.Spec.Template.Spec, webhooks.WebhooksName)
 		ctr.Args = append(ctr.Args, managedClusterArgs(managementCluster, multiTenant)...)
 	}
-	if mwc, ok := extensions.FindObject[*admregv1.MutatingWebhookConfiguration](create, "api.projectcalico.org"); ok {
-		mwc.Webhooks = append(mwc.Webhooks, managedClusterWebhook(cfg))
-	}
+	mwc.Webhooks = append(mwc.Webhooks, managedClusterWebhook(cfg))
+	create = append(create, mwc)
 	create = append(create, render.TunnelSecretRBAC(webhooks.WebhooksSecretsRBACName, webhooks.WebhooksName, managementCluster, multiTenant)...)
 
 	return create, del
 }
 
-// cleanupWebhooks deletes the tunnel secret RBAC a prior Enterprise installation left
-// behind.
+// cleanupWebhooks deletes the mutating webhooks and tunnel secret RBAC a prior Enterprise
+// installation left behind.
 func cleanupWebhooks(create, del []client.Object) ([]client.Object, []client.Object) {
+	del = append(del, &admregv1.MutatingWebhookConfiguration{
+		TypeMeta:   metav1.TypeMeta{Kind: "MutatingWebhookConfiguration", APIVersion: "admissionregistration.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: webhookConfigName},
+	})
 	return create, append(del, tunnelSecretRBACMeta()...)
+}
+
+// enableAuditLogging gives the webhook container the root context and host mount it needs
+// to write audit logs to the node.
+func enableAuditLogging(dep *appsv1.Deployment, installation *operatorv1.InstallationSpec) {
+	podSpec := &dep.Spec.Template.Spec
+	ctr := render.MustContainer(podSpec, webhooks.WebhooksName)
+	ctr.SecurityContext = securitycontext.NewRootContext(installation.KubernetesProvider.IsOpenShift())
+	ctr.VolumeMounts = append(ctr.VolumeMounts, corev1.VolumeMount{
+		Name:      webhookAuditLogVolumeName,
+		MountPath: webhookAuditLogPath,
+	})
+	podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
+		Name: webhookAuditLogVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: webhookAuditLogPath,
+				Type: ptr.To(corev1.HostPathDirectoryOrCreate),
+			},
+		},
+	})
+}
+
+// auditLoggingWebhook feeds every v3 write to the /audit handler, which only Enterprise
+// serves.
+func auditLoggingWebhook(cfg *webhooks.Configuration) admregv1.ValidatingWebhook {
+	return admregv1.ValidatingWebhook{
+		Name: "audit-logging.api.projectcalico.org",
+		Rules: []admregv1.RuleWithOperations{
+			{
+				Operations: []admregv1.OperationType{
+					admregv1.Create,
+					admregv1.Update,
+					admregv1.Delete,
+					admregv1.Connect,
+				},
+				Rule: admregv1.Rule{
+					APIGroups:   []string{"projectcalico.org"},
+					APIVersions: []string{"v3"},
+					Resources:   []string{"*"},
+					Scope:       ptr.To(admregv1.AllScopes),
+				},
+			},
+		},
+		ClientConfig: admregv1.WebhookClientConfig{
+			Service: &admregv1.ServiceReference{
+				Namespace: common.CalicoNamespace,
+				Name:      webhooks.WebhooksName,
+				Path:      ptr.To("/audit"),
+			},
+			CABundle: cfg.KeyPair.GetCertificatePEM(),
+		},
+		AdmissionReviewVersions: []string{"v1"},
+		SideEffects:             ptr.To(admregv1.SideEffectClassNone),
+		TimeoutSeconds:          ptr.To(int32(5)),
+		FailurePolicy:           ptr.To(admregv1.Ignore),
+		MatchPolicy:             ptr.To(admregv1.Exact),
+	}
+}
+
+// mutatingWebhookConfiguration holds the Enterprise mutating webhooks, none of which have a
+// Calico counterpart.
+func mutatingWebhookConfiguration(cfg *webhooks.Configuration) *admregv1.MutatingWebhookConfiguration {
+	return &admregv1.MutatingWebhookConfiguration{
+		TypeMeta:   metav1.TypeMeta{Kind: "MutatingWebhookConfiguration", APIVersion: "admissionregistration.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: webhookConfigName},
+		Webhooks:   []admregv1.MutatingWebhook{uiSettingsWebhook(cfg)},
+	}
+}
+
+// uiSettingsWebhook sets owner references and user fields on UISettings, and authorizes
+// every operation against the parent UISettingsGroup.
+func uiSettingsWebhook(cfg *webhooks.Configuration) admregv1.MutatingWebhook {
+	return admregv1.MutatingWebhook{
+		Name: "uisettings.api.projectcalico.org",
+		Rules: []admregv1.RuleWithOperations{
+			{
+				Operations: []admregv1.OperationType{
+					admregv1.Create,
+					admregv1.Update,
+					admregv1.Delete,
+				},
+				Rule: admregv1.Rule{
+					APIGroups:   []string{"projectcalico.org"},
+					APIVersions: []string{"v3"},
+					Resources:   []string{"uisettings"},
+					Scope:       ptr.To(admregv1.AllScopes),
+				},
+			},
+		},
+		ClientConfig: admregv1.WebhookClientConfig{
+			Service: &admregv1.ServiceReference{
+				Namespace: common.CalicoNamespace,
+				Name:      webhooks.WebhooksName,
+				Path:      ptr.To("/uisettings"),
+			},
+			CABundle: cfg.KeyPair.GetCertificatePEM(),
+		},
+		AdmissionReviewVersions: []string{"v1"},
+		SideEffects:             ptr.To(admregv1.SideEffectClassNone),
+		TimeoutSeconds:          ptr.To(int32(10)),
+		FailurePolicy:           ptr.To(admregv1.Fail),
+		MatchPolicy:             ptr.To(admregv1.Exact),
+	}
+}
+
+// enterpriseRules are the permissions the Enterprise-only webhook handlers need on top of
+// the base webhook RBAC.
+func enterpriseRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
+		{
+			// The ManagedCluster cleanup controller watches ManagedCluster objects and clears their
+			// installation manifest field after creation.
+			APIGroups: []string{"projectcalico.org"},
+			Resources: []string{"managedclusters"},
+			Verbs:     []string{"list", "watch", "update"},
+		},
+		{
+			// The UISettings webhook needs to GET UISettingsGroups to verify group existence
+			// and build owner references when creating UISettings.
+			APIGroups: []string{"projectcalico.org"},
+			Resources: []string{"uisettingsgroups"},
+			Verbs:     []string{"get"},
+		},
+	}
 }
 
 // managedClusterArgs are the flags the ManagedCluster webhook needs to generate the

--- a/pkg/extensions/component.go
+++ b/pkg/extensions/component.go
@@ -15,6 +15,8 @@
 package extensions
 
 import (
+	"fmt"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
@@ -61,4 +63,14 @@ func FindObject[T client.Object](objs []client.Object, name string) (T, bool) {
 		}
 	}
 	return zero, false
+}
+
+// MustFindObject returns the first object of type T with the given name, panicking
+// if the base render did not produce it.
+func MustFindObject[T client.Object](objs []client.Object, name string) T {
+	t, ok := FindObject[T](objs, name)
+	if !ok {
+		panic(fmt.Sprintf("BUG: no object named %q to modify", name))
+	}
+	return t
 }

--- a/pkg/extensions/extensions_test.go
+++ b/pkg/extensions/extensions_test.go
@@ -132,3 +132,23 @@ var _ = Describe("the base ManagementClusterConnection validation", func() {
 		Expect(e.ClusterConnection().ValidateAndDefault(cr)).NotTo(HaveOccurred())
 	})
 })
+
+var _ = Describe("MustFindObject", func() {
+	objs := []client.Object{configMap("present")}
+
+	It("should return the named object", func() {
+		Expect(extensions.MustFindObject[*corev1.ConfigMap](objs, "present").Name).To(Equal("present"))
+	})
+
+	It("should panic when the object is absent", func() {
+		Expect(func() {
+			extensions.MustFindObject[*corev1.ConfigMap](objs, "missing")
+		}).To(PanicWith(ContainSubstring(`BUG: no object named "missing"`)))
+	})
+
+	It("should panic when the object has a different type", func() {
+		Expect(func() {
+			extensions.MustFindObject[*corev1.Secret](objs, "present")
+		}).To(PanicWith(ContainSubstring(`BUG: no object named "present"`)))
+	})
+})

--- a/pkg/render/webhooks/render.go
+++ b/pkg/render/webhooks/render.go
@@ -108,13 +108,6 @@ func (c *component) Objects() ([]client.Object, []client.Object) {
 		},
 	}
 
-	// Create the correct security context for the webhook container. By default, it should run as non-root, but in Enterprise
-	// we need to run as root to be able to write audit logs to the host filesystem.
-	securtyContext := securitycontext.NewNonRootContext()
-	if c.cfg.Installation.Variant.IsEnterprise() {
-		securtyContext = securitycontext.NewRootContext(c.cfg.Installation.KubernetesProvider.IsOpenShift())
-	}
-
 	// Create the Deployment for the webhook with defaults, then apply overrides.
 	dep := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
@@ -147,7 +140,7 @@ func (c *component) Objects() ([]client.Object, []client.Object) {
 						Name:            WebhooksName,
 						Image:           c.calicoImage,
 						Command:         []string{components.CalicoBinaryPath, "component", "webhooks"},
-						SecurityContext: securtyContext,
+						SecurityContext: securitycontext.NewNonRootContext(),
 						Args: []string{
 							"webhook",
 							fmt.Sprintf("--tls-cert-file=%s", c.cfg.KeyPair.VolumeMountCertificateFilePath()),
@@ -173,27 +166,10 @@ func (c *component) Objects() ([]client.Object, []client.Object) {
 						},
 						VolumeMounts: []corev1.VolumeMount{
 							c.cfg.KeyPair.VolumeMount(c.SupportedOSType()),
-							{
-								Name:      "audit-logs",
-								MountPath: "/var/log/calico/audit",
-								ReadOnly:  false,
-							},
 						},
 					}},
 					Volumes: []corev1.Volume{
-						// The volume for the TLS certs.
 						c.cfg.KeyPair.Volume(),
-
-						// Host volume for audit logs to be wrriten.
-						{
-							Name: "audit-logs",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/var/log/calico/audit",
-									Type: ptr.To(corev1.HostPathDirectoryOrCreate),
-								},
-							},
-						},
 					},
 				},
 			},
@@ -415,87 +391,6 @@ func (c *component) Objects() ([]client.Object, []client.Object) {
 		},
 	}
 
-	if c.cfg.Installation.Variant.IsEnterprise() {
-		// The /audit handler only exists in Enterprise. Registering this webhook on Calico OSS
-		// points the API server at an endpoint that isn't served, filling its log with failed
-		// webhook calls, so only add it for Enterprise.
-		vwc.Webhooks = append(vwc.Webhooks, admissionregistrationv1.ValidatingWebhook{
-			Name: "audit-logging.api.projectcalico.org",
-			Rules: []admissionregistrationv1.RuleWithOperations{
-				{
-					Operations: []admissionregistrationv1.OperationType{
-						admissionregistrationv1.Create,
-						admissionregistrationv1.Update,
-						admissionregistrationv1.Delete,
-						admissionregistrationv1.Connect,
-					},
-					Rule: admissionregistrationv1.Rule{
-						APIGroups:   []string{"projectcalico.org"},
-						APIVersions: []string{"v3"},
-						Resources:   []string{"*"},
-						Scope:       ptr.To(admissionregistrationv1.AllScopes),
-					},
-				},
-			},
-			ClientConfig: admissionregistrationv1.WebhookClientConfig{
-				Service: &admissionregistrationv1.ServiceReference{
-					Namespace: common.CalicoNamespace,
-					Name:      WebhooksName,
-					Path:      ptr.To("/audit"),
-				},
-				CABundle: c.cfg.KeyPair.GetCertificatePEM(),
-			},
-			AdmissionReviewVersions: []string{"v1"},
-			SideEffects:             ptr.To(admissionregistrationv1.SideEffectClassNone),
-			TimeoutSeconds:          ptr.To(int32(5)),
-			FailurePolicy:           ptr.To(admissionregistrationv1.Ignore),
-			MatchPolicy:             ptr.To(admissionregistrationv1.Exact),
-		})
-	}
-
-	// Create a MutatingWebhookConfiguration for Enterprise-only mutating webhooks.
-	mwc := &admissionregistrationv1.MutatingWebhookConfiguration{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "api.projectcalico.org",
-		},
-		Webhooks: []admissionregistrationv1.MutatingWebhook{
-			{
-				// This webhook handles authorization, mutation, and validation for UISettings resources.
-				// On Create it sets ownerReferences and user fields; on all operations it performs
-				// authorization checks against the parent UISettingsGroup.
-				Name: "uisettings.api.projectcalico.org",
-				Rules: []admissionregistrationv1.RuleWithOperations{
-					{
-						Operations: []admissionregistrationv1.OperationType{
-							admissionregistrationv1.Create,
-							admissionregistrationv1.Update,
-							admissionregistrationv1.Delete,
-						},
-						Rule: admissionregistrationv1.Rule{
-							APIGroups:   []string{"projectcalico.org"},
-							APIVersions: []string{"v3"},
-							Resources:   []string{"uisettings"},
-							Scope:       ptr.To(admissionregistrationv1.AllScopes),
-						},
-					},
-				},
-				ClientConfig: admissionregistrationv1.WebhookClientConfig{
-					Service: &admissionregistrationv1.ServiceReference{
-						Namespace: common.CalicoNamespace,
-						Name:      WebhooksName,
-						Path:      ptr.To("/uisettings"),
-					},
-					CABundle: c.cfg.KeyPair.GetCertificatePEM(),
-				},
-				AdmissionReviewVersions: []string{"v1"},
-				SideEffects:             ptr.To(admissionregistrationv1.SideEffectClassNone),
-				TimeoutSeconds:          ptr.To(int32(10)),
-				FailurePolicy:           ptr.To(admissionregistrationv1.Fail),
-				MatchPolicy:             ptr.To(admissionregistrationv1.Exact),
-			},
-		},
-	}
-
 	// Create a ClusterRole and ClusterRoleBinding for the webhook service account.
 	rules := []rbacv1.PolicyRule{
 		{
@@ -510,25 +405,6 @@ func (c *component) Objects() ([]client.Object, []client.Object) {
 			Resources: []string{"tiers"},
 			Verbs:     []string{"get"},
 		},
-	}
-
-	if c.cfg.Installation.Variant.IsEnterprise() {
-		rules = append(rules,
-			rbacv1.PolicyRule{
-				// The ManagedCluster cleanup controller watches ManagedCluster objects and clears their
-				// installation manifest field after creation.
-				APIGroups: []string{"projectcalico.org"},
-				Resources: []string{"managedclusters"},
-				Verbs:     []string{"list", "watch", "update"},
-			},
-			rbacv1.PolicyRule{
-				// The UISettings webhook needs to GET UISettingsGroups to verify group existence
-				// and build owner references when creating UISettings.
-				APIGroups: []string{"projectcalico.org"},
-				Resources: []string{"uisettingsgroups"},
-				Verbs:     []string{"get"},
-			},
-		)
 	}
 
 	cr := &rbacv1.ClusterRole{
@@ -562,11 +438,7 @@ func (c *component) Objects() ([]client.Object, []client.Object) {
 	if np != nil {
 		objs = append(objs, np)
 	}
-	objs = append(objs, dep, svc, vwc)
-	if c.cfg.Installation.Variant.IsEnterprise() {
-		objs = append(objs, mwc)
-	}
-	objs = append(objs, cr, crb)
+	objs = append(objs, dep, svc, vwc, cr, crb)
 
 	return objs, nil
 }

--- a/pkg/render/webhooks/render_test.go
+++ b/pkg/render/webhooks/render_test.go
@@ -145,47 +145,10 @@ var _ = Describe("Webhooks rendering tests", func() {
 			&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: webhooks.WebhooksName, Namespace: common.CalicoNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"}},
 			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: webhooks.WebhooksName, Namespace: common.CalicoNamespace}, TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"}},
 			&admissionregistrationv1.ValidatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: "api.projectcalico.org"}, TypeMeta: metav1.TypeMeta{Kind: "ValidatingWebhookConfiguration", APIVersion: "admissionregistration.k8s.io/v1"}},
-			&admissionregistrationv1.MutatingWebhookConfiguration{ObjectMeta: metav1.ObjectMeta{Name: "api.projectcalico.org"}, TypeMeta: metav1.TypeMeta{Kind: "MutatingWebhookConfiguration", APIVersion: "admissionregistration.k8s.io/v1"}},
 			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: webhooks.WebhooksName}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"}},
 			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: webhooks.WebhooksName}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
 		}
 		rtest.ExpectResources(resources, expectedResources)
-
-		// Verify the MutatingWebhookConfiguration has the expected webhooks.
-		mwc, err := rtest.GetResourceOfType[*admissionregistrationv1.MutatingWebhookConfiguration](resources, "api.projectcalico.org", "")
-		Expect(err).NotTo(HaveOccurred())
-		Expect(mwc.Webhooks).To(HaveLen(1))
-		Expect(mwc.Webhooks[0].Name).To(Equal("uisettings.api.projectcalico.org"))
-		Expect(*mwc.Webhooks[0].ClientConfig.Service.Path).To(Equal("/uisettings"))
-		Expect(*mwc.Webhooks[0].FailurePolicy).To(Equal(admissionregistrationv1.Fail))
-		Expect(*mwc.Webhooks[0].TimeoutSeconds).To(Equal(int32(10)))
-		Expect(mwc.Webhooks[0].Rules).To(HaveLen(1))
-		Expect(mwc.Webhooks[0].Rules[0].Operations).To(ConsistOf(
-			admissionregistrationv1.Create,
-			admissionregistrationv1.Update,
-			admissionregistrationv1.Delete,
-		))
-		Expect(mwc.Webhooks[0].Rules[0].Rule.Resources).To(Equal([]string{"uisettings"}))
-
-		// The audit-logging webhook is Enterprise-only.
-		vwc, err := rtest.GetResourceOfType[*admissionregistrationv1.ValidatingWebhookConfiguration](resources, "api.projectcalico.org", "")
-		Expect(err).NotTo(HaveOccurred())
-		Expect(vwc.Webhooks).To(ContainElement(HaveField("Name", "audit-logging.api.projectcalico.org")))
-
-		// Verify the ClusterRole includes the enterprise-only rules.
-		cr := rtest.GetResource(resources, webhooks.WebhooksName, "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
-		Expect(cr.Rules).To(ContainElements(
-			rbacv1.PolicyRule{
-				APIGroups: []string{"projectcalico.org"},
-				Resources: []string{"managedclusters"},
-				Verbs:     []string{"list", "watch", "update"},
-			},
-			rbacv1.PolicyRule{
-				APIGroups: []string{"projectcalico.org"},
-				Resources: []string{"uisettingsgroups"},
-				Verbs:     []string{"get"},
-			},
-		))
 
 		// Verify Enterprise uses the Tigera webhooks image.
 		dep := rtest.GetResource(resources, webhooks.WebhooksName, common.CalicoNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
@@ -195,18 +158,6 @@ var _ = Describe("Webhooks rendering tests", func() {
 				components.TigeraImagePath,
 				components.ComponentTigeraCalico.Image,
 				components.ComponentTigeraCalico.Version)))
-	})
-
-	It("should only register the UISettings mutating webhook", func() {
-		installation.Variant = operatorv1.CalicoEnterprise
-		component := webhooks.Component(cfg)
-		Expect(component.ResolveImages(nil)).NotTo(HaveOccurred())
-		resources, _ := component.Objects()
-
-		mwc, err := rtest.GetResourceOfType[*admissionregistrationv1.MutatingWebhookConfiguration](resources, "api.projectcalico.org", "")
-		Expect(err).NotTo(HaveOccurred())
-		Expect(mwc.Webhooks).To(HaveLen(1))
-		Expect(mwc.Webhooks[0].Name).To(Equal("uisettings.api.projectcalico.org"))
 	})
 
 	It("should not include UISettingsGroup rule for Calico", func() {


### PR DESCRIPTION
## Description

Follow-up to #5164, moving the rest of the Enterprise-only webhook rendering behind the extensions boundary. The base render now produces the same objects for both variants, and the Enterprise extension layers on:

- audit logging, both the webhook registration and the host directory the container writes it to
- the mutating webhook configuration and the UISettings webhook in it
- permissions on managed clusters and UI settings groups
- a root (and on OpenShift, privileged) security context on the container

When the operator runs as Calico, the mutating webhook configuration is queued for deletion so an install downgraded from Enterprise cleans up after itself.

One behavior change worth calling out: Calico installs no longer mount the audit log host directory into the webhooks container. Only the Enterprise audit handler ever wrote there, so it was a mounted-but-unused hostPath, but dropping it does roll the webhooks deployment on upgrade.

Related: [CORE-13395](https://tigera.atlassian.net/browse/CORE-13395)

## Release Note

```release-note
None
```


[CORE-13395]: https://tigera.atlassian.net/browse/CORE-13395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ