### PR TITLE
Allow konnectivity agents to reach the Calico webhooks [release-v1.44]

### DIFF
--- a/pkg/render/common/networkpolicy/networkpolicy.go
+++ b/pkg/render/common/networkpolicy/networkpolicy.go
@@ -217,6 +217,12 @@ var KubeAPIServerEntityRule = v3.EntityRule{
 	},
 }
 
+// Konnectivity agents proxy apiserver traffic into the cluster. AKS and GKE label them differently.
+var KonnectivityAgentEntityRule = v3.EntityRule{
+	NamespaceSelector: "kubernetes.io/metadata.name == 'kube-system'",
+	Selector:          "app == 'konnectivity-agent' || k8s-app == 'konnectivity-agent'",
+}
+
 // Helper creates a helper for building network policies for multi-tenant capable components.
 // It takes two arguments:
 // - mt: true if running in multi-tenant mode, false otherwise.

--- a/pkg/render/webhooks/render.go
+++ b/pkg/render/webhooks/render.go
@@ -239,31 +239,11 @@ func (c *component) Objects() ([]client.Object, []client.Object) {
 			},
 		)
 
-		// Rule 1: Allow traffic from the kube-apiserver using serviceSelector.
-		// This covers the common case where the apiserver source IP survives unmodified
-		// to the webhook pod and matches the kubernetes Service's endpoints.
-		//
-		// Rule 2: Deny traffic from any Kubernetes workload endpoint. The selector
-		// "has(projectcalico.org/orchestrator)" matches only pods — Calico adds this
-		// label to every workload endpoint but not to NetworkSets or host endpoints, so
-		// a user-created NetworkSet (which could otherwise be picked up by a bare
-		// namespaceSelector: all()) does not short-circuit this deny. Traffic that has
-		// been SNAT'd to a node tunnel address (e.g. a hostnet apiserver sending through
-		// an IPIP/VXLAN overlay) arrives from the node, not from a workload endpoint,
-		// and so falls through to Rule 3. This is what makes the policy work for hostnet
-		// apiservers whose traffic arrives at the webhook with a tunnel IP source.
-		//
-		// Rule 3: Fallback allow for everything else on the webhook port. In practice
-		// this covers node-sourced traffic (including the SNAT'd hostnet-apiserver case
-		// above) and cluster-external sources routed to the pod.
-		//
-		// TODO: This three-rule structure exists because Calico's policy model has no
-		// native way to say "any node" or "any tunnel IP" as a source. If we add a
-		// first-class selector for that (e.g. a built-in label on host endpoints, or a
-		// Source match for tunnel-sourced traffic), we could collapse these rules into a
-		// single explicit allow from {apiserver service endpoints, cluster nodes} and
-		// drop the fallback.
+		// TODO: Calico policy can't match "any node" or "any tunnel IP" as a source. Such
+		// a selector would let us allow nodes explicitly and drop the fallback allow.
 		ingressRules := []v3.Rule{
+			// The apiserver source IP usually survives unmodified to the webhook pod, where it
+			// matches the endpoints of the default/kubernetes Service.
 			{
 				Action:   v3.Allow,
 				Protocol: &networkpolicy.TCPProtocol,
@@ -272,6 +252,19 @@ func (c *component) Objects() ([]client.Object, []client.Object) {
 					Ports: networkpolicy.Ports(uint16(containerPort)),
 				},
 			},
+			// AKS and GKE route the apiserver through konnectivity agents, so the admission call
+			// arrives with a pod source IP and would otherwise hit the deny below.
+			{
+				Action:   v3.Allow,
+				Protocol: &networkpolicy.TCPProtocol,
+				Source:   networkpolicy.KonnectivityAgentEntityRule,
+				Destination: v3.EntityRule{
+					Ports: networkpolicy.Ports(uint16(containerPort)),
+				},
+			},
+			// Only workload endpoints carry projectcalico.org/orchestrator, so a user-created
+			// NetworkSet can't match this deny. Traffic SNAT'd to a node tunnel address comes
+			// from the node, not a pod, and falls through.
 			{
 				Action: v3.Deny,
 				Source: v3.EntityRule{
@@ -279,6 +272,8 @@ func (c *component) Objects() ([]client.Object, []client.Object) {
 					Selector:          "has(projectcalico.org/orchestrator)",
 				},
 			},
+			// Catches node-sourced traffic, including a hostnet apiserver SNAT'd through an IPIP
+			// or VXLAN overlay, plus cluster-external sources routed to the pod.
 			{
 				Action:   v3.Allow,
 				Protocol: &networkpolicy.TCPProtocol,

--- a/pkg/render/webhooks/render_test.go
+++ b/pkg/render/webhooks/render_test.go
@@ -299,7 +299,7 @@ var _ = Describe("Webhooks rendering tests", func() {
 
 		// Verify the network policy.
 		np := rtest.GetResource(resources, webhooks.WebhooksPolicyName, common.CalicoNamespace, "projectcalico.org", "v3", "NetworkPolicy").(*v3.NetworkPolicy)
-		Expect(np.Spec.Ingress).To(HaveLen(3))
+		Expect(np.Spec.Ingress).To(HaveLen(4))
 
 		// Rule 1: Allow from kube-apiserver.
 		Expect(np.Spec.Ingress[0].Action).To(Equal(v3.Allow))
@@ -309,15 +309,20 @@ var _ = Describe("Webhooks rendering tests", func() {
 		}))
 		Expect(np.Spec.Ingress[0].Destination.Ports[0].MinPort).To(Equal(uint16(6443)))
 
-		// Rule 2: Deny from any workload endpoint (pod traffic); the orchestrator selector
-		// excludes NetworkSets so a user-defined set doesn't broaden or narrow the rule.
-		Expect(np.Spec.Ingress[1].Action).To(Equal(v3.Deny))
-		Expect(np.Spec.Ingress[1].Source.NamespaceSelector).To(Equal("all()"))
-		Expect(np.Spec.Ingress[1].Source.Selector).To(Equal("has(projectcalico.org/orchestrator)"))
+		// Rule 2: Allow from the konnectivity agents that proxy apiserver traffic on AKS and GKE.
+		Expect(np.Spec.Ingress[1].Action).To(Equal(v3.Allow))
+		Expect(np.Spec.Ingress[1].Source.NamespaceSelector).To(Equal("kubernetes.io/metadata.name == 'kube-system'"))
+		Expect(np.Spec.Ingress[1].Source.Selector).To(Equal("app == 'konnectivity-agent' || k8s-app == 'konnectivity-agent'"))
+		Expect(np.Spec.Ingress[1].Destination.Ports[0].MinPort).To(Equal(uint16(6443)))
 
-		// Rule 3: Fallback allow for non-pod sources (including tunnel-SNAT'd hostnet apiserver traffic).
-		Expect(np.Spec.Ingress[2].Action).To(Equal(v3.Allow))
-		Expect(np.Spec.Ingress[2].Destination.Ports[0].MinPort).To(Equal(uint16(6443)))
+		// Rule 3: Deny from any workload endpoint. The orchestrator selector excludes NetworkSets.
+		Expect(np.Spec.Ingress[2].Action).To(Equal(v3.Deny))
+		Expect(np.Spec.Ingress[2].Source.NamespaceSelector).To(Equal("all()"))
+		Expect(np.Spec.Ingress[2].Source.Selector).To(Equal("has(projectcalico.org/orchestrator)"))
+
+		// Rule 4: Fallback allow for non-pod sources (including tunnel-SNAT'd hostnet apiserver traffic).
+		Expect(np.Spec.Ingress[3].Action).To(Equal(v3.Allow))
+		Expect(np.Spec.Ingress[3].Destination.Ports[0].MinPort).To(Equal(uint16(6443)))
 	})
 
 	It("should use custom container port", func() {
@@ -355,12 +360,13 @@ var _ = Describe("Webhooks rendering tests", func() {
 
 		// Verify the network policy uses the custom port.
 		np := rtest.GetResource(resources, webhooks.WebhooksPolicyName, common.CalicoNamespace, "projectcalico.org", "v3", "NetworkPolicy").(*v3.NetworkPolicy)
-		Expect(np.Spec.Ingress).To(HaveLen(3))
+		Expect(np.Spec.Ingress).To(HaveLen(4))
 		Expect(np.Spec.Ingress[0].Destination.Ports[0].MinPort).To(Equal(uint16(customPort)))
-		Expect(np.Spec.Ingress[1].Action).To(Equal(v3.Deny))
-		Expect(np.Spec.Ingress[1].Source.NamespaceSelector).To(Equal("all()"))
-		Expect(np.Spec.Ingress[1].Source.Selector).To(Equal("has(projectcalico.org/orchestrator)"))
-		Expect(np.Spec.Ingress[2].Destination.Ports[0].MinPort).To(Equal(uint16(customPort)))
+		Expect(np.Spec.Ingress[1].Destination.Ports[0].MinPort).To(Equal(uint16(customPort)))
+		Expect(np.Spec.Ingress[2].Action).To(Equal(v3.Deny))
+		Expect(np.Spec.Ingress[2].Source.NamespaceSelector).To(Equal("all()"))
+		Expect(np.Spec.Ingress[2].Source.Selector).To(Equal("has(projectcalico.org/orchestrator)"))
+		Expect(np.Spec.Ingress[3].Destination.Ports[0].MinPort).To(Equal(uint16(customPort)))
 	})
 
 	It("should not use host network by default on non-EKS", func() {


### PR DESCRIPTION
Cherry-pick of https://github.com/tigera/operator/pull/5212 onto release-v1.44 for Calico v3.33. Picked clean, no conflicts.

```release-note
Fix Calico webhook admission requests being denied on clusters where the API server connects through konnectivity, including AKS and GKE.
```
