### PR TITLE
Move multi-tenant certificate manager behavior to an Enterprise package

### DIFF
--- a/pkg/controller/certificatemanager/certificatemanager.go
+++ b/pkg/controller/certificatemanager/certificatemanager.go
@@ -70,7 +70,9 @@ type certificateManager struct {
 	*crypto.CA
 	keyPair *certificatemanagement.KeyPair
 	log     logr.Logger
-	tenant  *operatorv1.Tenant
+
+	// caSecretName is the secret holding the CA this instance signs with.
+	caSecretName string
 
 	// Controls whether this instance of the certificate manager is allowed to
 	// create new CAs. Most instances should simply read the existing CA and use it to sign
@@ -103,9 +105,6 @@ type CertificateManager interface {
 	// - A bundle with Calico's root certificates + any user supplied certificates in /etc/pki/tls/certs/tigera-ca-bundle.crt.
 	// - A system root certificate bundle in /etc/pki/tls/certs/ca-bundle.crt.
 	CreateTrustedBundleWithSystemRootCertificates(certificates ...certificatemanagement.CertificateInterface) (certificatemanagement.TrustedBundle, error)
-	// CreateMultiTenantTrustedBundleWithSystemRootCertificates is an alternative to CreateTrustedBundleWithSystemRootCertificates that is appropriate for
-	// multi-tenant management clusters.
-	CreateMultiTenantTrustedBundleWithSystemRootCertificates(certificates ...certificatemanagement.CertificateInterface) (certificatemanagement.TrustedBundle, error)
 	// AddToStatusManager lets the status manager monitor pending CSRs if the certificate management is enabled.
 	AddToStatusManager(manager status.StatusManager, namespace string)
 	// KeyPair Returns the CA KeyPairInterface, so it can be rendered in the operator namespace.
@@ -113,8 +112,6 @@ type CertificateManager interface {
 	// LoadTrustedBundle loads an existing trusted bundle to pass to render.
 	LoadTrustedBundle(context.Context, client.Client, string) (certificatemanagement.TrustedBundleRO, error)
 	LoadNamedTrustedBundle(context.Context, client.Client, string, string) (certificatemanagement.TrustedBundleRO, error)
-	// LoadMultiTenantTrustedBundleWithRootCertificates loads an existing trusted bundle with system root certificates to pass to render.
-	LoadMultiTenantTrustedBundleWithRootCertificates(context.Context, client.Client, string) (certificatemanagement.TrustedBundleRO, error)
 	// SignCertificate signs a certificate using the certificate manager's private key. The function is assuming that the
 	// public key of the requestor is already set in the certificate template.
 	SignCertificate(certificate *x509.Certificate) ([]byte, error)
@@ -138,9 +135,11 @@ func WithLogger(log logr.Logger) Option {
 	}
 }
 
-func WithTenant(t *operatorv1.Tenant) Option {
+// WithCASecretName overrides the secret the CA is read from. Callers that manage more
+// than one CA in a cluster use this to keep them apart.
+func WithCASecretName(name string) Option {
 	return func(cm *certificateManager) error {
-		cm.tenant = t
+		cm.caSecretName = name
 		return nil
 	}
 }
@@ -160,20 +159,13 @@ func Create(cli client.Client, installation *operatorv1.InstallationSpec, cluste
 
 	// Create a certificatemanager instance and apply any user-provided options to
 	// initialize it.
-	cm := &certificateManager{log: log}
+	cm := &certificateManager{log: log, caSecretName: certificatemanagement.CASecretName}
 	for _, opt := range opts {
 		if err := opt(cm); err != nil {
 			return nil, err
 		}
 	}
 	cm.log.V(2).Info("Creating CertificateManager in namespace", "ns", ns)
-
-	// Determine the name of the CA secret to use. Default to the tigera CA name. For
-	// per-tenant CA secrets, we use a different name for differentiation.
-	caSecretName := certificatemanagement.CASecretName
-	if cm.tenant.MultiTenant() {
-		caSecretName = certificatemanagement.TenantCASecretName
-	}
 
 	var certificateManagementEnabled bool
 	if installation != nil {
@@ -198,9 +190,9 @@ func Create(cli client.Client, installation *operatorv1.InstallationSpec, cluste
 
 	if !certificateManagementEnabled {
 		// Using operator-managed certificates. Check to see if we have already provisioned a CA.
-		cm.log.V(2).Info("Looking for an existing CA", "secret", fmt.Sprintf("%s/%s", ns, caSecretName))
+		cm.log.V(2).Info("Looking for an existing CA", "secret", fmt.Sprintf("%s/%s", ns, cm.caSecretName))
 		caSecret := &corev1.Secret{}
-		k := types.NamespacedName{Name: caSecretName, Namespace: ns}
+		k := types.NamespacedName{Name: cm.caSecretName, Namespace: ns}
 		if err = cli.Get(context.Background(), k, caSecret); err != nil && !kerrors.IsNotFound(err) {
 			return nil, err
 		} else if kerrors.IsNotFound(err) {
@@ -214,7 +206,7 @@ func Create(cli client.Client, installation *operatorv1.InstallationSpec, cluste
 			if !cm.allowCACreation {
 				// Most controllers should NOT allow CA creation. For single-tenant, this is handled at cluster startup by the secret controller.
 				// For multi-tenant clusters, each tenant has its own CA that is created by the tenant controller.
-				return nil, fmt.Errorf("CA secret %s/%s does not exist yet and is not allowed for this call", ns, caSecretName)
+				return nil, fmt.Errorf("CA secret %s/%s does not exist yet and is not allowed for this call", ns, cm.caSecretName)
 			}
 			// No existing CA data - we need to generate a new one.
 			cm.log.Info("Generating a new CA", "namespace", ns)
@@ -262,7 +254,7 @@ func Create(cli client.Client, installation *operatorv1.InstallationSpec, cluste
 	cm.CA = cryptoCA
 	cm.Certificate = x509Cert
 	cm.keyPair = &certificatemanagement.KeyPair{
-		Name:                  caSecretName,
+		Name:                  cm.caSecretName,
 		Namespace:             ns,
 		PrivateKey:            privateKey,
 		PrivateKeyPEM:         privateKeyPEM,
@@ -607,20 +599,12 @@ func (cm *certificateManager) CreateTrustedBundleWithSystemRootCertificates(cert
 	return certificatemanagement.CreateTrustedBundleWithSystemRootCertificates(cm.keyPair, certificates...)
 }
 
-func (cm *certificateManager) CreateMultiTenantTrustedBundleWithSystemRootCertificates(certificates ...certificatemanagement.CertificateInterface) (certificatemanagement.TrustedBundle, error) {
-	return certificatemanagement.CreateMultiTenantTrustedBundleWithSystemRootCertificates(cm.keyPair, certificates...)
-}
-
 func (cm *certificateManager) LoadNamedTrustedBundle(ctx context.Context, client client.Client, ns, name string) (certificatemanagement.TrustedBundleRO, error) {
 	return cm.loadTrustedBundle(ctx, client, ns, name)
 }
 
 func (cm *certificateManager) LoadTrustedBundle(ctx context.Context, client client.Client, ns string) (certificatemanagement.TrustedBundleRO, error) {
 	return cm.loadTrustedBundle(ctx, client, ns, certificatemanagement.TrustedCertConfigMapName)
-}
-
-func (cm *certificateManager) LoadMultiTenantTrustedBundleWithRootCertificates(ctx context.Context, client client.Client, ns string) (certificatemanagement.TrustedBundleRO, error) {
-	return cm.loadTrustedBundle(ctx, client, ns, certificatemanagement.TrustedCertConfigMapNamePublic)
 }
 
 func (cm *certificateManager) loadTrustedBundle(ctx context.Context, client client.Client, ns string, name string) (certificatemanagement.TrustedBundleRO, error) {
@@ -633,8 +617,10 @@ func (cm *certificateManager) loadTrustedBundle(ctx context.Context, client clie
 
 	// Create a new readOnlyTrustedBundle based on the given configuration.
 	includeSystemCerts := len(obj.Data[certificatemanagement.RHELRootCertificateBundleName]) > 0
-	useMultiTenantName := name == certificatemanagement.TrustedCertConfigMapNamePublic
-	a := newReadOnlyTrustedBundle(cm, includeSystemCerts, useMultiTenantName)
+	a, err := newReadOnlyTrustedBundle(cm, name, includeSystemCerts)
+	if err != nil {
+		return nil, err
+	}
 
 	// Augment it with annotations from the actual ConfigMap so that we inherit the hash annotations used to
 	// detect changes to the ConfigMap's contents.
@@ -646,19 +632,15 @@ func (cm *certificateManager) loadTrustedBundle(ctx context.Context, client clie
 	return a, nil
 }
 
-// newReadOnlyTrustedBundle creates a new readOnlyTrustedBundle. If system is true, the bundle will include a system root certificate bundle.
-// TrustedBundleRO is useful for mounting a bundle of certificates to trust in a pod without the ability to modify the bundle, and allows
-// one controller to create the bundle and another to mount it.
-func newReadOnlyTrustedBundle(cm CertificateManager, includeSystemCerts, multiTenant bool) *readOnlyTrustedBundle {
-	if includeSystemCerts {
-		bundle, _ := cm.CreateTrustedBundleWithSystemRootCertificates()
-		if multiTenant {
-			// For multi-tenant clusters, the system root certificate bundle uses a different name. Load it instead.
-			bundle, _ = cm.CreateMultiTenantTrustedBundleWithSystemRootCertificates()
-		}
-		return &readOnlyTrustedBundle{annotations: map[string]string{}, bundle: bundle}
+// newReadOnlyTrustedBundle creates a new readOnlyTrustedBundle for the ConfigMap of the given
+// name. TrustedBundleRO lets one controller create a bundle and another mount it without being
+// able to modify it.
+func newReadOnlyTrustedBundle(cm CertificateManager, name string, includeSystemCerts bool) (*readOnlyTrustedBundle, error) {
+	bundle, err := certificatemanagement.CreateTrustedBundleWithName(name, includeSystemCerts, cm.KeyPair())
+	if err != nil {
+		return nil, err
 	}
-	return &readOnlyTrustedBundle{annotations: map[string]string{}, bundle: cm.CreateTrustedBundle()}
+	return &readOnlyTrustedBundle{annotations: map[string]string{}, bundle: bundle}, nil
 }
 
 // readOnlyTrustedBundle implements the TrustedBundleRO interface. It allows for annotations to be provided that will be added to

--- a/pkg/controller/certificatemanager/certificatemanager_test.go
+++ b/pkg/controller/certificatemanager/certificatemanager_test.go
@@ -612,28 +612,16 @@ var _ = Describe("Test CertificateManagement suite", func() {
 			Expect(keyPair.Secret(appNs).Data[corev1.TLSCertKey]).NotTo(BeNil())
 		})
 
-		It("should render correct CA secret name for single-tenant configuration", func() {
-			singleTenant := operatorv1.Tenant{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "single-tenant",
-					Namespace: "",
-				},
-			}
-			zeroTenantCM, err := certificatemanager.Create(cli, installation, clusterDomain, common.OperatorNamespace(), certificatemanager.AllowCACreation(), certificatemanager.WithTenant(&singleTenant))
+		It("should default the CA secret name", func() {
+			cm, err := certificatemanager.Create(cli, installation, clusterDomain, common.OperatorNamespace(), certificatemanager.AllowCACreation())
 			Expect(err).NotTo(HaveOccurred())
-			Expect(zeroTenantCM.KeyPair().GetName()).To(Equal(certificatemanagement.CASecretName))
+			Expect(cm.KeyPair().GetName()).To(Equal(certificatemanagement.CASecretName))
 		})
 
-		It("should render correct CA secret name for multi-tenant configuration", func() {
-			singleTenant := operatorv1.Tenant{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "multi-tenant",
-					Namespace: "tenant-namespace-a",
-				},
-			}
-			singleTenantCM, err := certificatemanager.Create(cli, installation, clusterDomain, common.OperatorNamespace(), certificatemanager.AllowCACreation(), certificatemanager.WithTenant(&singleTenant))
+		It("should read the CA from the secret name it is given", func() {
+			cm, err := certificatemanager.Create(cli, installation, clusterDomain, common.OperatorNamespace(), certificatemanager.AllowCACreation(), certificatemanager.WithCASecretName("my-own-ca"))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(singleTenantCM.KeyPair().GetName()).To(Equal(certificatemanagement.TenantCASecretName))
+			Expect(cm.KeyPair().GetName()).To(Equal("my-own-ca"))
 		})
 	})
 
@@ -743,50 +731,6 @@ var _ = Describe("Test CertificateManagement suite", func() {
 			bundle := configMap.Data[certificatemanagement.RHELRootCertificateBundleName]
 			numBlocks := strings.Count(bundle, "-----BEGIN CERTIFICATE-----")
 			Expect(numBlocks > 1).To(BeTrue()) // We expect tens of them most likely.
-		})
-
-		It("should load the system certificates into a multi-tenant bundle", func() {
-			if runtime.GOOS != "linux" {
-				Skip("Skip for users that run this test outside of a container on incompatible systems.")
-			}
-			trustedBundle, err := certificateManager.CreateMultiTenantTrustedBundleWithSystemRootCertificates()
-			Expect(err).NotTo(HaveOccurred())
-
-			configMap := trustedBundle.ConfigMap(appNs)
-			Expect(configMap.Name).To(Equal("tigera-ca-bundle-system-certs"))
-
-			Expect(configMap.Namespace).To(Equal(appNs))
-			Expect(configMap.Annotations).To(HaveKey("tigera-operator.hash.operator.tigera.io/tigera-ca-private"))
-			Expect(configMap.Annotations).To(HaveKey("hash.operator.tigera.io/system"))
-			Expect(configMap.TypeMeta).To(Equal(metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"}))
-
-			By("counting the number of pem blocks in the configmap")
-			bundle := configMap.Data[certificatemanagement.RHELRootCertificateBundleName]
-			numBlocks := strings.Count(bundle, "-----BEGIN CERTIFICATE-----")
-			Expect(numBlocks > 1).To(BeTrue()) // We expect tens of them most likely.
-
-			By("verifying the volume is correct")
-			volume := trustedBundle.Volume()
-			Expect(volume.ConfigMap).NotTo(BeNil())
-			Expect(volume.Name).To(Equal("tigera-ca-bundle-system-certs"))
-			Expect(volume.VolumeSource.ConfigMap.Name).To(Equal("tigera-ca-bundle-system-certs"))
-
-			By("verifying the volume mount is correct")
-			mounts := trustedBundle.VolumeMounts(rmeta.OSTypeLinux)
-			Expect(mounts).To(HaveLen(2))
-			Expect(mounts).To(Equal([]corev1.VolumeMount{
-				{
-					Name:      "tigera-ca-bundle-system-certs",
-					MountPath: "/etc/pki/tls/certs",
-					ReadOnly:  true,
-				},
-				{
-					Name:      "tigera-ca-bundle-system-certs",
-					MountPath: "/etc/pki/tls/cert.pem",
-					SubPath:   "ca-bundle.crt",
-					ReadOnly:  true,
-				},
-			}))
 		})
 
 		It("should create a hash for both secrets even if the same pem is used twice", func() {

--- a/pkg/controller/intrusiondetection/intrusiondetection_controller.go
+++ b/pkg/controller/intrusiondetection/intrusiondetection_controller.go
@@ -49,6 +49,7 @@ import (
 	"github.com/tigera/operator/pkg/controller/utils/imageset"
 	"github.com/tigera/operator/pkg/ctrlruntime"
 	"github.com/tigera/operator/pkg/dns"
+	entcertificatemanager "github.com/tigera/operator/pkg/enterprise/certificatemanager"
 	eutils "github.com/tigera/operator/pkg/enterprise/utils"
 	"github.com/tigera/operator/pkg/render"
 	rcertificatemanagement "github.com/tigera/operator/pkg/render/certificatemanagement"
@@ -359,12 +360,8 @@ func (r *ReconcileIntrusionDetection) Reconcile(ctx context.Context, request rec
 		}
 	}
 
-	// When creating the certificate manager, pass in the logger and tenant (if one exists).
-	opts := []certificatemanager.Option{
-		certificatemanager.WithLogger(reqLogger),
-		certificatemanager.WithTenant(tenant),
-	}
-	certificateManager, err := certificatemanager.Create(r.client, installationSpec, r.opts.ClusterDomain, helper.TruthNamespace(), opts...)
+	opts := []certificatemanager.Option{certificatemanager.WithLogger(reqLogger)}
+	certificateManager, err := entcertificatemanager.Create(r.client, installationSpec, r.opts.ClusterDomain, helper.TruthNamespace(), tenant, opts...)
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceCreateError, "Unable to create the Tigera CA", err, reqLogger)
 		return reconcile.Result{}, err
@@ -423,7 +420,7 @@ func (r *ReconcileIntrusionDetection) Reconcile(ctx context.Context, request rec
 	trustedBundle := bundleMaker.(certificatemanagement.TrustedBundleRO)
 	if r.opts.MultiTenant {
 		// For multi-tenant systems, we load the pre-created bundle for this tenant instead of using the one we built here.
-		trustedBundle, err = certificateManager.LoadMultiTenantTrustedBundleWithRootCertificates(ctx, r.client, helper.InstallNamespace())
+		trustedBundle, err = entcertificatemanager.LoadTenantBundleWithSystemRootCertificates(ctx, certificateManager, r.client, helper.InstallNamespace())
 		if err != nil {
 			r.status.SetDegraded(operatorv1.ResourceReadError, "Error getting trusted bundle", err, reqLogger)
 			return reconcile.Result{}, err

--- a/pkg/controller/intrusiondetection/intrusiondetection_controller_test.go
+++ b/pkg/controller/intrusiondetection/intrusiondetection_controller_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils"
 	ctrlrfake "github.com/tigera/operator/pkg/ctrlruntime/client/fake"
+	entcertificatemanager "github.com/tigera/operator/pkg/enterprise/certificatemanager"
 	"github.com/tigera/operator/pkg/render"
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
@@ -741,10 +742,10 @@ var _ = Describe("IntrusionDetection controller tests", func() {
 			err := c.Create(ctx, &operatorv1.IntrusionDetection{ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure", Namespace: tenantANamespace}})
 			Expect(err).NotTo(HaveOccurred())
 
-			certificateManagerTenantA, err := certificatemanager.Create(c, nil, "", tenantANamespace, certificatemanager.AllowCACreation(), certificatemanager.WithTenant(tenantA))
+			certificateManagerTenantA, err := entcertificatemanager.Create(c, nil, "", tenantANamespace, tenantA, certificatemanager.AllowCACreation())
 			Expect(err).NotTo(HaveOccurred())
 			Expect(c.Create(ctx, certificateManagerTenantA.KeyPair().Secret(tenantANamespace)))
-			tenantABundle, err := certificateManagerTenantA.CreateMultiTenantTrustedBundleWithSystemRootCertificates()
+			tenantABundle, err := entcertificatemanager.CreateTenantBundleWithSystemRootCertificates(certificateManagerTenantA)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(c.Create(ctx, tenantABundle.ConfigMap(tenantANamespace))).NotTo(HaveOccurred())
 

--- a/pkg/controller/logstorage/dashboards/dashboards_controller.go
+++ b/pkg/controller/logstorage/dashboards/dashboards_controller.go
@@ -28,6 +28,7 @@ import (
 	"github.com/tigera/operator/pkg/controller/certificatemanager"
 	"github.com/tigera/operator/pkg/controller/utils/imageset"
 	"github.com/tigera/operator/pkg/ctrlruntime"
+	entcertificatemanager "github.com/tigera/operator/pkg/enterprise/certificatemanager"
 	"github.com/tigera/operator/pkg/render/logstorage"
 	"github.com/tigera/operator/pkg/render/logstorage/dashboards"
 	batchv1 "k8s.io/api/batch/v1"
@@ -336,11 +337,8 @@ func (d DashboardsSubController) Reconcile(ctx context.Context, request reconcil
 	}
 
 	// Collect the certificates we need to provision Dashboards. These will have been provisioned already by the ES secrets controller.
-	opts := []certificatemanager.Option{
-		certificatemanager.WithLogger(reqLogger),
-		certificatemanager.WithTenant(tenant),
-	}
-	cm, err := certificatemanager.Create(d.client, installationSpec, d.clusterDomain, helper.TruthNamespace(), opts...)
+	opts := []certificatemanager.Option{certificatemanager.WithLogger(reqLogger)}
+	cm, err := entcertificatemanager.Create(d.client, installationSpec, d.clusterDomain, helper.TruthNamespace(), tenant, opts...)
 	if err != nil {
 		d.status.SetDegraded(operatorv1.ResourceCreateError, "Unable to create the Tigera CA", err, reqLogger)
 		return reconcile.Result{}, err

--- a/pkg/controller/logstorage/linseed/linseed_controller.go
+++ b/pkg/controller/logstorage/linseed/linseed_controller.go
@@ -47,6 +47,7 @@ import (
 	"github.com/tigera/operator/pkg/controller/utils/imageset"
 	"github.com/tigera/operator/pkg/ctrlruntime"
 	"github.com/tigera/operator/pkg/dns"
+	entcertificatemanager "github.com/tigera/operator/pkg/enterprise/certificatemanager"
 	"github.com/tigera/operator/pkg/enterprise/cloudconfig"
 	eutils "github.com/tigera/operator/pkg/enterprise/utils"
 	"github.com/tigera/operator/pkg/render"
@@ -368,11 +369,8 @@ func (r *LinseedSubController) Reconcile(ctx context.Context, request reconcile.
 	}
 
 	// Collect the certificates we need to provision Linseed. These will have been provisioned already by the ES secrets controller.
-	opts := []certificatemanager.Option{
-		certificatemanager.WithLogger(reqLogger),
-		certificatemanager.WithTenant(tenant),
-	}
-	cm, err := certificatemanager.Create(r.client, installationSpec, r.opts.ClusterDomain, helper.TruthNamespace(), opts...)
+	opts := []certificatemanager.Option{certificatemanager.WithLogger(reqLogger)}
+	cm, err := entcertificatemanager.Create(r.client, installationSpec, r.opts.ClusterDomain, helper.TruthNamespace(), tenant, opts...)
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceCreateError, "Unable to create the Tigera CA", err, reqLogger)
 		return reconcile.Result{}, err

--- a/pkg/controller/logstorage/linseed/linseed_controller_test.go
+++ b/pkg/controller/logstorage/linseed/linseed_controller_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/tigera/operator/pkg/controller/utils"
 	ctrlrfake "github.com/tigera/operator/pkg/ctrlruntime/client/fake"
 	"github.com/tigera/operator/pkg/dns"
+	entcertificatemanager "github.com/tigera/operator/pkg/enterprise/certificatemanager"
 	"github.com/tigera/operator/pkg/render"
 	"github.com/tigera/operator/pkg/render/logstorage"
 	"github.com/tigera/operator/pkg/render/logstorage/linseed"
@@ -332,11 +333,8 @@ var _ = Describe("LogStorage Linseed controller", func() {
 			mockStatus.On("ClearDegraded")
 
 			// Create a CA secret for the test, and create its KeyPair.
-			opts := []certificatemanager.Option{
-				certificatemanager.AllowCACreation(),
-				certificatemanager.WithTenant(tenant),
-			}
-			cm, err := certificatemanager.Create(cli, &install.Spec, dns.DefaultClusterDomain, tenantNS, opts...)
+			opts := []certificatemanager.Option{certificatemanager.AllowCACreation()}
+			cm, err := entcertificatemanager.Create(cli, &install.Spec, dns.DefaultClusterDomain, tenantNS, tenant, opts...)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(cli.Create(ctx, cm.KeyPair().Secret(tenantNS))).ShouldNot(HaveOccurred())
 

--- a/pkg/controller/logstorage/secrets/secret_controller.go
+++ b/pkg/controller/logstorage/secrets/secret_controller.go
@@ -41,6 +41,7 @@ import (
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/ctrlruntime"
 	"github.com/tigera/operator/pkg/dns"
+	entcertificatemanager "github.com/tigera/operator/pkg/enterprise/certificatemanager"
 	eutils "github.com/tigera/operator/pkg/enterprise/utils"
 	"github.com/tigera/operator/pkg/render"
 	rcertificatemanagement "github.com/tigera/operator/pkg/render/certificatemanagement"
@@ -302,8 +303,8 @@ func (r *SecretSubController) Reconcile(ctx context.Context, request reconcile.R
 	cm = operatorSigner
 	if r.multiTenant {
 		// Override with a tenant-scoped certificate manager which uses the CA in the tenant's namespace.
-		opts := []certificatemanager.Option{certificatemanager.WithLogger(reqLogger), certificatemanager.WithTenant(tenant)}
-		cm, err = certificatemanager.Create(r.client, installationSpec, r.clusterDomain, helper.InstallNamespace(), opts...)
+		opts := []certificatemanager.Option{certificatemanager.WithLogger(reqLogger)}
+		cm, err = entcertificatemanager.Create(r.client, installationSpec, r.clusterDomain, helper.InstallNamespace(), tenant, opts...)
 		if err != nil {
 			r.status.SetDegraded(operatorv1.ResourceReadError, "Error building certificate manager", err, reqLogger)
 			return reconcile.Result{}, err

--- a/pkg/controller/logstorage/secrets/secret_controller_test.go
+++ b/pkg/controller/logstorage/secrets/secret_controller_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/tigera/operator/pkg/controller/utils"
 	ctrlrfake "github.com/tigera/operator/pkg/ctrlruntime/client/fake"
 	"github.com/tigera/operator/pkg/dns"
+	entcertificatemanager "github.com/tigera/operator/pkg/enterprise/certificatemanager"
 	"github.com/tigera/operator/pkg/render"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/secret"
@@ -620,12 +621,12 @@ var _ = Describe("LogStorage Secrets controller", func() {
 			Expect(cli.Create(ctx, externalKibanaSecret)).ShouldNot(HaveOccurred())
 
 			// Create a per-tenant CA secret for the test, and create its KeyPair.
-			cm, err := certificatemanager.Create(cli,
+			cm, err := entcertificatemanager.Create(cli,
 				&install.Spec,
 				dns.DefaultClusterDomain,
 				tenantNS,
-				certificatemanager.AllowCACreation(),
-				certificatemanager.WithTenant(tenant))
+				tenant,
+				certificatemanager.AllowCACreation())
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(cli.Create(ctx, cm.KeyPair().Secret(tenantNS))).ShouldNot(HaveOccurred())
 		})

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -52,6 +52,7 @@ import (
 	"github.com/tigera/operator/pkg/controller/utils/imageset"
 	"github.com/tigera/operator/pkg/ctrlruntime"
 	"github.com/tigera/operator/pkg/dns"
+	entcertificatemanager "github.com/tigera/operator/pkg/enterprise/certificatemanager"
 	eutils "github.com/tigera/operator/pkg/enterprise/utils"
 	"github.com/tigera/operator/pkg/render"
 	rcertificatemanagement "github.com/tigera/operator/pkg/render/certificatemanagement"
@@ -391,12 +392,8 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 		return reconcile.Result{}, err
 	}
 
-	// When creating the certificate manager, pass in the logger and tenant (if one exists).
-	opts := []certificatemanager.Option{
-		certificatemanager.WithLogger(logc),
-		certificatemanager.WithTenant(tenant),
-	}
-	certificateManager, err := certificatemanager.Create(r.client, installationSpec, r.opts.ClusterDomain, helper.TruthNamespace(), opts...)
+	opts := []certificatemanager.Option{certificatemanager.WithLogger(logc)}
+	certificateManager, err := entcertificatemanager.Create(r.client, installationSpec, r.opts.ClusterDomain, helper.TruthNamespace(), tenant, opts...)
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceCreateError, "Unable to create the Tigera CA", err, logc)
 		return reconcile.Result{}, err
@@ -670,7 +667,7 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 	if r.opts.MultiTenant {
 		// For multi-tenant systems, we load the pre-created bundle for this tenant instead of using the one we built here.
 		// Multi-tenant managers need the bundle variant that includes system root certificates, in order to verify external auth providers.
-		trustedBundle, err = certificateManager.LoadMultiTenantTrustedBundleWithRootCertificates(ctx, r.client, helper.InstallNamespace())
+		trustedBundle, err = entcertificatemanager.LoadTenantBundleWithSystemRootCertificates(ctx, certificateManager, r.client, helper.InstallNamespace())
 		if err != nil {
 			r.status.SetDegraded(operatorv1.ResourceReadError, "Error getting trusted bundle", err, logc)
 			return reconcile.Result{}, err

--- a/pkg/controller/manager/manager_controller_test.go
+++ b/pkg/controller/manager/manager_controller_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/tigera/operator/pkg/controller/utils"
 	ctrlrfake "github.com/tigera/operator/pkg/ctrlruntime/client/fake"
 	"github.com/tigera/operator/pkg/dns"
+	entcertificatemanager "github.com/tigera/operator/pkg/enterprise/certificatemanager"
 	eutils "github.com/tigera/operator/pkg/enterprise/utils"
 	"github.com/tigera/operator/pkg/render"
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
@@ -1199,23 +1200,23 @@ var _ = Describe("Manager controller tests", func() {
 				}
 				Expect(c.Create(ctx, managementCluster)).NotTo(HaveOccurred())
 
-				certificateManagerTenantA, err := certificatemanager.Create(c, nil, "", tenantANamespace, certificatemanager.AllowCACreation(), certificatemanager.WithTenant(tenantA))
+				certificateManagerTenantA, err := entcertificatemanager.Create(c, nil, "", tenantANamespace, tenantA, certificatemanager.AllowCACreation())
 				Expect(err).NotTo(HaveOccurred())
 				Expect(c.Create(ctx, certificateManagerTenantA.KeyPair().Secret(tenantANamespace)))
 				managerTLSTenantA, err := certificateManagerTenantA.GetOrCreateKeyPair(c, render.ManagerInternalTLSSecretName, tenantANamespace, []string{render.ManagerInternalTLSSecretName})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(c.Create(ctx, managerTLSTenantA.Secret(tenantANamespace))).NotTo(HaveOccurred())
-				bundleA, err := certificateManagerTenantA.CreateMultiTenantTrustedBundleWithSystemRootCertificates()
+				bundleA, err := entcertificatemanager.CreateTenantBundleWithSystemRootCertificates(certificateManagerTenantA)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(c.Create(ctx, bundleA.ConfigMap(tenantANamespace))).NotTo(HaveOccurred())
 
-				certificateManagerTenantB, err := certificatemanager.Create(c, nil, "", tenantBNamespace, certificatemanager.AllowCACreation(), certificatemanager.WithTenant(tenantB))
+				certificateManagerTenantB, err := entcertificatemanager.Create(c, nil, "", tenantBNamespace, tenantB, certificatemanager.AllowCACreation())
 				Expect(err).NotTo(HaveOccurred())
 				Expect(c.Create(ctx, certificateManagerTenantB.KeyPair().Secret(tenantBNamespace)))
 				managerTLSTenantB, err := certificateManagerTenantB.GetOrCreateKeyPair(c, render.ManagerInternalTLSSecretName, tenantBNamespace, []string{render.ManagerInternalTLSSecretName})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(c.Create(ctx, managerTLSTenantB.Secret(tenantBNamespace))).NotTo(HaveOccurred())
-				bundleB, err := certificateManagerTenantB.CreateMultiTenantTrustedBundleWithSystemRootCertificates()
+				bundleB, err := entcertificatemanager.CreateTenantBundleWithSystemRootCertificates(certificateManagerTenantB)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(c.Create(ctx, bundleB.ConfigMap(tenantBNamespace))).NotTo(HaveOccurred())
 
@@ -1383,13 +1384,13 @@ var _ = Describe("Manager controller tests", func() {
 					Expect(c.Create(ctx, tenantC)).NotTo(HaveOccurred())
 
 					// Create certificates for this tenant.
-					certificateManagerTenantC, err := certificatemanager.Create(c, nil, "", tenantCNamespace, certificatemanager.AllowCACreation(), certificatemanager.WithTenant(tenantC))
+					certificateManagerTenantC, err := entcertificatemanager.Create(c, nil, "", tenantCNamespace, tenantC, certificatemanager.AllowCACreation())
 					Expect(err).NotTo(HaveOccurred())
 					Expect(c.Create(ctx, certificateManagerTenantC.KeyPair().Secret(tenantCNamespace)))
 					managerTLStenantC, err := certificateManagerTenantC.GetOrCreateKeyPair(c, render.ManagerInternalTLSSecretName, tenantCNamespace, []string{render.ManagerInternalTLSSecretName})
 					Expect(err).NotTo(HaveOccurred())
 					Expect(c.Create(ctx, managerTLStenantC.Secret(tenantCNamespace))).NotTo(HaveOccurred())
-					bundleB, err := certificateManagerTenantC.CreateMultiTenantTrustedBundleWithSystemRootCertificates()
+					bundleB, err := entcertificatemanager.CreateTenantBundleWithSystemRootCertificates(certificateManagerTenantC)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(c.Create(ctx, bundleB.ConfigMap(tenantCNamespace))).NotTo(HaveOccurred())
 

--- a/pkg/controller/policyrecommendation/policyrecommendation_controller.go
+++ b/pkg/controller/policyrecommendation/policyrecommendation_controller.go
@@ -42,6 +42,7 @@ import (
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/controller/utils/imageset"
 	"github.com/tigera/operator/pkg/ctrlruntime"
+	entcertificatemanager "github.com/tigera/operator/pkg/enterprise/certificatemanager"
 	"github.com/tigera/operator/pkg/enterprise/cloudconfig"
 	eutils "github.com/tigera/operator/pkg/enterprise/utils"
 	"github.com/tigera/operator/pkg/render"
@@ -372,11 +373,8 @@ func (r *ReconcilePolicyRecommendation) Reconcile(ctx context.Context, request r
 	var components []render.Component
 
 	if !isManagedCluster {
-		opts := []certificatemanager.Option{
-			certificatemanager.WithLogger(logc),
-			certificatemanager.WithTenant(tenant),
-		}
-		certificateManager, err := certificatemanager.Create(r.client, installationSpec, r.opts.ClusterDomain, helper.TruthNamespace(), opts...)
+		opts := []certificatemanager.Option{certificatemanager.WithLogger(logc)}
+		certificateManager, err := entcertificatemanager.Create(r.client, installationSpec, r.opts.ClusterDomain, helper.TruthNamespace(), tenant, opts...)
 		if err != nil {
 			r.status.SetDegraded(operatorv1.ResourceCreateError, "Unable to create the Tigera CA", err, logc)
 			return reconcile.Result{}, err

--- a/pkg/controller/policyrecommendation/policyrecommendation_controller_test.go
+++ b/pkg/controller/policyrecommendation/policyrecommendation_controller_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils"
 	ctrlrfake "github.com/tigera/operator/pkg/ctrlruntime/client/fake"
+	entcertificatemanager "github.com/tigera/operator/pkg/enterprise/certificatemanager"
 	"github.com/tigera/operator/pkg/render"
 	"github.com/tigera/operator/pkg/render/logstorage/eck"
 	"github.com/tigera/operator/test"
@@ -353,7 +354,7 @@ var _ = Describe("PolicyRecommendation controller tests", func() {
 				}
 				Expect(c.Create(ctx, tenantB)).NotTo(HaveOccurred())
 
-				certificateManagerTenantA, err := certificatemanager.Create(c, nil, "", tenantANamespace, certificatemanager.AllowCACreation(), certificatemanager.WithTenant(tenantA))
+				certificateManagerTenantA, err := entcertificatemanager.Create(c, nil, "", tenantANamespace, tenantA, certificatemanager.AllowCACreation())
 				Expect(err).NotTo(HaveOccurred())
 				Expect(c.Create(ctx, certificateManagerTenantA.KeyPair().Secret(tenantANamespace)))
 				Expect(c.Create(ctx, certificateManagerTenantA.CreateTrustedBundle().ConfigMap(tenantANamespace))).NotTo(HaveOccurred())
@@ -362,7 +363,7 @@ var _ = Describe("PolicyRecommendation controller tests", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(c.Create(ctx, linseedTLSTenantA.Secret(tenantANamespace))).NotTo(HaveOccurred())
 
-				certificateManagerTenantB, err := certificatemanager.Create(c, nil, "", tenantBNamespace, certificatemanager.AllowCACreation(), certificatemanager.WithTenant(tenantB))
+				certificateManagerTenantB, err := entcertificatemanager.Create(c, nil, "", tenantBNamespace, tenantB, certificatemanager.AllowCACreation())
 				Expect(err).NotTo(HaveOccurred())
 				Expect(c.Create(ctx, certificateManagerTenantB.KeyPair().Secret(tenantBNamespace)))
 				Expect(c.Create(ctx, certificateManagerTenantB.CreateTrustedBundle().ConfigMap(tenantBNamespace))).NotTo(HaveOccurred())
@@ -455,7 +456,7 @@ var _ = Describe("PolicyRecommendation controller tests", func() {
 				Expect(err.Error()).Should(ContainSubstring("CA secret"))
 
 				// Create a CA secret for the test, and create its KeyPair.
-				certificateManagerTenantA, err := certificatemanager.Create(c, nil, "", tenantANamespace, certificatemanager.AllowCACreation(), certificatemanager.WithTenant(tenantA))
+				certificateManagerTenantA, err := entcertificatemanager.Create(c, nil, "", tenantANamespace, tenantA, certificatemanager.AllowCACreation())
 				Expect(err).NotTo(HaveOccurred())
 				Expect(c.Create(ctx, certificateManagerTenantA.KeyPair().Secret(tenantANamespace))).NotTo(HaveOccurred())
 				Expect(c.Create(ctx, certificateManagerTenantA.CreateTrustedBundle().ConfigMap(tenantANamespace))).NotTo(HaveOccurred())

--- a/pkg/controller/tenantsecrets/tenant_controller.go
+++ b/pkg/controller/tenantsecrets/tenant_controller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils"
 	"github.com/tigera/operator/pkg/ctrlruntime"
+	entcertificatemanager "github.com/tigera/operator/pkg/enterprise/certificatemanager"
 	eutils "github.com/tigera/operator/pkg/enterprise/utils"
 	"github.com/tigera/operator/pkg/render"
 	rcertificatemanagement "github.com/tigera/operator/pkg/render/certificatemanagement"
@@ -153,9 +154,8 @@ func (r *TenantController) Reconcile(ctx context.Context, request reconcile.Requ
 	opts := []certificatemanager.Option{
 		certificatemanager.AllowCACreation(),
 		certificatemanager.WithLogger(logc),
-		certificatemanager.WithTenant(tenant),
 	}
-	cm, err := certificatemanager.Create(r.client, installationSpec, r.clusterDomain, tenant.Namespace, opts...)
+	cm, err := entcertificatemanager.Create(r.client, installationSpec, r.clusterDomain, tenant.Namespace, tenant, opts...)
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceCreateError, "Unable to create CA", err, logc)
 		return reconcile.Result{}, err
@@ -185,7 +185,7 @@ func (r *TenantController) Reconcile(ctx context.Context, request reconcile.Requ
 	// We also need a trusted bundle that includes the system root certificates in addition to the certificates
 	// listed above, so that components that talk to public endpoints can verify them. In a multi-tenant cluster, this
 	// bundle will co-exist in the same namespace as the default trusted bundle, but with a different name.
-	trustedBundleWithSystemCAs, err := cm.CreateMultiTenantTrustedBundleWithSystemRootCertificates()
+	trustedBundleWithSystemCAs, err := entcertificatemanager.CreateTenantBundleWithSystemRootCertificates(cm)
 	if err != nil {
 		r.status.SetDegraded(operatorv1.ResourceReadError, "Error querying system root certificates", err, logc)
 		return reconcile.Result{}, err

--- a/pkg/enterprise/certificatemanager/certificatemanager.go
+++ b/pkg/enterprise/certificatemanager/certificatemanager.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package certificatemanager adapts the generic certificate manager for Enterprise
+// controllers, which run in clusters that may host more than one tenant.
+package certificatemanager
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/controller/certificatemanager"
+	"github.com/tigera/operator/pkg/tls/certificatemanagement"
+)
+
+// Create returns a certificate manager for the given tenant. Multi-tenant clusters keep a
+// per-tenant CA, so each tenant's manager signs with its own.
+func Create(cli client.Client, installation *operatorv1.InstallationSpec, clusterDomain, ns string, tenant *operatorv1.Tenant, opts ...certificatemanager.Option) (certificatemanager.CertificateManager, error) {
+	if tenant.MultiTenant() {
+		opts = append(opts, certificatemanager.WithCASecretName(certificatemanagement.TenantCASecretName))
+	}
+	return certificatemanager.Create(cli, installation, clusterDomain, ns, opts...)
+}
+
+// CreateTenantBundleWithSystemRootCertificates creates the trusted bundle holding public CAs.
+// A multi-tenant namespace needs both this and a bundle without them, so the two are stored
+// under different names.
+func CreateTenantBundleWithSystemRootCertificates(cm certificatemanager.CertificateManager, certificates ...certificatemanagement.CertificateInterface) (certificatemanagement.TrustedBundle, error) {
+	return certificatemanagement.CreateTrustedBundleWithName(certificatemanagement.TrustedCertConfigMapNamePublic, true, cm.KeyPair(), certificates...)
+}
+
+// LoadTenantBundleWithSystemRootCertificates loads the bundle created by
+// CreateTenantBundleWithSystemRootCertificates so another controller can mount it.
+func LoadTenantBundleWithSystemRootCertificates(ctx context.Context, cm certificatemanager.CertificateManager, cli client.Client, ns string) (certificatemanagement.TrustedBundleRO, error) {
+	return cm.LoadNamedTrustedBundle(ctx, cli, ns, certificatemanagement.TrustedCertConfigMapNamePublic)
+}

--- a/pkg/enterprise/certificatemanager/certificatemanager_suite_test.go
+++ b/pkg/enterprise/certificatemanager/certificatemanager_suite_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificatemanager_test
+
+import (
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	uzap "go.uber.org/zap"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func TestCertificateManager(t *testing.T) {
+	logf.SetLogger(zap.New(zap.WriteTo(ginkgo.GinkgoWriter), zap.UseDevMode(true), zap.Level(uzap.NewAtomicLevelAt(uzap.DebugLevel))))
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
+	reporterConfig.JUnitReport = "../../../report/ut/enterprise_certificatemanager_suite.xml"
+	ginkgo.RunSpecs(t, "pkg/enterprise/certificatemanager Suite", suiteConfig, reporterConfig)
+}

--- a/pkg/enterprise/certificatemanager/certificatemanager_test.go
+++ b/pkg/enterprise/certificatemanager/certificatemanager_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificatemanager_test
+
+import (
+	"runtime"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/apis"
+	"github.com/tigera/operator/pkg/common"
+	"github.com/tigera/operator/pkg/controller/certificatemanager"
+	ctrlrfake "github.com/tigera/operator/pkg/ctrlruntime/client/fake"
+	entcertificatemanager "github.com/tigera/operator/pkg/enterprise/certificatemanager"
+	rmeta "github.com/tigera/operator/pkg/render/common/meta"
+	"github.com/tigera/operator/pkg/tls/certificatemanagement"
+)
+
+const (
+	appNs         = "my-app"
+	clusterDomain = "cluster.local"
+)
+
+var _ = Describe("Enterprise certificate manager", func() {
+	var (
+		cli          client.Client
+		installation *operatorv1.InstallationSpec
+	)
+
+	BeforeEach(func() {
+		scheme := k8sruntime.NewScheme()
+		Expect(apis.AddToScheme(scheme, false)).NotTo(HaveOccurred())
+		Expect(corev1.SchemeBuilder.AddToScheme(scheme)).NotTo(HaveOccurred())
+		cli = ctrlrfake.DefaultFakeClientBuilder(scheme).Build()
+		installation = &operatorv1.InstallationSpec{}
+	})
+
+	create := func(tenant *operatorv1.Tenant) certificatemanager.CertificateManager {
+		cm, err := entcertificatemanager.Create(cli, installation, clusterDomain, common.OperatorNamespace(), tenant, certificatemanager.AllowCACreation())
+		Expect(err).NotTo(HaveOccurred())
+		return cm
+	}
+
+	It("should render correct CA secret name for zero-tenant configuration", func() {
+		Expect(create(nil).KeyPair().GetName()).To(Equal(certificatemanagement.CASecretName))
+	})
+
+	It("should render correct CA secret name for single-tenant configuration", func() {
+		tenant := &operatorv1.Tenant{ObjectMeta: metav1.ObjectMeta{Name: "single-tenant", Namespace: ""}}
+		Expect(create(tenant).KeyPair().GetName()).To(Equal(certificatemanagement.CASecretName))
+	})
+
+	It("should render correct CA secret name for multi-tenant configuration", func() {
+		tenant := &operatorv1.Tenant{ObjectMeta: metav1.ObjectMeta{Name: "multi-tenant", Namespace: "tenant-namespace-a"}}
+		Expect(create(tenant).KeyPair().GetName()).To(Equal(certificatemanagement.TenantCASecretName))
+	})
+
+	It("should load the system certificates into a multi-tenant bundle", func() {
+		if runtime.GOOS != "linux" {
+			Skip("Skip for users that run this test outside of a container on incompatible systems.")
+		}
+		trustedBundle, err := entcertificatemanager.CreateTenantBundleWithSystemRootCertificates(create(nil))
+		Expect(err).NotTo(HaveOccurred())
+
+		configMap := trustedBundle.ConfigMap(appNs)
+		Expect(configMap.Name).To(Equal("tigera-ca-bundle-system-certs"))
+		Expect(configMap.Namespace).To(Equal(appNs))
+		Expect(configMap.Annotations).To(HaveKey("tigera-operator.hash.operator.tigera.io/tigera-ca-private"))
+		Expect(configMap.Annotations).To(HaveKey("hash.operator.tigera.io/system"))
+		Expect(configMap.TypeMeta).To(Equal(metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"}))
+
+		By("counting the number of pem blocks in the configmap")
+		bundle := configMap.Data[certificatemanagement.RHELRootCertificateBundleName]
+		Expect(strings.Count(bundle, "-----BEGIN CERTIFICATE-----") > 1).To(BeTrue())
+
+		By("verifying the volume is correct")
+		volume := trustedBundle.Volume()
+		Expect(volume.ConfigMap).NotTo(BeNil())
+		Expect(volume.Name).To(Equal("tigera-ca-bundle-system-certs"))
+		Expect(volume.VolumeSource.ConfigMap.Name).To(Equal("tigera-ca-bundle-system-certs"))
+
+		By("verifying the volume mount is correct")
+		Expect(trustedBundle.VolumeMounts(rmeta.OSTypeLinux)).To(Equal([]corev1.VolumeMount{
+			{
+				Name:      "tigera-ca-bundle-system-certs",
+				MountPath: "/etc/pki/tls/certs",
+				ReadOnly:  true,
+			},
+			{
+				Name:      "tigera-ca-bundle-system-certs",
+				MountPath: "/etc/pki/tls/cert.pem",
+				SubPath:   "ca-bundle.crt",
+				ReadOnly:  true,
+			},
+		}))
+	})
+})

--- a/pkg/tls/certificatemanagement/certificatebundle.go
+++ b/pkg/tls/certificatemanagement/certificatebundle.go
@@ -80,10 +80,10 @@ func CreateTrustedBundleWithSystemRootCertificates(ca CertificateInterface, cert
 	return createTrustedBundle(true, TrustedCertConfigMapName, ca, certificates...)
 }
 
-// CreateMultiTenantTrustedBundleWithSystemRootCertificates creates a TrustedBundle with system root certificates that is
-// appropraite for a multi-tenant cluster, in which each tenant needs multiple trusted bundles.
-func CreateMultiTenantTrustedBundleWithSystemRootCertificates(ca CertificateInterface, certificates ...CertificateInterface) (TrustedBundle, error) {
-	return createTrustedBundle(true, TrustedCertConfigMapNamePublic, ca, certificates...)
+// CreateTrustedBundleWithName creates a TrustedBundle backed by a ConfigMap of the given name.
+// Callers that need more than one bundle in a single namespace use this to keep them apart.
+func CreateTrustedBundleWithName(name string, includeSystem bool, ca CertificateInterface, certificates ...CertificateInterface) (TrustedBundle, error) {
+	return createTrustedBundle(includeSystem, name, ca, certificates...)
 }
 
 // createTrustedBundle creates a TrustedBundle, which provides standardized methods for mounting a bundle of certificates to trust.


### PR DESCRIPTION
## Description

Another variant-gating split. The base certificate manager no longer knows what a tenant is:

- the CA secret name is now an option on the constructor, instead of a tenant argument the constructor inspects
- trusted bundle creation takes the configmap name as a parameter, which lets the multi-tenant branch in the bundle loader be deleted rather than relocated
- a new Enterprise package wraps the base one and supplies the per-tenant CA secret name and the public bundle name

No behavior change. Enterprise controllers go through the new package and get the same CA secret and configmap names as before.

One thing for review: the CA secret name option is exported, so nothing structurally stops a Calico caller from pointing it at the tenant CA. That seemed like a better trade than keeping the tenant type in the base package, but say the word if you'd rather pay for a narrower mechanism.

Related: [CORE-13395](https://tigera.atlassian.net/browse/CORE-13395)

```release-note
None
```



[CORE-13395]: https://tigera.atlassian.net/browse/CORE-13395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ