### PR TITLE
Move Enterprise-only kube-controllers settings to an Enterprise configuration

### DIFF
--- a/pkg/controller/logstorage/kubecontrollers/cloud.go
+++ b/pkg/controller/logstorage/kubecontrollers/cloud.go
@@ -21,8 +21,8 @@ import (
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/controller/utils"
+	entkubecontrollers "github.com/tigera/operator/pkg/enterprise/kubecontrollers"
 	eutils "github.com/tigera/operator/pkg/enterprise/utils"
-	"github.com/tigera/operator/pkg/render/kubecontrollers"
 	"github.com/tigera/operator/pkg/render/logstorage"
 	"github.com/tigera/operator/pkg/render/logstorage/esgateway"
 	corev1 "k8s.io/api/core/v1"
@@ -69,8 +69,8 @@ func (r *ESKubeControllersController) esGatewayAddCloudModificationsToConfig(c *
 	return true, nil
 }
 
-// esKubeControllersAddCloudModificationsToConfig modifies the provided *kubecontrollers.KubeControllersConfiguration to include Calico Cloud specific configuration.
-func (r *ESKubeControllersController) esKubeControllersAddCloudModificationsToConfig(c *kubecontrollers.KubeControllersConfiguration, reqLogger logr.Logger, ctx context.Context) (reconcile.Result, bool, error) {
+// esKubeControllersAddCloudModificationsToConfig modifies the provided *entkubecontrollers.Configuration to include Calico Cloud specific configuration.
+func (r *ESKubeControllersController) esKubeControllersAddCloudModificationsToConfig(c *entkubecontrollers.Configuration, reqLogger logr.Logger, ctx context.Context) (reconcile.Result, bool, error) {
 	if r.cloud && r.elasticExternal && !r.multiTenant {
 		cloudConfig, err := eutils.GetCloudConfig(ctx, r.client)
 		if err != nil {

--- a/pkg/controller/logstorage/kubecontrollers/es_kube_controllers.go
+++ b/pkg/controller/logstorage/kubecontrollers/es_kube_controllers.go
@@ -348,22 +348,25 @@ func (r *ESKubeControllersController) Reconcile(ctx context.Context, request rec
 		K8sServiceEp:                 k8sapi.Endpoint,
 		K8sServiceEpPodNetwork:       k8sapi.PodNetworkEndpoint,
 		Installation:                 installationSpec,
-		ManagementCluster:            managementCluster,
 		ClusterDomain:                r.clusterDomain,
 		Authentication:               authentication,
 		KubeControllersGatewaySecret: kubeControllersUserSecret,
 		TrustedBundle:                trustedBundle,
 		Namespace:                    helper.InstallNamespace(),
 		BindingNamespaces:            namespaces,
+	}
+	esKubeControllersCfg := entkubecontrollers.Configuration{
+		KubeControllersConfiguration: &kubeControllersCfg,
+		ManagementCluster:            managementCluster,
 		Tenant:                       nil,
 		Cloud:                        r.cloud,
 	}
 	if r.cloud {
-		if result, proceed, err := r.esKubeControllersAddCloudModificationsToConfig(&kubeControllersCfg, reqLogger, ctx); err != nil || !proceed {
+		if result, proceed, err := r.esKubeControllersAddCloudModificationsToConfig(&esKubeControllersCfg, reqLogger, ctx); err != nil || !proceed {
 			return result, err
 		}
 	}
-	esKubeControllerComponents := entkubecontrollers.NewElasticsearchKubeControllers(&kubeControllersCfg)
+	esKubeControllerComponents := entkubecontrollers.NewElasticsearchKubeControllers(&esKubeControllersCfg)
 
 	imageSet, err := imageset.GetImageSet(ctx, r.client, r.variant)
 	if err != nil {

--- a/pkg/enterprise/kubecontrollers/config.go
+++ b/pkg/enterprise/kubecontrollers/config.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubecontrollers
+
+import (
+	operatorv1 "github.com/tigera/operator/api/v1"
+	rkc "github.com/tigera/operator/pkg/render/kubecontrollers"
+)
+
+// Configuration is the es-calico-kube-controllers input. The embedded generic
+// configuration is what the base renderer reads; the fields here are the ones only
+// this assembler consumes.
+type Configuration struct {
+	*rkc.KubeControllersConfiguration
+
+	ManagementCluster           *operatorv1.ManagementCluster
+	ManagementClusterConnection *operatorv1.ManagementClusterConnection
+
+	// Tenant configures both single and multi-tenant modes. Nil means zero-tenant.
+	Tenant *operatorv1.Tenant
+
+	// TenantID is the Calico Cloud tenant, read only when Tenant is nil.
+	TenantID string
+
+	// Cloud reports whether this is a Calico Cloud install.
+	Cloud bool
+}

--- a/pkg/enterprise/kubecontrollers/es_kube_controllers_test.go
+++ b/pkg/enterprise/kubecontrollers/es_kube_controllers_test.go
@@ -46,7 +46,7 @@ var _ = Describe("es-kube-controllers rendering tests", func() {
 	var (
 		instance     *operatorv1.InstallationSpec
 		k8sServiceEp k8sapi.ServiceEndpoint
-		cfg          rkc.KubeControllersConfiguration
+		cfg          Configuration
 		cli          client.Client
 	)
 
@@ -104,14 +104,16 @@ var _ = Describe("es-kube-controllers rendering tests", func() {
 		certificateManager, err := certificatemanager.Create(cli, nil, dns.DefaultClusterDomain, common.OperatorNamespace(), certificatemanager.AllowCACreation())
 		Expect(err).NotTo(HaveOccurred())
 
-		cfg = rkc.KubeControllersConfiguration{
-			K8sServiceEp:      k8sServiceEp,
-			Installation:      instance,
-			ClusterDomain:     dns.DefaultClusterDomain,
-			MetricsPort:       9094,
-			TrustedBundle:     certificateManager.CreateTrustedBundle(),
-			Namespace:         common.CalicoNamespace,
-			BindingNamespaces: []string{common.CalicoNamespace},
+		cfg = Configuration{
+			KubeControllersConfiguration: &rkc.KubeControllersConfiguration{
+				K8sServiceEp:      k8sServiceEp,
+				Installation:      instance,
+				ClusterDomain:     dns.DefaultClusterDomain,
+				MetricsPort:       9094,
+				TrustedBundle:     certificateManager.CreateTrustedBundle(),
+				Namespace:         common.CalicoNamespace,
+				BindingNamespaces: []string{common.CalicoNamespace},
+			},
 		}
 	})
 

--- a/pkg/enterprise/kubecontrollers/kubecontrollers.go
+++ b/pkg/enterprise/kubecontrollers/kubecontrollers.go
@@ -51,7 +51,7 @@ const (
 // component. es-kube-controllers is a distinct deployment (talks to Elasticsearch via
 // es-gateway) reconciled by the logstorage kube-controllers controller, so it's
 // assembled here rather than through the render-time modifier mechanism.
-func NewElasticsearchKubeControllers(cfg *rkc.KubeControllersConfiguration) render.Component {
+func NewElasticsearchKubeControllers(cfg *Configuration) render.Component {
 	cfg.Name = EsKubeController
 	cfg.ConfigName = "elasticsearch"
 	cfg.RoleName = EsKubeControllerRole
@@ -59,7 +59,7 @@ func NewElasticsearchKubeControllers(cfg *rkc.KubeControllersConfiguration) rend
 	cfg.MetricsName = EsKubeControllerMetrics
 	cfg.DisableConfigAPI = cfg.Tenant.MultiTenant()
 
-	cfg.Rules = rkc.KubeControllersRoleCommonRules(cfg)
+	cfg.Rules = rkc.KubeControllersRoleCommonRules(cfg.KubeControllersConfiguration)
 	cfg.Rules = append(cfg.Rules, KubeControllersEnterpriseCommonRules(false, cfg.ManagementClusterConnection != nil)...)
 	// Calico Cloud's es-kube-controllers provisions RBAC for managed-cluster access, so it needs to
 	// create and update cluster roles and bindings. Enterprise only reads them.
@@ -101,11 +101,11 @@ func NewElasticsearchKubeControllers(cfg *rkc.KubeControllersConfiguration) rend
 	cfg.DeprecatedNetworkPolicyName = "es-kube-controller-access"
 	cfg.ExtraEnv = esKubeControllersEnv(cfg)
 
-	return rkc.NewKubeControllers(cfg)
+	return rkc.NewKubeControllers(cfg.KubeControllersConfiguration)
 }
 
 // esKubeControllersEnv builds the enterprise env vars for es-calico-kube-controllers.
-func esKubeControllersEnv(cfg *rkc.KubeControllersConfiguration) []corev1.EnvVar {
+func esKubeControllersEnv(cfg *Configuration) []corev1.EnvVar {
 	var env []corev1.EnvVar
 
 	if cfg.Tenant != nil {
@@ -305,7 +305,7 @@ func wafRules() []rbacv1.PolicyRule {
 	}
 }
 
-func esKubeControllersCalicoSystemPolicy(cfg *rkc.KubeControllersConfiguration) *v3.NetworkPolicy {
+func esKubeControllersCalicoSystemPolicy(cfg *Configuration) *v3.NetworkPolicy {
 	if cfg.ManagementClusterConnection != nil {
 		return nil
 	}

--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -72,11 +72,6 @@ type KubeControllersConfiguration struct {
 	Installation   *operatorv1.InstallationSpec
 	Authentication *operatorv1.Authentication
 
-	// ManagementCluster and ManagementClusterConnection are inputs for the enterprise
-	// es-kube-controllers assembler. No base rendering reads them.
-	ManagementCluster           *operatorv1.ManagementCluster
-	ManagementClusterConnection *operatorv1.ManagementClusterConnection
-
 	// ManagedClusterWatchBinding binds kube-controllers to the managed-cluster watch
 	// ClusterRole. The assemblers set it; multi-cluster management is not a core feature.
 	ManagedClusterWatchBinding bool
@@ -93,13 +88,6 @@ type KubeControllersConfiguration struct {
 	KubeControllersGatewaySecret *corev1.Secret
 	TrustedBundle                certificatemanagement.TrustedBundleRO
 
-	// TenantID is the Calico Cloud tenant. Only the enterprise assembler consumes it.
-	TenantID string
-
-	// Cloud reports whether this is a Calico Cloud install. Only the enterprise
-	// es-kube-controllers assembler consumes it.
-	Cloud bool
-
 	// ImageOverrides lets a variant swap the kube-controllers image. The controller
 	// wires in the operator's image overrides; nil resolves to the core image.
 	ImageOverrides *imageoverride.Overrides
@@ -109,10 +97,6 @@ type KubeControllersConfiguration struct {
 
 	// List of namespaces that are running a kube-controllers instance that need a cluster role binding.
 	BindingNamespaces []string
-
-	// Tenant object provides tenant configuration for both single and multi-tenant modes.
-	// If this is nil, then we should run in zero-tenant mode.
-	Tenant *operatorv1.Tenant
 
 	// The fields below parameterize the generic kube-controllers component. The
 	// variant assemblers (NewCalicoKubeControllers, the enterprise es builder)

--- a/pkg/render/kubecontrollers/kube-controllers_test.go
+++ b/pkg/render/kubecontrollers/kube-controllers_test.go
@@ -704,11 +704,6 @@ var _ = Describe("kube-controllers rendering tests", func() {
 				} else {
 					cfg.Installation.KubernetesProvider = operatorv1.ProviderNone
 				}
-				if scenario.ManagedCluster {
-					cfg.ManagementClusterConnection = &operatorv1.ManagementClusterConnection{}
-				} else {
-					cfg.ManagementClusterConnection = nil
-				}
 				instance.Variant = operatorv1.CalicoEnterprise
 				defaultDenyPolicy := &v3.NetworkPolicy{
 					ObjectMeta: metav1.ObjectMeta{

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -96,14 +96,12 @@ func allCalicoComponents(
 		FelixHealthPort:   9099,
 	}
 	kcCfg := &kubecontrollers.KubeControllersConfiguration{
-		K8sServiceEp:                k8sServiceEp,
-		Installation:                cr,
-		ManagementCluster:           managementCluster,
-		ManagementClusterConnection: managementClusterConnection,
-		ClusterDomain:               clusterDomain,
-		MetricsPort:                 kubeControllersMetricsPort,
-		Namespace:                   common.CalicoNamespace,
-		BindingNamespaces:           []string{common.CalicoNamespace},
+		K8sServiceEp:      k8sServiceEp,
+		Installation:      cr,
+		ClusterDomain:     clusterDomain,
+		MetricsPort:       kubeControllersMetricsPort,
+		Namespace:         common.CalicoNamespace,
+		BindingNamespaces: []string{common.CalicoNamespace},
 	}
 
 	winCfg := &render.WindowsConfiguration{


### PR DESCRIPTION
## Description

Another variant-gating split. The kube-controllers configuration the base render reads is generic again; the management cluster, tenant, and Calico Cloud settings now live on an Enterprise-only configuration that wraps it.

No behavior change. The base render read none of the five settings that moved, and the Enterprise assembler is the only thing that ever set them.

One thing worth flagging for review: the managed cluster connection setting is never populated by any caller today, so the managed cluster permission and policy branches in the Enterprise assembler are unreachable. Moved it as-is rather than deleting it.

Follow-on from #5189.

Related: [CORE-13395](https://tigera.atlassian.net/browse/CORE-13395)

```release-note
None
```



[CORE-13395]: https://tigera.atlassian.net/browse/CORE-13395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ