### PR TITLE
Pass FelixConfiguration into the node and typha render

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1225,12 +1225,12 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 
 	// Build a configuration for rendering calico/typha.
 	typhaCfg := render.TyphaConfiguration{
-		K8sServiceEp:      k8sapi.Endpoint,
-		Installation:      &defaulted.Spec,
-		TLS:               typhaNodeTLS,
-		MigrateNamespaces: needsNamespaceMigration,
-		ClusterDomain:     r.opts.ClusterDomain,
-		FelixHealthPort:   *felixConfiguration.Spec.HealthPort,
+		K8sServiceEp:       k8sapi.Endpoint,
+		Installation:       &defaulted.Spec,
+		TLS:                typhaNodeTLS,
+		MigrateNamespaces:  needsNamespaceMigration,
+		ClusterDomain:      r.opts.ClusterDomain,
+		FelixConfiguration: felixConfiguration,
 	}
 	components = append(components, render.Typha(&typhaCfg))
 
@@ -1355,8 +1355,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		NodeAppArmorProfile:   nodeAppArmorProfile,
 		MigrateNamespaces:     needsNamespaceMigration,
 		CanRemoveCNIFinalizer: canRemoveCNI,
-		FelixHealthPort:       *felixConfiguration.Spec.HealthPort,
-		NodeCgroupV2Path:      felixConfiguration.Spec.CgroupV2Path,
+		FelixConfiguration:    felixConfiguration,
 		V3CRDs:                r.opts.UseV3CRDs,
 		ImageOverrides:        r.ext.Images(),
 	}
@@ -1745,7 +1744,7 @@ func (r *ReconcileInstallation) setDefaultsOnFelixConfiguration(ctx context.Cont
 
 	// Determine the felix health port to use. Prefer the configuration from FelixConfiguration,
 	// but default to 9099 (or 9199 on OpenShift). We will also write back whatever we select to FelixConfiguration.
-	felixHealthPort := 9099
+	felixHealthPort := render.DefaultFelixHealthPort
 	if install.Spec.KubernetesProvider.IsOpenShift() {
 		felixHealthPort = 9199
 	}

--- a/pkg/controller/utils/component_enterprise_test.go
+++ b/pkg/controller/utils/component_enterprise_test.go
@@ -17,6 +17,9 @@ package utils_test
 import (
 	"context"
 
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+	"k8s.io/utils/ptr"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -62,10 +65,10 @@ var _ = Describe("enterprise typha modifier integration", func() {
 				CNI:     &operatorv1.CNISpec{Type: operatorv1.PluginCalico},
 			}
 			typhaCfg := &render.TyphaConfiguration{
-				K8sServiceEp:    k8sapi.ServiceEndpoint{},
-				Installation:    instance,
-				ClusterDomain:   dns.DefaultClusterDomain,
-				FelixHealthPort: 9099,
+				K8sServiceEp:       k8sapi.ServiceEndpoint{},
+				Installation:       instance,
+				ClusterDomain:      dns.DefaultClusterDomain,
+				FelixConfiguration: &v3.FelixConfiguration{Spec: v3.FelixConfigurationSpec{HealthPort: ptr.To(9099)}},
 				TLS: &render.TyphaNodeTLS{
 					TrustedBundle:   certManager.CreateTrustedBundle(),
 					TyphaSecret:     typhaKeyPair,

--- a/pkg/enterprise/installation/node_enterprise_test.go
+++ b/pkg/enterprise/installation/node_enterprise_test.go
@@ -17,6 +17,9 @@ package installation_test
 import (
 	"context"
 
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+	"k8s.io/utils/ptr"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -136,12 +139,12 @@ var _ = Describe("node enterprise modifier integration", func() {
 	// modifier, exactly as the componentHandler does.
 	renderNodeObjects := func(ri render.Inputs) []client.Object {
 		cfg := &render.NodeConfiguration{
-			K8sServiceEp:    k8sapi.ServiceEndpoint{},
-			Installation:    instance,
-			TLS:             typhaNodeTLS,
-			ClusterDomain:   dns.DefaultClusterDomain,
-			FelixHealthPort: 9099,
-			IPPools:         instance.CalicoNetwork.IPPools,
+			K8sServiceEp:       k8sapi.ServiceEndpoint{},
+			Installation:       instance,
+			TLS:                typhaNodeTLS,
+			ClusterDomain:      dns.DefaultClusterDomain,
+			FelixConfiguration: &v3.FelixConfiguration{Spec: v3.FelixConfigurationSpec{HealthPort: ptr.To(9099)}},
+			IPPools:            instance.CalicoNetwork.IPPools,
 		}
 		comp := render.Node(cfg)
 		Expect(comp.ResolveImages(nil)).NotTo(HaveOccurred())
@@ -237,11 +240,11 @@ var _ = Describe("node enterprise modifier integration", func() {
 
 	It("adds the enterprise rules to the real typha cluster role", func() {
 		comp := render.Typha(&render.TyphaConfiguration{
-			K8sServiceEp:    k8sapi.ServiceEndpoint{},
-			Installation:    instance,
-			TLS:             typhaNodeTLS,
-			ClusterDomain:   dns.DefaultClusterDomain,
-			FelixHealthPort: 9099,
+			K8sServiceEp:       k8sapi.ServiceEndpoint{},
+			Installation:       instance,
+			TLS:                typhaNodeTLS,
+			ClusterDomain:      dns.DefaultClusterDomain,
+			FelixConfiguration: &v3.FelixConfiguration{Spec: v3.FelixConfigurationSpec{HealthPort: ptr.To(9099)}},
 		})
 		Expect(comp.ResolveImages(nil)).NotTo(HaveOccurred())
 		objs, _ := comp.Objects()

--- a/pkg/enterprise/installation/typha_noncluster_host_test.go
+++ b/pkg/enterprise/installation/typha_noncluster_host_test.go
@@ -99,11 +99,11 @@ var _ = Describe("non-cluster host typha", func() {
 	// exactly as the installation controller does.
 	renderTypha := func(ci controller.Inputs) []client.Object {
 		cfg := &render.TyphaConfiguration{
-			K8sServiceEp:    k8sapi.Endpoint,
-			Installation:    ci.RenderInputs.Installation,
-			TLS:             typhaNodeTLSFor(ci),
-			ClusterDomain:   dns.DefaultClusterDomain,
-			FelixHealthPort: 9099,
+			K8sServiceEp:       k8sapi.Endpoint,
+			Installation:       ci.RenderInputs.Installation,
+			TLS:                typhaNodeTLSFor(ci),
+			ClusterDomain:      dns.DefaultClusterDomain,
+			FelixConfiguration: ci.RenderInputs.FelixConfiguration,
 		}
 		component := render.Typha(cfg)
 		Expect(component.ResolveImages(nil)).NotTo(HaveOccurred())

--- a/pkg/enterprise/installation/typha_test.go
+++ b/pkg/enterprise/installation/typha_test.go
@@ -17,10 +17,12 @@ package installation_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
@@ -69,11 +71,11 @@ var _ = Describe("typha enterprise modifier", func() {
 	// exactly as the installation controller does.
 	renderTypha := func(r extensions.Extensions, install *operatorv1.InstallationSpec, ri render.Inputs) []client.Object {
 		component := render.Typha(&render.TyphaConfiguration{
-			K8sServiceEp:    k8sapi.ServiceEndpoint{},
-			Installation:    install,
-			TLS:             typhaNodeTLS,
-			ClusterDomain:   dns.DefaultClusterDomain,
-			FelixHealthPort: 9099,
+			K8sServiceEp:       k8sapi.ServiceEndpoint{},
+			Installation:       install,
+			TLS:                typhaNodeTLS,
+			ClusterDomain:      dns.DefaultClusterDomain,
+			FelixConfiguration: &v3.FelixConfiguration{Spec: v3.FelixConfigurationSpec{HealthPort: ptr.To(9099)}},
 		})
 		Expect(component.ResolveImages(nil)).NotTo(HaveOccurred())
 		objs, del := component.Objects()

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -30,6 +30,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
@@ -50,6 +52,10 @@ const (
 	BPFOperatorAnnotation      = "operator.tigera.io/bpfEnabled"
 
 	DisableKubeProxyKey = "operator.tigera.io/disable-kube-proxy"
+
+	// DefaultFelixHealthPort is the port Felix binds its health endpoints to when
+	// FelixConfiguration does not say.
+	DefaultFelixHealthPort = 9099
 
 	nodeCniConfigAnnotation   = "hash.operator.tigera.io/cni-config"
 	bgpLayoutHashAnnotation   = "hash.operator.tigera.io/bgp-layout"
@@ -130,12 +136,9 @@ type NodeConfiguration struct {
 	// configmap, rather than this "copy" semantic.
 	BGPLayouts *corev1.ConfigMap
 
-	// The health port that Felix should bind to. The controller reads FelixConfiguration
-	// and sets this.
-	FelixHealthPort int
-
-	// Node's CgroupV2Path override. The controller reads FelixConfiguration and sets this.
-	NodeCgroupV2Path string
+	// FelixConfiguration is the cluster's default FelixConfiguration, which the render
+	// reads Felix's health port and cgroup path from.
+	FelixConfiguration *v3.FelixConfiguration
 
 	// The bindMode read from the default BGPConfiguration. Used to trigger rolling updates
 	// should this value change.
@@ -156,6 +159,23 @@ func Node(cfg *NodeConfiguration) Component {
 		cfg.DefaultDNSPolicy = corev1.DNSClusterFirstWithHostNet
 	}
 	return &nodeComponent{cfg: cfg}
+}
+
+// felixHealthPort returns the port Felix binds its health endpoints to. The installation
+// controller defaults it, so an unset FelixConfiguration only happens in tests.
+func felixHealthPort(fc *v3.FelixConfiguration) int {
+	if fc == nil || fc.Spec.HealthPort == nil {
+		return DefaultFelixHealthPort
+	}
+	return *fc.Spec.HealthPort
+}
+
+// felixCgroupV2Path returns the cgroup v2 mount path override, or the empty string.
+func felixCgroupV2Path(fc *v3.FelixConfiguration) string {
+	if fc == nil {
+		return ""
+	}
+	return fc.Spec.CgroupV2Path
 }
 
 type nodeComponent struct {
@@ -1288,8 +1308,8 @@ func (c *nodeComponent) bpffsEnvvars() []corev1.EnvVar {
 		envVars = append(envVars, corev1.EnvVar{Name: "KUBERNETES_APISERVER_ENDPOINTS", Value: env})
 	}
 
-	if c.cfg.NodeCgroupV2Path != "" {
-		envVars = append(envVars, corev1.EnvVar{Name: "CALICO_CGROUP_PATH", Value: c.cfg.NodeCgroupV2Path})
+	if path := felixCgroupV2Path(c.cfg.FelixConfiguration); path != "" {
+		envVars = append(envVars, corev1.EnvVar{Name: "CALICO_CGROUP_PATH", Value: path})
 	}
 
 	return envVars
@@ -1454,7 +1474,7 @@ func (c *nodeComponent) nodeEnvVars() []corev1.EnvVar {
 		{Name: "CALICO_DISABLE_FILE_LOGGING", Value: "false"},
 		{Name: "FELIX_DEFAULTENDPOINTTOHOSTACTION", Value: "ACCEPT"},
 		{Name: "FELIX_HEALTHENABLED", Value: "true"},
-		{Name: "FELIX_HEALTHPORT", Value: fmt.Sprintf("%d", c.cfg.FelixHealthPort)},
+		{Name: "FELIX_HEALTHPORT", Value: fmt.Sprintf("%d", felixHealthPort(c.cfg.FelixConfiguration))},
 		{
 			Name: "NODENAME",
 			ValueFrom: &corev1.EnvVarSource{
@@ -1695,7 +1715,7 @@ func (c *nodeComponent) nodeLifecycle() *corev1.Lifecycle {
 // nodeProbes creates calico/node health probes. It returns in order: startupProbe, livenessProbe, readinessProbe
 func (c *nodeComponent) nodeProbes() (*corev1.Probe, *corev1.Probe, *corev1.Probe) {
 	// Determine liveness and readiness configuration for node.
-	livenessPort := intstr.FromInt(c.cfg.FelixHealthPort)
+	livenessPort := intstr.FromInt(felixHealthPort(c.cfg.FelixConfiguration))
 	var readinessCmd []string
 
 	readinessCmd = []string{components.CalicoBinaryPath, "component", "node", "health", "--bird-ready", "--felix-ready"}

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"strings"
 
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gstruct"
@@ -135,13 +137,13 @@ var _ = Describe("Node rendering tests", func() {
 
 				// Create a default configuration.
 				cfg = render.NodeConfiguration{
-					K8sServiceEp:    k8sServiceEp,
-					Installation:    defaultInstance,
-					TLS:             typhaNodeTLS,
-					ClusterDomain:   defaultClusterDomain,
-					FelixHealthPort: 9099,
-					IPPools:         defaultInstance.CalicoNetwork.IPPools,
-					ImageOverrides:  imageoverride.New(),
+					K8sServiceEp:       k8sServiceEp,
+					Installation:       defaultInstance,
+					TLS:                typhaNodeTLS,
+					ClusterDomain:      defaultClusterDomain,
+					FelixConfiguration: &v3.FelixConfiguration{Spec: v3.FelixConfigurationSpec{HealthPort: ptr.To(9099)}},
+					IPPools:            defaultInstance.CalicoNetwork.IPPools,
+					ImageOverrides:     imageoverride.New(),
 				}
 			})
 
@@ -1429,7 +1431,7 @@ var _ = Describe("Node rendering tests", func() {
 				defaultInstance.KubernetesProvider = operatorv1.ProviderOpenShift
 				defaultCNIConfDir, defaultCNIBinDir := render.DefaultCNIDirectories(defaultInstance.KubernetesProvider)
 				defaultInstance.CNI.ConfDir, defaultInstance.CNI.BinDir = &defaultCNIConfDir, &defaultCNIBinDir
-				cfg.FelixHealthPort = 9199
+				cfg.FelixConfiguration = &v3.FelixConfiguration{Spec: v3.FelixConfigurationSpec{HealthPort: ptr.To(9199)}}
 				component := render.Node(&cfg)
 				Expect(component.ResolveImages(nil)).To(BeNil())
 				resources, _ := component.Objects()
@@ -1839,6 +1841,31 @@ var _ = Describe("Node rendering tests", func() {
 				// Assert we set annotations properly.
 				Expect(ds.Spec.Template.Annotations["prometheus.io/scrape"]).To(Equal("true"))
 				Expect(ds.Spec.Template.Annotations["prometheus.io/port"]).To(Equal("1234"))
+			})
+
+			It("should set CALICO_CGROUP_PATH from FelixConfiguration", func() {
+				cfg.FelixConfiguration.Spec.CgroupV2Path = "/run/calico/cgroup"
+				component := render.Node(&cfg)
+				Expect(component.ResolveImages(nil)).To(BeNil())
+				resources, _ := component.Objects()
+
+				ds := rtest.GetResource(resources, "calico-node", "calico-system", "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
+				bootstrap := rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "ebpf-bootstrap")
+				Expect(bootstrap).NotTo(BeNil())
+				rtest.ExpectEnv(bootstrap.Env, "CALICO_CGROUP_PATH", "/run/calico/cgroup")
+			})
+
+			It("should not set CALICO_CGROUP_PATH when FelixConfiguration has no override", func() {
+				component := render.Node(&cfg)
+				Expect(component.ResolveImages(nil)).To(BeNil())
+				resources, _ := component.Objects()
+
+				ds := rtest.GetResource(resources, "calico-node", "calico-system", "apps", "v1", "DaemonSet").(*appsv1.DaemonSet)
+				bootstrap := rtest.GetContainer(ds.Spec.Template.Spec.InitContainers, "ebpf-bootstrap")
+				Expect(bootstrap).NotTo(BeNil())
+				for _, e := range bootstrap.Env {
+					Expect(e.Name).NotTo(Equal("CALICO_CGROUP_PATH"))
+				}
 			})
 
 			It("should not render a FlexVolume container if FlexVolumePath is set to None", func() {
@@ -2658,7 +2685,7 @@ var _ = Describe("Node rendering tests", func() {
 						defaultInstance.KubernetesProvider = operatorv1.ProviderOpenShift
 						defaultCNIConfDir, defaultCNIBinDir := render.DefaultCNIDirectories(defaultInstance.KubernetesProvider)
 						defaultInstance.CNI.ConfDir, defaultInstance.CNI.BinDir = &defaultCNIConfDir, &defaultCNIBinDir
-						cfg.FelixHealthPort = 9199
+						cfg.FelixConfiguration = &v3.FelixConfiguration{Spec: v3.FelixConfigurationSpec{HealthPort: ptr.To(9199)}}
 					}
 
 					if isEnterprise {

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -21,6 +21,9 @@ import (
 	glog "log"
 	"reflect"
 
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+	"k8s.io/utils/ptr"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -85,15 +88,15 @@ func allCalicoComponents(
 		BGPLayouts:          bgpLayout,
 		BirdTemplates:       bt,
 		MigrateNamespaces:   up,
-		FelixHealthPort:     9099,
+		FelixConfiguration:  &v3.FelixConfiguration{Spec: v3.FelixConfigurationSpec{HealthPort: ptr.To(9099)}},
 	}
 	typhaCfg := &render.TyphaConfiguration{
-		K8sServiceEp:      k8sServiceEp,
-		Installation:      cr,
-		TLS:               typhaNodeTLS,
-		ClusterDomain:     clusterDomain,
-		MigrateNamespaces: up,
-		FelixHealthPort:   9099,
+		K8sServiceEp:       k8sServiceEp,
+		Installation:       cr,
+		TLS:                typhaNodeTLS,
+		ClusterDomain:      clusterDomain,
+		MigrateNamespaces:  up,
+		FelixConfiguration: &v3.FelixConfiguration{Spec: v3.FelixConfigurationSpec{HealthPort: ptr.To(9099)}},
 	}
 	kcCfg := &kubecontrollers.KubeControllersConfiguration{
 		K8sServiceEp:      k8sServiceEp,

--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -25,6 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
@@ -76,9 +78,9 @@ type TyphaConfiguration struct {
 	MigrateNamespaces bool
 	ClusterDomain     string
 
-	// The health port that Felix is bound to. We configure Typha to bind to the port
-	// that is one less.
-	FelixHealthPort int
+	// FelixConfiguration is the cluster's default FelixConfiguration. Typha binds to the
+	// port one below Felix's health port.
+	FelixConfiguration *v3.FelixConfiguration
 }
 
 // Typha creates the typha daemonset and other resources for the daemonset to operate normally.
@@ -587,7 +589,7 @@ func (c *typhaComponent) typhaEnvVars(typhaSecret certificatemanagement.KeyPairI
 
 // typhaHealthPort returns the liveness and readiness port to use for typha.
 func typhaHealthPort(cfg *TyphaConfiguration) int {
-	return TyphaHealthPort(cfg.FelixHealthPort)
+	return TyphaHealthPort(felixHealthPort(cfg.FelixConfiguration))
 }
 
 // TyphaHealthPort returns the health port Typha binds to, given Felix's.

--- a/pkg/render/typha_test.go
+++ b/pkg/render/typha_test.go
@@ -17,6 +17,8 @@ package render_test
 import (
 	"fmt"
 
+	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gstruct"
@@ -70,11 +72,11 @@ var _ = Describe("Typha rendering tests", func() {
 		Expect(err).NotTo(HaveOccurred())
 		typhaNodeTLS = getTyphaNodeTLS(cli, certificateManager)
 		cfg = render.TyphaConfiguration{
-			K8sServiceEp:    k8sServiceEp,
-			TLS:             typhaNodeTLS,
-			Installation:    installation,
-			ClusterDomain:   defaultClusterDomain,
-			FelixHealthPort: 9099,
+			K8sServiceEp:       k8sServiceEp,
+			TLS:                typhaNodeTLS,
+			Installation:       installation,
+			ClusterDomain:      defaultClusterDomain,
+			FelixConfiguration: &v3.FelixConfiguration{Spec: v3.FelixConfigurationSpec{HealthPort: ptr.To(9099)}},
 		}
 	})
 
@@ -232,7 +234,7 @@ var _ = Describe("Typha rendering tests", func() {
 
 	It("should properly configure a non-default typha health port", func() {
 		// Set a non-default health port.
-		cfg.FelixHealthPort = 7878
+		cfg.FelixConfiguration = &v3.FelixConfiguration{Spec: v3.FelixConfigurationSpec{HealthPort: ptr.To(7878)}}
 
 		component := render.Typha(&cfg)
 		resources, _ := component.Objects()


### PR DESCRIPTION
## Description

The installation controller was reading Felix's health port and the cgroup v2 path override off FelixConfiguration and copying them into the node and typha render config as scalars. The render takes the FelixConfiguration itself instead, so a render modifier can read anything else it needs from the same object without the controller having to copy another field in.

The health port keeps its 9099 default, which the render falls back to when FelixConfiguration does not set one.

No behavior change. Adds test coverage for the cgroup path, which had none.

Related: [CORE-13402](https://tigera.atlassian.net/browse/CORE-13402)

## Release Note

```release-note
None
```


[CORE-13402]: https://tigera.atlassian.net/browse/CORE-13402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ