### PR TITLE
Skip the Installation finalizer write when nothing changed

### DIFF
--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -923,7 +923,14 @@ func MaintainInstallationFinalizer(
 
 	// Determine the correct finalizers to apply to the Installation.
 	if mainResource != nil {
-		// Add a finalizer indicating that the mainResource is still available.
+		// Add a finalizer indicating that the mainResource is still available. We can skip this if the
+		// finalizer is already present: the optimistic lock above makes an otherwise empty patch fail
+		// whenever another writer has touched the Installation, degrading the controller over a write
+		// that had nothing to change.
+		if stringsutil.StringInSlice(finalizer, installation.GetFinalizers()) {
+			log.V(2).Info("Finalizer already present, skipping update", "finalizer", finalizer)
+			return true, nil
+		}
 		SetInstallationFinalizer(installation, finalizer)
 		finalizerSet = true
 	} else {

--- a/pkg/controller/utils/utils_test.go
+++ b/pkg/controller/utils/utils_test.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -543,5 +544,115 @@ var _ = Describe("WaitToAddResourceWatch with custom predicates", func() {
 
 		Expect(flag.IsReady()).To(BeTrue())
 		ctrl.AssertNumberOfCalls(GinkgoT(), "WatchObject", 2)
+	})
+})
+
+var _ = Describe("MaintainInstallationFinalizer", func() {
+	const otherFinalizer = "example.com/another-controller"
+
+	var (
+		ctx     context.Context
+		scheme  *runtime.Scheme
+		patches int
+	)
+
+	countPatches := func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+		if _, ok := obj.(*opv1.Installation); ok {
+			patches++
+		}
+		return c.Patch(ctx, obj, patch, opts...)
+	}
+
+	installWith := func(finalizers ...string) *opv1.Installation {
+		return &opv1.Installation{
+			ObjectMeta: metav1.ObjectMeta{Name: "default", Finalizers: finalizers},
+		}
+	}
+
+	newClient := func(install *opv1.Installation, funcs interceptor.Funcs) client.Client {
+		funcs.Patch = countPatches
+		return ctrlrfake.DefaultFakeClientBuilder(scheme).
+			WithObjects(install).
+			WithInterceptorFuncs(funcs).
+			Build()
+	}
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		scheme = runtime.NewScheme()
+		Expect(apis.AddToScheme(scheme, false)).ShouldNot(HaveOccurred())
+		Expect(corev1.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+		Expect(apps.SchemeBuilder.AddToScheme(scheme)).ShouldNot(HaveOccurred())
+		patches = 0
+	})
+
+	It("does not write the Installation when the finalizer is already present", func() {
+		c := newClient(installWith(render.WhiskerFinalizer), interceptor.Funcs{})
+
+		set, err := MaintainInstallationFinalizer(ctx, c, &apps.Deployment{}, render.WhiskerFinalizer)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(set).To(BeTrue())
+		Expect(patches).To(BeZero())
+	})
+
+	It("does not fail when another writer updates the Installation and no finalizer changed", func() {
+		bumped := false
+		// Stand in for a second controller writing the Installation between our read and our write.
+		funcs := interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if err := c.Get(ctx, key, obj, opts...); err != nil {
+					return err
+				}
+				if _, ok := obj.(*opv1.Installation); !ok || bumped {
+					return nil
+				}
+				bumped = true
+				other := &opv1.Installation{}
+				Expect(c.Get(ctx, key, other)).ShouldNot(HaveOccurred())
+				other.Labels = map[string]string{"written-by": "someone-else"}
+				return c.Update(ctx, other)
+			},
+		}
+		c := newClient(installWith(render.WhiskerFinalizer), funcs)
+
+		set, err := MaintainInstallationFinalizer(ctx, c, &apps.Deployment{}, render.WhiskerFinalizer)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(set).To(BeTrue())
+		Expect(patches).To(BeZero())
+	})
+
+	It("adds the finalizer when it is missing, keeping the ones it does not own", func() {
+		c := newClient(installWith(otherFinalizer), interceptor.Funcs{})
+
+		set, err := MaintainInstallationFinalizer(ctx, c, &apps.Deployment{}, render.WhiskerFinalizer)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(set).To(BeTrue())
+		Expect(patches).To(Equal(1))
+
+		updated := &opv1.Installation{}
+		Expect(c.Get(ctx, DefaultInstanceKey, updated)).ShouldNot(HaveOccurred())
+		Expect(updated.GetFinalizers()).To(ConsistOf(otherFinalizer, render.WhiskerFinalizer))
+	})
+
+	It("removes the finalizer once the main resource is gone", func() {
+		c := newClient(installWith(otherFinalizer, render.WhiskerFinalizer), interceptor.Funcs{})
+
+		set, err := MaintainInstallationFinalizer(ctx, c, nil, render.WhiskerFinalizer)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(set).To(BeFalse())
+		Expect(patches).To(Equal(1))
+
+		updated := &opv1.Installation{}
+		Expect(c.Get(ctx, DefaultInstanceKey, updated)).ShouldNot(HaveOccurred())
+		Expect(updated.GetFinalizers()).To(ConsistOf(otherFinalizer))
+	})
+
+	It("does not write the Installation when the finalizer is already absent", func() {
+		c := newClient(installWith(otherFinalizer), interceptor.Funcs{})
+
+		set, err := MaintainInstallationFinalizer(ctx, c, nil, render.WhiskerFinalizer)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(set).To(BeFalse())
+		Expect(patches).To(BeZero())
 	})
 })


### PR DESCRIPTION
This PR proposes skipping the `Installation` finalizer write when the finalizer is already present, so a steady-state reconcile stops issuing an optimistic-lock patch that has nothing to change and can only fail (Fixes #4999). We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/402. You can sign in with your GitHub ID to claim ownership of the project.

## Description

This is a bug fix in `pkg/controller/utils`, affecting every controller that maintains a finalizer on the `Installation`: whisker, goldmane, apiserver, gatewayapi and clusterconnection.

`MaintainInstallationFinalizer` reads the `Installation`, captures a patch base with `client.MergeFromWithOptimisticLock{}`, and then patches unconditionally — including the ordinary case where the controller's finalizer is already in the list and nothing needs writing. The optimistic lock means that patch is never an empty no-op: `mergeFromPatch.Data` always writes `metadata.resourceVersion` into the body, so the request goes to the apiserver every time. That happens on every reconcile of each of those controllers — at minimum once per `PeriodicReconcileTime` (5 minutes) each, and again on every watch event.

Because each of those writes carries a resourceVersion precondition, any other writer touching the `Installation` between the read and the write turns a request that had nothing to change into a `409`. The callers do not treat that as benign: it becomes `SetDegraded(ResourceReadError, "Error setting finalizer on Installation", ...)`, which is the error reported in #4999 for a cluster where Argo CD also writes the object.

The removal path already guards against precisely this — it returns early when the finalizer is not present, rather than writing to discover there was nothing to do. This change adds the mirror-image guard on the add path, so the write only happens when the finalizer list actually changes.

### Reproducing on master

The five specs added here run against `pkg/controller/utils`. On `master` at 5615c1ab5, two of them fail:

```
$ go test ./pkg/controller/utils/ -args -ginkgo.focus="MaintainInstallationFinalizer"

Summarizing 2 Failures:
  [FAIL] MaintainInstallationFinalizer [It] does not write the Installation when the finalizer is already present
  [FAIL] MaintainInstallationFinalizer [It] does not fail when another writer updates the Installation and no finalizer changed

Ran 5 of 446 Specs in 0.107 seconds
FAIL! -- 3 Passed | 2 Failed | 0 Pending | 441 Skipped
```

The second failure reproduces the reported symptom exactly, with the apiserver's own wording:

```
[FAILED] Unexpected error:
    Operation cannot be fulfilled on installations.operator.tigera.io "default": object was modified
    Reason: "Conflict",
    Code: 409,
```

The three specs that pass on both trees are the controls: the finalizer is still added when it is missing, finalizers owned by other controllers are still preserved alongside it, and the finalizer is still removed once the main resource is gone. They are there so the guard cannot pass by simply doing less work.

### Testing

Automated only; I have no cluster reproduction of the Argo CD setup in #4999, so the concurrent writer is modelled with an interceptor that updates the `Installation` between the read and the write.

With the change applied, all five specs pass. The wider suite was run before and after the change with no new failures — `go test ./pkg/...` is green across 98 packages, using envtest assets from `setup-envtest use 1.34.x` to match the `ut` target (without them the `Installation` CEL validation specs fail in `BeforeEach` on a missing control plane, before and after alike).

One thing worth being explicit about: this does not make finalizer writes conflict-proof. A genuine first-time add can still lose the optimistic lock if another writer lands at the same instant, and that path is deliberately unchanged — it has something real to write, and it retries on the next reconcile. What goes away is the steady-state write that recurs for the life of the cluster, which is the one behind a recurring error.

## Release Note

```release-note
Stop rewriting the Installation resource on every reconcile when the controller's finalizer is already present, which could surface as a spurious "Error setting finalizer on Installation" degraded status on clusters where another controller also writes the Installation.
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files` — not changed.
- [ ] If changing versions, run `make gen-versions` — not changed.

## How this was managed

This work was tracked on a board imported from this repository's own issues and pull requests — 5,202 stories, with release milestones as epics. The story for this fix is [`Error setting finalizer on Installation` errors in operator logs](https://eastagiletracker.com/projects/402/stories/336302), on the board at https://eastagiletracker.com/projects/402.

![board](https://raw.githubusercontent.com/eastagiletracker/operator/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
