### PR TITLE
Add a startup probe to the calico-node DaemonSet

### DIFF
--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1353,7 +1353,7 @@ func (c *nodeComponent) cniEnvvars() []corev1.EnvVar {
 func (c *nodeComponent) nodeContainer() corev1.Container {
 	sc := securitycontext.NewRootContext(true)
 
-	lp, rp := c.nodeLivenessReadinessProbes()
+	sp, lp, rp := c.nodeProbes()
 
 	return corev1.Container{
 		Name:            CalicoNodeObjectName,
@@ -1363,6 +1363,7 @@ func (c *nodeComponent) nodeContainer() corev1.Container {
 		SecurityContext: sc,
 		Env:             c.nodeEnvVars(),
 		VolumeMounts:    c.nodeVolumeMounts(),
+		StartupProbe:    sp,
 		LivenessProbe:   lp,
 		ReadinessProbe:  rp,
 		Lifecycle:       c.nodeLifecycle(),
@@ -1747,8 +1748,8 @@ func (c *nodeComponent) nodeLifecycle() *corev1.Lifecycle {
 	return lc
 }
 
-// nodeLivenessReadinessProbes creates the node's liveness and readiness probes.
-func (c *nodeComponent) nodeLivenessReadinessProbes() (*corev1.Probe, *corev1.Probe) {
+// nodeProbes creates calico/node health probes. It returns in order: startupProbe, livenessProbe, readinessProbe
+func (c *nodeComponent) nodeProbes() (*corev1.Probe, *corev1.Probe, *corev1.Probe) {
 	// Determine liveness and readiness configuration for node.
 	livenessPort := intstr.FromInt(c.cfg.FelixHealthPort)
 	readinessCmd := []string{"/bin/calico-node", "-bird-ready", "-felix-ready"}
@@ -1779,7 +1780,16 @@ func (c *nodeComponent) nodeLivenessReadinessProbes() (*corev1.Probe, *corev1.Pr
 		// This timeout should be less than the PeriodSeconds (30s in controller/utils/component.go).
 		TimeoutSeconds: 10,
 	}
-	return lp, rp
+
+	// Poll every 2s so readiness lands fast; 150 failures gives ~300s of startup, more if checks time out.
+	sp := &corev1.Probe{
+		ProbeHandler:     corev1.ProbeHandler{Exec: &corev1.ExecAction{Command: readinessCmd}},
+		PeriodSeconds:    2,
+		TimeoutSeconds:   10,
+		FailureThreshold: 150,
+	}
+
+	return sp, lp, rp
 }
 
 // nodeMetricsService creates a Service which exposes two endpoints on calico/node for

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -3260,7 +3260,7 @@ var _ = Describe("Node rendering tests", func() {
 	}
 })
 
-// verifyProbesAndLifecycle asserts the expected node liveness and readiness probe plus pod lifecycle settings.
+// verifyProbesAndLifecycle asserts the expected node startup, liveness and readiness probes plus pod lifecycle settings.
 func verifyProbesAndLifecycle(ds *appsv1.DaemonSet, isOpenshift, isEnterprise bool) {
 	// Verify readiness and liveness probes.
 	expectedReadiness := &corev1.Probe{
@@ -3304,8 +3304,16 @@ func verifyProbesAndLifecycle(ds *appsv1.DaemonSet, isOpenshift, isEnterprise bo
 		expectedReadiness.Exec.Command = []string{"/bin/calico-node", "-bird-ready", "-felix-ready", "-bgp-metrics-ready"}
 	}
 
+	expectedStartup := &corev1.Probe{
+		ProbeHandler:     corev1.ProbeHandler{Exec: &corev1.ExecAction{Command: expectedReadiness.Exec.Command}},
+		PeriodSeconds:    2,
+		TimeoutSeconds:   10,
+		FailureThreshold: 150,
+	}
+
 	ExpectWithOffset(1, ds.Spec.Template.Spec.Containers[0].ReadinessProbe).To(Equal(expectedReadiness))
 	ExpectWithOffset(1, ds.Spec.Template.Spec.Containers[0].LivenessProbe).To(Equal(expectedLiveness))
+	ExpectWithOffset(1, ds.Spec.Template.Spec.Containers[0].StartupProbe).To(Equal(expectedStartup))
 
 	expectedLifecycle := &corev1.Lifecycle{
 		PreStop: &corev1.LifecycleHandler{Exec: &corev1.ExecAction{Command: []string{"/bin/calico-node", "-shutdown"}}},


### PR DESCRIPTION
Backport of #5163 to release-v1.42, carrying just the startup probe itself.

The probe timing override API landed on master after this branch was cut, and we don't want to backport an API change, so the startup probe timings here are operator-owned and not overridable. The TigeraStatus grace period change from the original PR is also left out, since this branch has no probe-derived grace period to adjust.

```release-note
Reduces the time calico-node takes to be marked ready after starting, which shortens calico-node rolling updates on large clusters.
```
