### PR TITLE
Move the whisker non-Calico cleanup behind an Enterprise modifier

### DIFF
--- a/pkg/controller/whisker/controller.go
+++ b/pkg/controller/whisker/controller.go
@@ -39,6 +39,7 @@ import (
 	"github.com/tigera/operator/pkg/controller/utils/imageset"
 	"github.com/tigera/operator/pkg/ctrlruntime"
 	"github.com/tigera/operator/pkg/dns"
+	"github.com/tigera/operator/pkg/extensions"
 	"github.com/tigera/operator/pkg/render"
 	rcertificatemanagement "github.com/tigera/operator/pkg/render/certificatemanagement"
 	"github.com/tigera/operator/pkg/render/goldmane"
@@ -131,6 +132,7 @@ func newReconciler(
 		status:        statusMgr,
 		clusterDomain: opts.ClusterDomain,
 		variant:       opts.Variant,
+		ext:           opts.Extensions.Whisker(),
 	}
 	c.status.Run(opts.ShutdownContext)
 	return c
@@ -146,6 +148,7 @@ type Reconciler struct {
 	status        status.StatusManager
 	clusterDomain string
 	variant       operatorv1.ProductVariant
+	ext           extensions.WhiskerExtension
 }
 
 // Reconcile reads that state of the cluster for a Whisker object and makes changes based on the
@@ -245,7 +248,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 
-	ch := utils.NewComponentHandler(log, r.cli, r.scheme, whiskerCR)
+	ri := render.Inputs{
+		Installation:  installationSpec,
+		ClusterDomain: r.clusterDomain,
+		TrustedBundle: trustedBundle,
+	}
+	ch := utils.NewComponentHandler(log, r.cli, r.scheme, whiskerCR, utils.WithExtension(r.ext, ri))
 	cfg := &whisker.Configuration{
 		PullSecrets:           pullSecrets,
 		OpenShift:             r.provider.IsOpenShift(),

--- a/pkg/controller/whisker/controller_test.go
+++ b/pkg/controller/whisker/controller_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/controller/certificatemanager"
 	ctrlrfake "github.com/tigera/operator/pkg/ctrlruntime/client/fake"
+	"github.com/tigera/operator/pkg/extensions"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/tls"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -134,6 +135,7 @@ var _ = Describe("whisker controller tests", func() {
 				scheme:   scheme,
 				provider: operatorv1.ProviderNone,
 				status:   mockStatus,
+				ext:      extensions.Extensions{}.Whisker(),
 			}
 			_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "default", Namespace: "calico-system"}})
 			Expect(err).ShouldNot(HaveOccurred())
@@ -148,6 +150,7 @@ var _ = Describe("whisker controller tests", func() {
 				scheme:   scheme,
 				provider: operatorv1.ProviderNone,
 				status:   mockStatus,
+				ext:      extensions.Extensions{}.Whisker(),
 			}
 			_, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "default", Namespace: "calico-system"}})
 			Expect(err).ShouldNot(HaveOccurred())

--- a/pkg/enterprise/register.go
+++ b/pkg/enterprise/register.go
@@ -24,6 +24,7 @@ import (
 	"github.com/tigera/operator/pkg/enterprise/istio"
 	eoptions "github.com/tigera/operator/pkg/enterprise/options"
 	"github.com/tigera/operator/pkg/enterprise/tiers"
+	"github.com/tigera/operator/pkg/enterprise/whisker"
 	"github.com/tigera/operator/pkg/enterprise/windows"
 	"github.com/tigera/operator/pkg/extensions"
 )
@@ -44,6 +45,7 @@ func New(variant operatorv1.ProductVariant, o eoptions.Options) extensions.Exten
 			CSR:               csr.New(),
 			Istio:             istio.New(),
 			Goldmane:          goldmane.New(variant),
+			Whisker:           whisker.New(variant),
 		})
 	}
 

--- a/pkg/enterprise/whisker/extension.go
+++ b/pkg/enterprise/whisker/extension.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package whisker
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/extensions"
+	"github.com/tigera/operator/pkg/render"
+	rwhisker "github.com/tigera/operator/pkg/render/whisker"
+)
+
+// Extension is the Calico Enterprise behavior for the whisker controller.
+type Extension struct {
+	variant operatorv1.ProductVariant
+}
+
+var _ extensions.WhiskerExtension = &Extension{}
+
+// New returns the whisker extension for the variant the operator resolved.
+func New(variant operatorv1.ProductVariant) *Extension {
+	return &Extension{variant: variant}
+}
+
+// Modify dispatches over the components the whisker controller renders.
+func (e *Extension) Modify(c render.Component, ri render.Inputs) render.Component {
+	switch c.(type) {
+	case *rwhisker.Component:
+		return extensions.Decorate(c, ri, e.variant, deleteWhisker)
+	default:
+		return c
+	}
+}
+
+// deleteWhisker moves everything whisker rendered to the delete list. Enterprise has
+// no whisker, so an install upgraded from Calico cleans up after itself.
+func deleteWhisker(create, del []client.Object) ([]client.Object, []client.Object) {
+	return nil, append(del, create...)
+}

--- a/pkg/enterprise/whisker/extension_test.go
+++ b/pkg/enterprise/whisker/extension_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package whisker_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/render"
+	rwhisker "github.com/tigera/operator/pkg/render/whisker"
+	"github.com/tigera/operator/pkg/tls/certificatemanagement"
+)
+
+var _ = Describe("whisker enterprise render extension", func() {
+	renderInputs := func(variant operatorv1.ProductVariant) render.Inputs {
+		return render.Inputs{Installation: &operatorv1.InstallationSpec{Variant: variant}}
+	}
+
+	component := func(variant operatorv1.ProductVariant) render.Component {
+		return rwhisker.Whisker(&rwhisker.Configuration{
+			Installation:          &operatorv1.InstallationSpec{Variant: variant},
+			TrustedCertBundle:     certificatemanagement.CreateTrustedBundle(nil),
+			WhiskerKeyPair:        certificatemanagement.NewKeyPair(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: rwhisker.WhiskerKeyPairSecret}}, nil, ""),
+			WhiskerBackendKeyPair: certificatemanagement.NewKeyPair(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: rwhisker.WhiskerBackendKeyPairSecret}}, nil, ""),
+			Whisker:               &operatorv1.Whisker{Spec: operatorv1.WhiskerSpec{Notifications: ptr.To(operatorv1.Enabled)}},
+		})
+	}
+
+	It("queues everything whisker rendered for deletion", func() {
+		base := component(operatorv1.CalicoEnterprise)
+		baseCreate, baseDelete := base.Objects()
+		Expect(baseCreate).NotTo(BeEmpty())
+
+		create, del := ext.Whisker().Modify(base, renderInputs(operatorv1.CalicoEnterprise)).Objects()
+		Expect(create).To(BeEmpty())
+		Expect(del).To(HaveLen(len(baseCreate) + len(baseDelete)))
+		Expect(del).To(ContainElements(baseCreate))
+	})
+
+	It("leaves whisker alone when the installation is Calico", func() {
+		base := component(operatorv1.Calico)
+		baseCreate, baseDelete := base.Objects()
+
+		create, del := calicoExt.Whisker().Modify(base, renderInputs(operatorv1.Calico)).Objects()
+		Expect(create).To(HaveLen(len(baseCreate)))
+		Expect(del).To(HaveLen(len(baseDelete)))
+	})
+})

--- a/pkg/enterprise/whisker/suite_test.go
+++ b/pkg/enterprise/whisker/suite_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package whisker_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/enterprise"
+	eoptions "github.com/tigera/operator/pkg/enterprise/options"
+)
+
+var (
+	ext       = enterprise.New(operatorv1.CalicoEnterprise, eoptions.Options{})
+	calicoExt = enterprise.New(operatorv1.Calico, eoptions.Options{})
+)
+
+func TestWhisker(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "pkg/enterprise/whisker Suite")
+}

--- a/pkg/extensions/extensions.go
+++ b/pkg/extensions/extensions.go
@@ -25,6 +25,7 @@ type Set struct {
 	CSR               CSRExtension
 	Istio             IstioExtension
 	Goldmane          GoldmaneExtension
+	Whisker           WhiskerExtension
 }
 
 // Extensions is the variant behavior the operator runs with. The zero value extends
@@ -93,4 +94,11 @@ func (e Extensions) Goldmane() GoldmaneExtension {
 		return noopGoldmane{}
 	}
 	return e.set.Goldmane
+}
+
+func (e Extensions) Whisker() WhiskerExtension {
+	if e.set.Whisker == nil {
+		return noopWhisker{}
+	}
+	return e.set.Whisker
 }

--- a/pkg/extensions/whisker.go
+++ b/pkg/extensions/whisker.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extensions
+
+import (
+	"github.com/tigera/operator/pkg/render"
+)
+
+// WhiskerExtension is the variant's hook into the components the whisker controller
+// renders.
+type WhiskerExtension interface {
+	// Modify layers the variant onto a component the controller rendered.
+	Modify(c render.Component, ri render.Inputs) render.Component
+}
+
+// noopWhisker runs the core operator's behavior unchanged.
+type noopWhisker struct{}
+
+func (noopWhisker) Modify(c render.Component, _ render.Inputs) render.Component {
+	return c
+}

--- a/pkg/render/whisker/component.go
+++ b/pkg/render/whisker/component.go
@@ -135,14 +135,7 @@ func (c *Component) Objects() ([]client.Object, []client.Object) {
 
 	toCreate = append(toCreate, secret.ToRuntimeObjects(secret.CopyToNamespace(WhiskerNamespace, c.cfg.PullSecrets...)...)...)
 
-	// Whisker needs to be removed if the installation is not Calico, since it's not supported (yet!) for any other variant.
-	var toDelete []client.Object
-	if c.cfg.Installation.Variant != operatorv1.Calico {
-		toDelete = toCreate
-		toCreate = nil
-	}
-
-	toDelete = append(toDelete, c.deprecatedObjects()...)
+	toDelete := c.deprecatedObjects()
 
 	return toCreate, toDelete
 }

--- a/pkg/render/whisker/component_test.go
+++ b/pkg/render/whisker/component_test.go
@@ -58,7 +58,7 @@ var _ = Describe("ComponentRendering", func() {
 		Expect(objsToCreate).To(HaveLen(createObjs))
 		Expect(objsToDelete).To(HaveLen(delObjs))
 	},
-		Entry("Should return objects to create when variant is Calico",
+		Entry("Should return the whisker objects to create",
 			&whisker.Configuration{
 				Installation: &operatorv1.InstallationSpec{
 					KubernetesProvider: operatorv1.ProviderGKE,
@@ -70,19 +70,6 @@ var _ = Describe("ComponentRendering", func() {
 				Whisker:               &operatorv1.Whisker{Spec: operatorv1.WhiskerSpec{Notifications: ptr.To(operatorv1.Enabled)}},
 			},
 			numExpectedObjects, numDeprecatedObjects,
-		),
-		Entry("Should return objects to delete when variant is not Calico",
-			&whisker.Configuration{
-				Installation: &operatorv1.InstallationSpec{
-					KubernetesProvider: operatorv1.ProviderGKE,
-					Variant:            operatorv1.CalicoEnterprise,
-				},
-				TrustedCertBundle:     defaultTrustedCertBundle,
-				WhiskerKeyPair:        defaultWhiskerKeyPair,
-				WhiskerBackendKeyPair: defaultTLSKeyPair,
-				Whisker:               &operatorv1.Whisker{Spec: operatorv1.WhiskerSpec{Notifications: ptr.To(operatorv1.Enabled)}},
-			},
-			0, numExpectedObjects+numDeprecatedObjects,
 		),
 	)
 


### PR DESCRIPTION
## Description

The whisker render was deleting everything it produced when the variant wasn't Calico, which put variant knowledge in a base render package. The base render now produces the same objects either way, and the Enterprise extension moves them to the delete list, so an install upgraded from Calico still cleans up after itself.

Related: [CORE-13395](https://tigera.atlassian.net/browse/CORE-13395)

## Release Note

```release-note
None
```


[CORE-13395]: https://tigera.atlassian.net/browse/CORE-13395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ