### PR TITLE
Match the build-time helm binary to the linked helm library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ OPERATOR_SDK_URL = https://github.com/operator-framework/operator-sdk/releases/d
 
 # Our version of helm3 - Note that we use BUILD_ARCH here instead of NATIVE_ARCH because
 # that's what we used before and we don't want to break things if that's necessary.
-HELM3_VERSION = v3.21.1
+HELM3_VERSION = v3.21.3
 HELM3_URL = https://get.helm.sh/helm-$(HELM3_VERSION)-$(NATIVE_OS)-$(BUILDARCH).tar.gz
 HELM_BUILDARCH_BINARY = $(HACK_BIN)/helm-$(BUILDARCH)
 HELM_BUILDARCH_VERSIONED_BINARY = $(HELM_BUILDARCH_BINARY)-$(HELM3_VERSION)


### PR DESCRIPTION
`HELM3_VERSION` v3.21.1 → **v3.21.3**

This is the helm *program* `hack/bin` downloads during a build. It's a build tool — it never ships in the operator image — and it's separate from the `helm.sh/helm/v3` library the operator links, which is on v3.21.3. The binary was one patch behind it.

### Nothing committed changes

On master the binary's only job is `helm pull` of an OCI artifact, and the chart tarball it lands is gitignored (`*.tgz`), fetched fresh each build and rendered at runtime by the library. An OCI pull is content-addressed, so the artifact is identical whichever helm version fetches it. The diff is one line.

### Context

Noticed while answering a review comment on #5176, where this binary had been left on **v3.11.3** — a 2021 release — on `release-v1.41`.

The other branches are worse off than master and get the same change separately:

| branch | helm binary | helm library | PR |
|---|---|---|---|
| master | v3.21.1 | v3.21.3 | this one |
| release-v1.42 | v3.11.3 | v3.21.3 | see companion |
| release-v1.40 | v3.11.3 | v3.21.3 | see companion |

This commit does **not** cherry-pick to those branches: they still `helm template` the chart into a committed `gateway_api_resources.yaml` rather than pulling it, so their version of the bump also regenerates that file. I verified the pick conflicts rather than assuming it.

**Release note:**
```release-note
None
```