### PR TITLE
Match the build-time helm binary to the linked helm library (release-v1.40)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ OPERATOR_SDK_URL = https://github.com/operator-framework/operator-sdk/releases/d
 
 # Our version of helm3 - Note that we use BUILD_ARCH here instead of NATIVE_ARCH because
 # that's what we used before and we don't want to break things if that's necessary.
-HELM3_VERSION = v3.11.3
+HELM3_VERSION = v3.21.3
 HELM3_URL = https://get.helm.sh/helm-$(HELM3_VERSION)-$(NATIVE_OS)-$(BUILDARCH).tar.gz
 HELM_BUILDARCH_BINARY = $(HACK_BIN)/helm-$(BUILDARCH)
 HELM_BUILDARCH_VERSIONED_BINARY = $(HELM_BUILDARCH_BINARY)-$(HELM3_VERSION)

--- a/pkg/render/gatewayapi/gateway_api_resources.yaml
+++ b/pkg/render/gatewayapi/gateway_api_resources.yaml
@@ -4,7 +4,7 @@ kind: Namespace
 metadata:
   name: tigera-gateway
 ---
-# Source: crds/gatewayapi-crds.yaml
+# Source: gateway-helm/charts/crds/crds/gatewayapi-crds.yaml
 # Copyright The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22091,7 +22091,7 @@ status:
   storedVersions: null
 
 ---
-# Source: crds/generated/gateway.envoyproxy.io_backends.yaml
+# Source: gateway-helm/charts/crds/crds/generated/gateway.envoyproxy.io_backends.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -22593,7 +22593,7 @@ spec:
       status: {}
 
 ---
-# Source: crds/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
+# Source: gateway-helm/charts/crds/crds/generated/gateway.envoyproxy.io_backendtrafficpolicies.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -26200,7 +26200,7 @@ spec:
       status: {}
 
 ---
-# Source: crds/generated/gateway.envoyproxy.io_clienttrafficpolicies.yaml
+# Source: gateway-helm/charts/crds/crds/generated/gateway.envoyproxy.io_clienttrafficpolicies.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -28343,7 +28343,7 @@ spec:
       status: {}
 
 ---
-# Source: crds/generated/gateway.envoyproxy.io_envoyextensionpolicies.yaml
+# Source: gateway-helm/charts/crds/crds/generated/gateway.envoyproxy.io_envoyextensionpolicies.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -30902,7 +30902,7 @@ spec:
       status: {}
 
 ---
-# Source: crds/generated/gateway.envoyproxy.io_envoypatchpolicies.yaml
+# Source: gateway-helm/charts/crds/crds/generated/gateway.envoyproxy.io_envoypatchpolicies.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -31415,7 +31415,7 @@ spec:
       status: {}
 
 ---
-# Source: crds/generated/gateway.envoyproxy.io_envoyproxies.yaml
+# Source: gateway-helm/charts/crds/crds/generated/gateway.envoyproxy.io_envoyproxies.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -49499,7 +49499,7 @@ spec:
       status: {}
 
 ---
-# Source: crds/generated/gateway.envoyproxy.io_httproutefilters.yaml
+# Source: gateway-helm/charts/crds/crds/generated/gateway.envoyproxy.io_httproutefilters.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -49995,7 +49995,7 @@ spec:
     subresources: {}
 
 ---
-# Source: crds/generated/gateway.envoyproxy.io_securitypolicies.yaml
+# Source: gateway-helm/charts/crds/crds/generated/gateway.envoyproxy.io_securitypolicies.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition


### PR DESCRIPTION
`HELM3_VERSION` v3.11.3 → **v3.21.3**. Clean cherry-pick of the `release-v1.42` change (#5214) — the two branches share the chart version and resources file.

This is the helm *program* `hack/bin` downloads to render the Envoy Gateway chart into `pkg/render/gatewayapi/gateway_api_resources.yaml` at build time. It's a build tool — it never ships in the operator image — and it's separate from the `helm.sh/helm/v3` library the operator links, which is already on v3.21.3. The binary had been left on a **2021 release**, ten minors behind.

The regenerated resources file is committed alongside, because the make rule keys off the versioned binary name and would otherwise re-render it and fail `dirty-check`.

### The upgrade is inert

Across **58,298 lines** the only change is **nine comment lines**, where helm now records the full chart path in the source comment:

```diff
-# Source: crds/gatewayapi-crds.yaml
+# Source: gateway-helm/charts/crds/crds/gatewayapi-crds.yaml
```

No Kubernetes resource changes — not a field, not an ordering, not a generated label. Those nine lines are YAML comments, dropped at parse time.

**v3.11.3 re-renders the committed file byte for byte**, so the comparison is against a faithful baseline rather than a file that had drifted from its generator.

---

## ⚠️ Two pre-existing problems on this branch, found while testing this

Neither is caused by this change, and this PR does not fix either. Both need a separate decision.

### 1. The gatewayapi unit tests cannot pass on this branch

`go test ./pkg/render/gatewayapi/...` panics, on the **untouched base branch** and with this change alike — byte-identically:

```
missing/extra k8s CRDs from gateway API YAML (12 != 11)
  pkg/render/gatewayapi/gateway_api.go:295
```

The committed YAML carries 12 Gateway API CRDs; `gateway_api.go` asserts exactly 11.

This looks like more than a stale test. `gateway_api_resources.yaml` is `//go:embed`-ed into the operator binary, and the panic sits in the lazily-called `GatewayAPIResourcesGetter` closure — so on the face of it a shipped `release-v1.40` operator would panic the first time it renders Gateway API resources. Someone who knows this code should confirm whether that path is reachable in production.

### 2. CI cannot report a UT failure on this branch

The panic above is already in CI logs, and the job still reports green. The UT step is:

```yaml
- make ut 2>&1 | tee ut.log        # release-v1.40
```

Without `set -o pipefail`, the step's exit status is `tee`'s, which is always 0. Every UT failure on this branch is silently swallowed.

master and `release-v1.42` already carry the fix:

```yaml
- set -o pipefail; make ut 2>&1 | tee ut.log
```

(`release-v1.41` doesn't pipe at all, so it's unaffected.) Worth picking that one-liner onto this branch — and note that until it lands, **this PR's own green CI proves nothing about the tests**.

**Release note:**
```release-note
None
```