### PR TITLE
Report the Calico release in status when the Calico variant is installed

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1092,7 +1092,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		return reconcile.Result{}, err
 	}
 
-	calicoVersion := r.ext.ProductVersion()
+	calicoVersion := r.ext.ProductVersion(&instance.Spec)
 
 	ci := controller.Inputs{
 		RenderInputs: render.Inputs{

--- a/pkg/enterprise/installation/core.go
+++ b/pkg/enterprise/installation/core.go
@@ -90,9 +90,12 @@ func collectProcessPathEnabled(lc *operatorv1.LogCollector) bool {
 		*lc.Spec.CollectProcessPath == operatorv1.CollectProcessPathEnable
 }
 
-// Validate rejects installation config Calico Enterprise does not support.
-// ProductVersion is the Calico Enterprise release the operator reports in status.
-func (e *Extension) ProductVersion() string {
+// ProductVersion is the release the operator reports in status. The Enterprise
+// operator also manages Calico variant installs, during migration.
+func (e *Extension) ProductVersion(install *operatorv1.InstallationSpec) string {
+	if !install.Variant.IsEnterprise() {
+		return components.CalicoRelease
+	}
 	return components.EnterpriseRelease
 }
 

--- a/pkg/extensions/extensions_test.go
+++ b/pkg/extensions/extensions_test.go
@@ -84,7 +84,7 @@ var _ = Describe("the zero value Extensions", func() {
 	It("runs the base behavior for every controller", func() {
 		var e extensions.Extensions
 
-		Expect(e.Installation().ProductVersion()).NotTo(BeEmpty())
+		Expect(e.Installation().ProductVersion(&operatorv1.InstallationSpec{})).NotTo(BeEmpty())
 		Expect(e.Installation().Images()).To(BeNil())
 		Expect(e.Windows().Watches(nil)).NotTo(HaveOccurred())
 

--- a/pkg/extensions/installation.go
+++ b/pkg/extensions/installation.go
@@ -42,8 +42,9 @@ type InstallationExtension interface {
 	// it changed fc. It runs before Felix defaulting persists.
 	DefaultFelixConfiguration(install *operatorv1.InstallationSpec, fc *v3.FelixConfiguration) (bool, error)
 
-	// ProductVersion is the version the operator writes to the Installation status.
-	ProductVersion() string
+	// ProductVersion is the version the operator writes to the Installation status
+	// for the variant the given spec installs.
+	ProductVersion(install *operatorv1.InstallationSpec) string
 
 	// Images overrides the images the rendered components resolve to.
 	Images() *imageoverride.Overrides
@@ -67,7 +68,7 @@ func (noopInstallation) DefaultFelixConfiguration(*operatorv1.InstallationSpec, 
 	return false, nil
 }
 
-func (noopInstallation) ProductVersion() string {
+func (noopInstallation) ProductVersion(*operatorv1.InstallationSpec) string {
 	return components.CalicoRelease
 }
 


### PR DESCRIPTION
Cherry-pick of #5210 to release-v1.44. This also fixes the unit test failure the branch has had since it was cut, where the two versions differ and the wrong one is reported.

Related: [CORE-13375](https://tigera.atlassian.net/browse/CORE-13375)

```release-note
Fixes the Calico version reported in the installation status when the Calico variant is installed.
```



[CORE-13375]: https://tigera.atlassian.net/browse/CORE-13375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ