### PR TITLE
Panic when a guaranteed extension lookup misses

### DIFF
--- a/pkg/enterprise/apiserver/extension.go
+++ b/pkg/enterprise/apiserver/extension.go
@@ -393,13 +393,10 @@ func modifyAPIServer(ri render.Inputs, cfg *render.APIServerConfiguration, creat
 	// those objects back out of the delete list.
 	create, del = c.ensureDeployment(create, del)
 
-	if dep, ok := extensions.FindObject[*appsv1.Deployment](create, render.APIServerName); ok {
-		c.layerDeployment(dep)
-	}
-	if svc, ok := extensions.FindObject[*corev1.Service](create, render.APIServerServiceName); ok {
-		c.addServicePorts(svc)
-	}
-	// Enterprise serves staged policies through the tiered-policy passthrough role.
+	c.layerDeployment(extensions.MustFindObject[*appsv1.Deployment](create, render.APIServerName))
+	c.addServicePorts(extensions.MustFindObject[*corev1.Service](create, render.APIServerServiceName))
+	// Enterprise serves staged policies through the tiered-policy passthrough role, which
+	// the base only creates when running an aggregation API server.
 	if role, ok := extensions.FindObject[*rbacv1.ClusterRole](create, render.TieredPolicyPassthruClusterRoleName); ok {
 		for i := range role.Rules {
 			if slices.Contains(role.Rules[i].Resources, "networkpolicies") {
@@ -473,10 +470,8 @@ func modifyAPIServer(ri render.Inputs, cfg *render.APIServerConfiguration, creat
 	// Re-apply deployment overrides so the modifier-added query server container picks up
 	// any per-container overrides. The override appliers use replace/merge semantics, so
 	// re-running over the render-applied containers is idempotent.
-	if dep, ok := extensions.FindObject[*appsv1.Deployment](create, render.APIServerName); ok {
-		if overrides := c.cfg.APIServer.APIServerDeployment; overrides != nil {
-			rcomp.ApplyDeploymentOverrides(dep, overrides)
-		}
+	if overrides := c.cfg.APIServer.APIServerDeployment; overrides != nil {
+		rcomp.ApplyDeploymentOverrides(extensions.MustFindObject[*appsv1.Deployment](create, render.APIServerName), overrides)
 	}
 
 	return create, del

--- a/pkg/enterprise/clusterconnection/guardian.go
+++ b/pkg/enterprise/clusterconnection/guardian.go
@@ -198,17 +198,13 @@ func enterpriseGuardianPolicySpec(gpc *render.GuardianConfiguration) (v3.Network
 func modifyGuardian(ri render.Inputs, cfg *render.GuardianConfiguration, objs, del []client.Object) ([]client.Object, []client.Object) {
 	gc := guardianInputsFrom(cfg)
 
-	if role, ok := extensions.FindObject[*rbacv1.ClusterRole](objs, render.GuardianClusterRoleName); ok {
-		role.Rules = guardianEnterpriseRules(gc)
-	}
+	role := extensions.MustFindObject[*rbacv1.ClusterRole](objs, render.GuardianClusterRoleName)
+	role.Rules = guardianEnterpriseRules(gc)
 
-	if svc, ok := extensions.FindObject[*corev1.Service](objs, render.GuardianServiceName); ok {
-		svc.Spec.Ports = append(svc.Spec.Ports, guardianEnterpriseServicePorts()...)
-	}
+	svc := extensions.MustFindObject[*corev1.Service](objs, render.GuardianServiceName)
+	svc.Spec.Ports = append(svc.Spec.Ports, guardianEnterpriseServicePorts()...)
 
-	if dep, ok := extensions.FindObject[*appsv1.Deployment](objs, render.GuardianDeploymentName); ok {
-		addGuardianEnterpriseEnv(gc, dep)
-	}
+	addGuardianEnterpriseEnv(gc, extensions.MustFindObject[*appsv1.Deployment](objs, render.GuardianDeploymentName))
 
 	return append(objs,
 		guardianSecretsRole(),

--- a/pkg/enterprise/installation/kubecontrollers.go
+++ b/pkg/enterprise/installation/kubecontrollers.go
@@ -106,6 +106,7 @@ func modifyKubeControllersPolicy(ri render.Inputs, objs, del []client.Object) ([
 func modifyKubeControllers(ri render.Inputs, objs, del []client.Object) ([]client.Object, []client.Object) {
 	data := installationData(ri)
 
+	// Nothing is created while the installation is terminating.
 	if role, ok := extensions.FindObject[*rbacv1.ClusterRole](objs, kubecontrollers.KubeControllerRole); ok {
 		role.Rules = append(role.Rules, data.kubeControllerRules...)
 	}
@@ -120,6 +121,7 @@ func modifyKubeControllers(ri render.Inputs, objs, del []client.Object) ([]clien
 		))
 	}
 
+	// The deployment is queued for deletion, not created, when no controllers are enabled.
 	if dp, ok := extensions.FindObject[*appsv1.Deployment](objs, kubecontrollers.KubeController); ok {
 		modifyKubeControllersDeployment(ri, dp, data)
 	}

--- a/pkg/enterprise/installation/node.go
+++ b/pkg/enterprise/installation/node.go
@@ -49,19 +49,18 @@ const (
 // daemonset configuration (flow/DNS log env, prometheus reporter, BGP metrics
 // readiness check, multi-interface mode, and the calico log volume).
 func modifyNode(ri render.Inputs, objs, del []client.Object) ([]client.Object, []client.Object) {
-	if role, ok := extensions.FindObject[*rbacv1.ClusterRole](objs, render.CalicoNodeObjectName); ok {
-		role.Rules = append(role.Rules, nodeEnterpriseRules()...)
-	}
+	role := extensions.MustFindObject[*rbacv1.ClusterRole](objs, render.CalicoNodeObjectName)
+	role.Rules = append(role.Rules, nodeEnterpriseRules()...)
 
 	// The Network resource is only available in Enterprise / Cloud at this time.
-	if role, ok := extensions.FindObject[*rbacv1.ClusterRole](objs, render.CalicoCNIPluginObjectName); ok {
-		role.Rules = append(role.Rules, rbacv1.PolicyRule{
-			APIGroups: []string{"projectcalico.org", "crd.projectcalico.org"},
-			Resources: []string{"networks"},
-			Verbs:     []string{"get"},
-		})
-	}
+	cni := extensions.MustFindObject[*rbacv1.ClusterRole](objs, render.CalicoCNIPluginObjectName)
+	cni.Rules = append(cni.Rules, rbacv1.PolicyRule{
+		APIGroups: []string{"projectcalico.org", "crd.projectcalico.org"},
+		Resources: []string{"networks"},
+		Verbs:     []string{"get"},
+	})
 
+	// The daemonset is queued for deletion, not created, while the CNI finalizer is being removed.
 	if ds, ok := extensions.FindObject[*appsv1.DaemonSet](objs, common.NodeDaemonSetName); ok {
 		modifyNodeDaemonSet(ri, ds)
 	}

--- a/pkg/enterprise/installation/typha.go
+++ b/pkg/enterprise/installation/typha.go
@@ -26,22 +26,21 @@ import (
 )
 
 func modifyTypha(ri render.Inputs, cfg *render.TyphaConfiguration, objs, del []client.Object) ([]client.Object, []client.Object) {
-	if role, ok := extensions.FindObject[*rbacv1.ClusterRole](objs, render.TyphaClusterRoleName); ok {
-		role.Rules = append(role.Rules, rbacv1.PolicyRule{
-			APIGroups: []string{"projectcalico.org", "crd.projectcalico.org"},
-			Resources: []string{
-				"bfdconfigurations",
-				"deeppacketinspections",
-				"egressgatewaypolicies",
-				"externalnetworks",
-				"licensekeys",
-				"networks",
-				"packetcaptures",
-				"remoteclusterconfigurations",
-			},
-			Verbs: []string{"get", "list", "watch"},
-		})
-	}
+	role := extensions.MustFindObject[*rbacv1.ClusterRole](objs, render.TyphaClusterRoleName)
+	role.Rules = append(role.Rules, rbacv1.PolicyRule{
+		APIGroups: []string{"projectcalico.org", "crd.projectcalico.org"},
+		Resources: []string{
+			"bfdconfigurations",
+			"deeppacketinspections",
+			"egressgatewaypolicies",
+			"externalnetworks",
+			"licensekeys",
+			"networks",
+			"packetcaptures",
+			"remoteclusterconfigurations",
+		},
+		Verbs: []string{"get", "list", "watch"},
+	})
 
 	if data := installationData(ri).nonClusterHost; data.enabled {
 		objs = addNonClusterHostTypha(cfg, data, objs)
@@ -52,6 +51,7 @@ func modifyTypha(ri render.Inputs, cfg *render.TyphaConfiguration, objs, del []c
 	net := ri.Installation.CalicoNetwork
 	if net != nil && net.MultiInterfaceMode != nil {
 		for _, name := range []string{common.TyphaDeploymentName, common.TyphaDeploymentName + render.TyphaNonClusterHostSuffix} {
+			// The non-cluster-host deployment only renders when that feature is enabled.
 			dep, ok := extensions.FindObject[*appsv1.Deployment](objs, name)
 			if !ok {
 				continue

--- a/pkg/enterprise/windows/extension.go
+++ b/pkg/enterprise/windows/extension.go
@@ -124,9 +124,7 @@ func (e *Extension) ExtendInputs(ctx context.Context, ci controller.Inputs) (con
 // daemonset configuration (flow/DNS log env, prometheus reporter, trusted DNS
 // servers, the calico log volume, and the prometheus reporter keypair mount).
 func modifyWindows(ri render.Inputs, objs, del []client.Object) ([]client.Object, []client.Object) {
-	if ds, ok := extensions.FindObject[*appsv1.DaemonSet](objs, common.WindowsDaemonSetName); ok {
-		modifyWindowsDaemonSet(ri, ds)
-	}
+	modifyWindowsDaemonSet(ri, extensions.MustFindObject[*appsv1.DaemonSet](objs, common.WindowsDaemonSetName))
 
 	return append(objs, windowsNodeMetricsService(ri)), del
 }


### PR DESCRIPTION
Follow-up to the review comment on #5164, converting the extension lookups that cannot miss to the panicking `MustFindObject`, so a base render that stops producing an object fails loudly instead of silently skipping the Enterprise layering. Stacked on #5206, which adds `MustFindObject` itself, so review that one first.

Most of the remaining lookups are staying as `if ok` because the object may not be there - the calico/node daemonset moves to the delete list while the CNI finalizer is being removed, kube-controllers renders nothing while terminating, the tiered-policy passthrough role only exists with an aggregation API server, and the non-cluster-host typha deployment is optional. Those each carry a comment now saying so.

Related: [CORE-13395](https://tigera.atlassian.net/browse/CORE-13395)

## Release Note

```release-note
None
```



[CORE-13395]: https://tigera.atlassian.net/browse/CORE-13395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ