### PR TITLE
Add a startup probe to the calico-node DaemonSet

### DIFF
--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -1423,7 +1423,7 @@ func (c *nodeComponent) cniEnvvars() []corev1.EnvVar {
 func (c *nodeComponent) nodeContainer() corev1.Container {
 	sc := securitycontext.NewRootContext(true)
 
-	lp, rp := c.nodeLivenessReadinessProbes()
+	sp, lp, rp := c.nodeProbes()
 
 	return corev1.Container{
 		Name:            CalicoNodeObjectName,
@@ -1432,6 +1432,7 @@ func (c *nodeComponent) nodeContainer() corev1.Container {
 		SecurityContext: sc,
 		Env:             c.nodeEnvVars(),
 		VolumeMounts:    c.nodeVolumeMounts(),
+		StartupProbe:    sp,
 		LivenessProbe:   lp,
 		ReadinessProbe:  rp,
 		Lifecycle:       c.nodeLifecycle(),
@@ -1817,8 +1818,8 @@ func (c *nodeComponent) nodeLifecycle() *corev1.Lifecycle {
 	}
 }
 
-// nodeLivenessReadinessProbes creates the node's liveness and readiness probes.
-func (c *nodeComponent) nodeLivenessReadinessProbes() (*corev1.Probe, *corev1.Probe) {
+// nodeProbes creates calico/node health probes. It returns in order: startupProbe, livenessProbe, readinessProbe
+func (c *nodeComponent) nodeProbes() (*corev1.Probe, *corev1.Probe, *corev1.Probe) {
 	// Determine liveness and readiness configuration for node.
 	livenessPort := intstr.FromInt(c.cfg.FelixHealthPort)
 	var readinessCmd []string
@@ -1857,7 +1858,16 @@ func (c *nodeComponent) nodeLivenessReadinessProbes() (*corev1.Probe, *corev1.Pr
 		PeriodSeconds:  10,
 		TimeoutSeconds: 5,
 	}
-	return lp, rp
+
+	// Poll every 2s so readiness lands fast; 150 failures gives ~300s of startup, more if checks time out.
+	sp := &corev1.Probe{
+		ProbeHandler:     corev1.ProbeHandler{Exec: &corev1.ExecAction{Command: readinessCmd}},
+		PeriodSeconds:    2,
+		TimeoutSeconds:   5,
+		FailureThreshold: 150,
+	}
+
+	return sp, lp, rp
 }
 
 // nodeMetricsService creates a Service which exposes two endpoints on calico/node for

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -3289,12 +3289,17 @@ var _ = Describe("Node rendering tests", func() {
 	}
 })
 
-// verifyProbesAndLifecycle asserts the expected node liveness and readiness probe plus pod lifecycle settings.
+// verifyProbesAndLifecycle asserts the expected node startup, liveness and readiness probes plus pod lifecycle settings.
 func verifyProbesAndLifecycle(ds *appsv1.DaemonSet, isOpenshift, isEnterprise bool) {
 	// Verify readiness and liveness probes.
 	expectedReadiness := &corev1.Probe{
 		PeriodSeconds:  10,
 		TimeoutSeconds: 5,
+	}
+	expectedStartup := &corev1.Probe{
+		PeriodSeconds:    2,
+		TimeoutSeconds:   5,
+		FailureThreshold: 150,
 	}
 	expectedLiveness := &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
@@ -3341,9 +3346,11 @@ func verifyProbesAndLifecycle(ds *appsv1.DaemonSet, isOpenshift, isEnterprise bo
 		}
 	}
 	expectedReadiness.ProbeHandler = corev1.ProbeHandler{Exec: &corev1.ExecAction{Command: expectedReadinessCmd}}
+	expectedStartup.ProbeHandler = corev1.ProbeHandler{Exec: &corev1.ExecAction{Command: expectedReadinessCmd}}
 
 	ExpectWithOffset(1, ds.Spec.Template.Spec.Containers[0].ReadinessProbe).To(Equal(expectedReadiness))
 	ExpectWithOffset(1, ds.Spec.Template.Spec.Containers[0].LivenessProbe).To(Equal(expectedLiveness))
+	ExpectWithOffset(1, ds.Spec.Template.Spec.Containers[0].StartupProbe).To(Equal(expectedStartup))
 
 	expectedPreStopCmd := []string{"/bin/calico-node", "-shutdown"}
 	if isEnterprise {


### PR DESCRIPTION
Backport of #5163 to release-v1.43, carrying just the startup probe itself.

This branch has the readiness and liveness probe timing overrides, but not the startup probe override the original PR added, since we don't want to backport an API change. The TigeraStatus grace period change is also left out, since the grace period here is a fixed 60s rather than probe-derived.

```release-note
Reduces the time calico-node takes to be marked ready after starting, which shortens calico-node rolling updates on large clusters.
```
