### PR TITLE
Mirror the new RBAC UI role grants onto rbacsync's ClusterRole (EV-6977)

### DIFF
--- a/pkg/enterprise/apiserver/extension.go
+++ b/pkg/enterprise/apiserver/extension.go
@@ -87,10 +87,6 @@ type apiServerRenderData struct {
 	// run. The base render resolves it too, but a modifier runs with no ImageSet.
 	calicoImage string
 
-	// rbacManagementEnabled mirrors the rbac-ui-config gate. ui-apis writes role bindings
-	// impersonating the caller, so tigera-network-admin needs the verbs itself.
-	rbacManagementEnabled bool
-
 	// bindingNamespaces is the set of tenant namespaces whose calico-apiserver ServiceAccount
 	// should be granted Linseed access. Empty for zero/single-tenant clusters; every tenant
 	// namespace for multi-tenant management clusters.
@@ -225,8 +221,10 @@ func (e *Extension) ExtendInputs(ctx context.Context, ci controller.Inputs) (con
 		return ci, nil, extensions.InvalidConfigf("having both a ManagementCluster and a ManagementClusterConnection is not supported")
 	}
 
-	rbacManagementEnabled, err := utils.RBACManagementEnabled(ctx, ci.Client, e.variant, e.opts.MultiTenant)
-	if err != nil {
+	// Nothing the apiserver renders branches on the switch any more, but an unreadable
+	// switch still means unknown cluster state, so degrade rather than reconcile on a
+	// guess.
+	if _, err := utils.RBACManagementEnabled(ctx, ci.Client, e.variant, e.opts.MultiTenant); err != nil {
 		return ci, nil, extensions.Degradedf(operatorv1.ResourceReadError, "error reading the RBAC management UI ConfigMap: %w", err)
 	}
 
@@ -345,7 +343,6 @@ func (e *Extension) ExtendInputs(ctx context.Context, ci controller.Inputs) (con
 		calicoImage:                 calicoImage,
 		bindingNamespaces:           bindingNamespaces,
 		cloud:                       e.opts.Cloud,
-		rbacManagementEnabled:       rbacManagementEnabled,
 	}
 	return ci, nil, nil
 }
@@ -1657,20 +1654,30 @@ func (c *apiServer) tigeraNetworkAdminClusterRole() *rbacv1.ClusterRole {
 
 	// ui-apis writes these impersonating the caller, so the apiserver enforces escalation
 	// against the user's own permissions.
-	if c.data.rbacManagementEnabled {
-		rules = append(rules,
-			rbacv1.PolicyRule{
-				APIGroups: []string{"rbac.authorization.k8s.io"},
-				Resources: []string{"clusterroles", "roles"},
-				Verbs:     []string{"get", "list", "watch"},
-			},
-			rbacv1.PolicyRule{
-				APIGroups: []string{"rbac.authorization.k8s.io"},
-				Resources: []string{"clusterrolebindings", "rolebindings"},
-				Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
-			},
-		)
-	}
+	//
+	// Ungated, like the switch above, because gating them on the switch races the user.
+	// Enabling the feature is a UI action: it writes the switch, and only then does this
+	// controller observe it and re-render the role. In that window ui-apis is already
+	// serving /team, so its first list of ClusterRoleBindings is rejected. The UI polls
+	// for the feature to come live and treats a 404 as "not ready yet", but a 403 is not
+	// a state it expects, so it surfaces a permission error instead of retrying and the
+	// user has to reload to recover.
+	//
+	// Leaving them ungated does not expose the feature -- ui-apis still gates every /team
+	// route on the switch -- but it does mean a network admin holds binding writes through
+	// the Kubernetes API whether or not the feature is on.
+	rules = append(rules,
+		rbacv1.PolicyRule{
+			APIGroups: []string{"rbac.authorization.k8s.io"},
+			Resources: []string{"clusterroles", "roles"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{"rbac.authorization.k8s.io"},
+			Resources: []string{"clusterrolebindings", "rolebindings"},
+			Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
+		},
+	)
 
 	// Privileges for lma.tigera.io have no effect on managed clusters.
 	if c.data.managementClusterConnection == nil {

--- a/pkg/enterprise/apiserver/extension.go
+++ b/pkg/enterprise/apiserver/extension.go
@@ -1622,6 +1622,39 @@ func (c *apiServer) tigeraNetworkAdminClusterRole() *rbacv1.ClusterRole {
 		},
 	}...)
 
+	// Write access to the switch, so a network admin can turn the RBAC management UI on
+	// without cluster-admin. Not gated: a rule rendered only while the feature is off
+	// could never be used to turn it on.
+	//
+	// bind carries two jobs. The UI greys out both its Enable and its Create Role button
+	// unless the caller holds escalate or bind on clusterroles, so without it a network
+	// admin cannot reach the feature at all. It is also what the apiserver's escalation
+	// check requires when ui-apis writes a binding to a ClusterRole whose permissions the
+	// caller does not already hold.
+	//
+	// create cannot be restricted by resource name -- the name is not in the request path
+	// at authorization time, so such a rule never matches -- so it admits creating any
+	// ConfigMap in the namespace. update, not patch: ui-apis writes the switch back with a
+	// full update, so patch alone cannot turn the feature off again.
+	rules = append(rules,
+		rbacv1.PolicyRule{
+			APIGroups: []string{"rbac.authorization.k8s.io"},
+			Resources: []string{"clusterroles"},
+			Verbs:     []string{"bind"},
+		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{""},
+			Resources: []string{"configmaps"},
+			Verbs:     []string{"create"},
+		},
+		rbacv1.PolicyRule{
+			APIGroups:     []string{""},
+			Resources:     []string{"configmaps"},
+			ResourceNames: []string{rbacmanagement.ConfigMapName},
+			Verbs:         []string{"get", "update"},
+		},
+	)
+
 	// ui-apis writes these impersonating the caller, so the apiserver enforces escalation
 	// against the user's own permissions.
 	if c.data.rbacManagementEnabled {

--- a/pkg/enterprise/apiserver/extension_test.go
+++ b/pkg/enterprise/apiserver/extension_test.go
@@ -425,6 +425,44 @@ var _ = Describe("API server enterprise modifier", func() {
 		Entry("no ConfigMap", nil, false),
 	)
 
+	DescribeTable("grants tigera-network-admin write access to the switch whatever the gate says",
+		func(gate *corev1.ConfigMap) {
+			var objs []client.Object
+			if gate != nil {
+				objs = append(objs, gate)
+			}
+			ci := apiServerControllerInputs(operatorv1.CalicoEnterprise, nil, objs...)
+			eci, _, err := ext.APIServer().ExtendInputs(ctx, ci)
+			Expect(err).NotTo(HaveOccurred())
+
+			rendered, _ := renderAPIServer(ci, eci.RenderInputs, apiServerKeyPair(ci))
+			networkAdmin, ok := extensions.FindObject[*rbacv1.ClusterRole](rendered, "tigera-network-admin")
+			Expect(ok).To(BeTrue())
+
+			// A rule rendered only while the feature is off could never be used to turn it
+			// on, so all three are ungated. bind additionally ungates the UI's buttons.
+			Expect(networkAdmin.Rules).To(ContainElement(rbacv1.PolicyRule{
+				APIGroups: []string{"rbac.authorization.k8s.io"},
+				Resources: []string{"clusterroles"},
+				Verbs:     []string{"bind"},
+			}))
+			Expect(networkAdmin.Rules).To(ContainElement(rbacv1.PolicyRule{
+				APIGroups: []string{""},
+				Resources: []string{"configmaps"},
+				Verbs:     []string{"create"},
+			}))
+			Expect(networkAdmin.Rules).To(ContainElement(rbacv1.PolicyRule{
+				APIGroups:     []string{""},
+				Resources:     []string{"configmaps"},
+				ResourceNames: []string{rbacmanagement.ConfigMapName},
+				Verbs:         []string{"get", "update"},
+			}))
+		},
+		Entry("enabled", rbacManagementGate("true")),
+		Entry("disabled", rbacManagementGate("false")),
+		Entry("no ConfigMap", nil),
+	)
+
 	It("reads the gate on a managed cluster, which carries tigera-network-admin too", func() {
 		ci := apiServerControllerInputs(operatorv1.CalicoEnterprise, nil,
 			&operatorv1.ManagementClusterConnection{ObjectMeta: metav1.ObjectMeta{Name: utils.DefaultEnterpriseInstanceKey.Name}},

--- a/pkg/enterprise/apiserver/extension_test.go
+++ b/pkg/enterprise/apiserver/extension_test.go
@@ -393,8 +393,8 @@ var _ = Describe("API server enterprise modifier", func() {
 		Expect(svc.Spec.Ports).To(ContainElement(HaveField("Name", render.QueryServerPortName)))
 	})
 
-	DescribeTable("grants tigera-network-admin the role management verbs only when RBAC management is enabled",
-		func(gate *corev1.ConfigMap, expected bool) {
+	DescribeTable("grants tigera-network-admin the role management verbs whatever the gate says",
+		func(gate *corev1.ConfigMap) {
 			var objs []client.Object
 			if gate != nil {
 				objs = append(objs, gate)
@@ -409,20 +409,25 @@ var _ = Describe("API server enterprise modifier", func() {
 
 			// ui-apis writes bindings impersonating the caller, so the caller's own role
 			// has to carry the verbs or the apiserver's escalation check rejects it.
-			matcher := ContainElement(rbacv1.PolicyRule{
+			//
+			// Rendered whatever the gate says: gating them races the user, who enables the
+			// feature from the UI. ui-apis starts serving /team as soon as the switch is
+			// written, before this controller has re-rendered the role, and the resulting
+			// 403 is not a state the UI retries on.
+			Expect(networkAdmin.Rules).To(ContainElement(rbacv1.PolicyRule{
 				APIGroups: []string{"rbac.authorization.k8s.io"},
 				Resources: []string{"clusterrolebindings", "rolebindings"},
 				Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
-			})
-			if expected {
-				Expect(networkAdmin.Rules).To(matcher)
-			} else {
-				Expect(networkAdmin.Rules).NotTo(matcher)
-			}
+			}))
+			Expect(networkAdmin.Rules).To(ContainElement(rbacv1.PolicyRule{
+				APIGroups: []string{"rbac.authorization.k8s.io"},
+				Resources: []string{"clusterroles", "roles"},
+				Verbs:     []string{"get", "list", "watch"},
+			}))
 		},
-		Entry("enabled", rbacManagementGate("true"), true),
-		Entry("disabled", rbacManagementGate("false"), false),
-		Entry("no ConfigMap", nil, false),
+		Entry("enabled", rbacManagementGate("true")),
+		Entry("disabled", rbacManagementGate("false")),
+		Entry("no ConfigMap", nil),
 	)
 
 	DescribeTable("grants tigera-network-admin write access to the switch whatever the gate says",

--- a/pkg/enterprise/installation/kubecontrollers.go
+++ b/pkg/enterprise/installation/kubecontrollers.go
@@ -382,9 +382,10 @@ func rbacSyncIDPGroupsRole() []client.Object {
 // context roles). The comment on each rule names the managed role(s) it covers.
 //
 // Only the grants unique to the managed roles live here. Core resources those
-// roles also grant (namespaces, nodes, services, pods, clusterinformations,
-// hostendpoints, serviceaccounts, tiers) are already held by the common
-// kube-controllers rules above, which satisfy the escalation guard for them.
+// roles also grant (namespaces, nodes, services, pods, configmaps,
+// clusterinformations, hostendpoints, serviceaccounts, tiers) are already held
+// by the common kube-controllers rules above, which satisfy the escalation
+// guard for them.
 func rbacSyncControllerRules() []rbacv1.PolicyRule {
 	return []rbacv1.PolicyRule{
 		// RBAC management: the ClusterRoles and bindings the controller
@@ -426,7 +427,8 @@ func rbacSyncControllerRules() []rbacv1.PolicyRule {
 		// The per-feature pages, view and modify: Dashboards, Managed Clusters,
 		// Global Network Sets, Network Sets, Policy Recommendations, Packet
 		// Captures, Alerts and Security Events, Threat Feeds, Compliance
-		// Reports, Webhooks, Deep Packet Inspection, and Egress Gateways.
+		// Reports, Deep Packet Inspection, and Egress Gateways. Webhooks has
+		// its own rule below, because it spans two API groups.
 		// Mirrors the matching calico-ui-<feature>-{view,mod} roles
 		// (e.g. calico-ui-managed-clusters-{view,mod}, calico-ui-alerts-
 		// {view,mod}, calico-ui-egress-gateways-{view,mod}).
@@ -444,6 +446,7 @@ func rbacSyncControllerRules() []rbacv1.PolicyRule {
 				"deeppacketinspections/status",
 				"egressgatewaypolicies",
 				"externalnetworks",
+				"networks",
 				"globalalerts",
 				"globalalerts/status",
 				"globalalerttemplates",
@@ -455,7 +458,33 @@ func rbacSyncControllerRules() []rbacv1.PolicyRule {
 				"globalreporttypes",
 				"packetcaptures",
 				"packetcaptures/files",
-				"securityeventwebhooks",
+			},
+			Verbs: []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+		},
+		// Webhooks, view and modify: securityeventwebhooks is reachable under
+		// both the aggregated API group and the CRD group behind it, and the
+		// managed role grants reads on both. Writes go through the aggregated
+		// group only, so that is the only group needing the write verbs here.
+		// Mirrors calico-ui-webhooks-{view,mod}.
+		{
+			APIGroups: []string{"projectcalico.org"},
+			Resources: []string{"securityeventwebhooks"},
+			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+		},
+		{
+			APIGroups: []string{"crd.projectcalico.org"},
+			Resources: []string{"securityeventwebhooks"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+		// Admin Network Policies, view and modify: the Kubernetes admin network
+		// policy API is tierless, so it is granted outside the tier rules above.
+		// Mirrors calico-ui-admin-network-policies-{view,mod}.
+		{
+			APIGroups: []string{"policy.networking.k8s.io"},
+			Resources: []string{
+				"adminnetworkpolicies",
+				"baselineadminnetworkpolicies",
+				"clusternetworkpolicies",
 			},
 			Verbs: []string{"get", "list", "watch", "create", "update", "patch", "delete"},
 		},
@@ -516,12 +545,54 @@ func rbacSyncControllerRules() []rbacv1.PolicyRule {
 			Verbs:     []string{"get"},
 		},
 		// Manager UI load: feature-enabled checks for Application Layer / WAF,
-		// Packet Capture, and Intrusion Detection. Mirrors calico-ui-cluster-
-		// context (which bundles the compliances check above into the same rule).
+		// Gateway API, Packet Capture, and Intrusion Detection. Mirrors
+		// calico-ui-cluster-context (which bundles the compliances check above
+		// into the same rule).
 		{
 			APIGroups: []string{"operator.tigera.io"},
-			Resources: []string{"applicationlayers", "packetcaptureapis", "intrusiondetections"},
+			Resources: []string{"applicationlayers", "gatewayapis", "packetcaptureapis", "intrusiondetections"},
 			Verbs:     []string{"get"},
+		},
+		// WAF, view and modify: the policy, plugin and validation policy
+		// resources the WAF pages read and write. Mirrors calico-ui-waf-
+		// {view,mod}.
+		//
+		// KubeControllersEnterpriseCommonRules already grants these through
+		// wafRules(), but only when the GatewayAPI CR is present. The rbacsync
+		// controller needs them whenever RBAC management is enabled, so they are
+		// repeated here rather than relying on that gate — otherwise the managed
+		// WAF roles are creatable on Gateway API clusters and rejected by the
+		// escalation guard everywhere else.
+		{
+			APIGroups: []string{"applicationlayer.projectcalico.org"},
+			Resources: []string{
+				"globalwafpolicies",
+				"globalwafplugins",
+				"globalwafvalidationpolicies",
+				"wafpolicies",
+				"wafplugins",
+				"wafvalidationpolicies",
+			},
+			Verbs: []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+		},
+		// WAF, view and modify: the Gateway API objects a WAF policy attaches
+		// to, offered as attach targets. Read-only on both managed variants.
+		// Mirrors calico-ui-waf-{view,mod}. Same wafRules() gating caveat as
+		// the rule above.
+		{
+			APIGroups: []string{"gateway.networking.k8s.io"},
+			Resources: []string{"gateways", "httproutes"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+		// WAF, view and modify: the deployments the WAF configuration page
+		// displays; the mod role also patches a deployment's pod template to
+		// toggle sidecar WAF. Mirrors calico-ui-waf-{view,mod}. The base
+		// kube-controllers rules grant apps/daemonsets only, scoped to
+		// calico-node, so none of this is already held.
+		{
+			APIGroups: []string{"apps"},
+			Resources: []string{"deployments"},
+			Verbs:     []string{"get", "list", "watch", "patch"},
 		},
 		// Global Network Sets and Network Sets, view and modify: listing the
 		// pods a network set selects. Mirrors the pods grant on calico-ui-

--- a/pkg/enterprise/installation/kubecontrollers_test.go
+++ b/pkg/enterprise/installation/kubecontrollers_test.go
@@ -393,6 +393,103 @@ var _ = Describe("calico-kube-controllers enterprise surface", func() {
 			Expect(enabledControllers(create)).NotTo(ContainSubstring("rbacsync"))
 		})
 
+		// Kubernetes' privilege-escalation guard lets the controller create a
+		// ClusterRole only if it already holds every permission that role
+		// grants. So each grant the managed calico-ui-* roles make has to be
+		// mirrored here, or rbacsync's create is rejected and the sync cycle
+		// aborts. These entries are the ones added for EV-6977; the resource is
+		// enough to pin, since the whole rule is what would go missing.
+		DescribeTable("mirrors the managed roles' grants so rbacsync clears the escalation guard",
+			func(apiGroup, resource string) {
+				create, _ := renderWith(ext, gate("true"))
+				role, ok := extensions.FindObject[*rbacv1.ClusterRole](create, kubecontrollers.KubeControllerRole)
+				Expect(ok).To(BeTrue())
+				Expect(role.Rules).To(ContainElement(SatisfyAll(
+					HaveField("APIGroups", ContainElement(apiGroup)),
+					HaveField("Resources", ContainElement(resource)),
+				)), "no rule grants %s/%s", apiGroup, resource)
+			},
+			Entry("the Gateway API enabled check on cluster-context", "operator.tigera.io", "gatewayapis"),
+			Entry("WAF policies", "applicationlayer.projectcalico.org", "globalwafpolicies"),
+			Entry("WAF policy attach targets", "gateway.networking.k8s.io", "httproutes"),
+			Entry("the deployments the WAF page displays", "apps", "deployments"),
+			Entry("admin network policies", "policy.networking.k8s.io", "adminnetworkpolicies"),
+			Entry("baseline admin network policies", "policy.networking.k8s.io", "baselineadminnetworkpolicies"),
+			Entry("cluster network policies", "policy.networking.k8s.io", "clusternetworkpolicies"),
+			Entry("networks, which egress-gateways-mod writes", "projectcalico.org", "networks"),
+			Entry("security event webhooks under the CRD group", "crd.projectcalico.org", "securityeventwebhooks"),
+		)
+
+		It("grants networks the modify verbs, not just the IPAM syncer's reads", func() {
+			// The common rules already grant networks watch/list/get for the
+			// node controller. calico-ui-egress-gateways-mod also writes them,
+			// so a read-only grant would not clear the escalation guard.
+			create, _ := renderWith(ext, gate("true"))
+			role, ok := extensions.FindObject[*rbacv1.ClusterRole](create, kubecontrollers.KubeControllerRole)
+			Expect(ok).To(BeTrue())
+			Expect(role.Rules).To(ContainElement(SatisfyAll(
+				HaveField("APIGroups", ContainElement("projectcalico.org")),
+				HaveField("Resources", ContainElement("networks")),
+				HaveField("Verbs", ContainElements("create", "update", "patch", "delete")),
+			)))
+		})
+
+		It("grants deployments patch for the WAF sidecar toggle", func() {
+			// calico-ui-waf-mod patches a deployment's pod template to enable
+			// sidecar WAF, so a read-only grant would not clear the escalation
+			// guard for that role.
+			create, _ := renderWith(ext, gate("true"))
+			role, ok := extensions.FindObject[*rbacv1.ClusterRole](create, kubecontrollers.KubeControllerRole)
+			Expect(ok).To(BeTrue())
+			Expect(role.Rules).To(ContainElement(SatisfyAll(
+				HaveField("APIGroups", ContainElement("apps")),
+				HaveField("Resources", ContainElement("deployments")),
+				HaveField("Verbs", ContainElement("patch")),
+			)))
+		})
+
+		It("keeps the webhooks CRD group read-only", func() {
+			// The managed role writes securityeventwebhooks through the
+			// aggregated group only, so the escalation guard needs write here
+			// on that group and reads on the CRD group behind it. Write on the
+			// CRD group would be privilege the catalogue never hands out.
+			create, _ := renderWith(ext, gate("true"))
+			role, ok := extensions.FindObject[*rbacv1.ClusterRole](create, kubecontrollers.KubeControllerRole)
+			Expect(ok).To(BeTrue())
+
+			for _, rule := range role.Rules {
+				for _, group := range rule.APIGroups {
+					if group != "crd.projectcalico.org" {
+						continue
+					}
+					for _, resource := range rule.Resources {
+						if resource != "securityeventwebhooks" {
+							continue
+						}
+						Expect(rule.Verbs).NotTo(ContainElements("create", "update", "patch", "delete"),
+							"the CRD group must stay read-only for securityeventwebhooks")
+					}
+				}
+			}
+
+			Expect(role.Rules).To(ContainElement(SatisfyAll(
+				HaveField("APIGroups", ContainElement("projectcalico.org")),
+				HaveField("Resources", ContainElement("securityeventwebhooks")),
+				HaveField("Verbs", ContainElements("create", "update", "patch", "delete")),
+			)), "the aggregated group must carry the write verbs")
+		})
+
+		It("withholds the rbacsync-only grants when the feature is off", func() {
+			// policy.networking.k8s.io is granted by nothing else in the
+			// kube-controllers role, so it tracks the gate exactly.
+			create, _ := renderWith(ext, gate("false"))
+			role, ok := extensions.FindObject[*rbacv1.ClusterRole](create, kubecontrollers.KubeControllerRole)
+			Expect(ok).To(BeTrue())
+			Expect(role.Rules).NotTo(ContainElement(
+				HaveField("APIGroups", ContainElement("policy.networking.k8s.io")),
+			))
+		})
+
 		It("never creates the ConfigMap itself", func() {
 			create, _ := renderWith(ext, gate("true"))
 			_, ok := extensions.FindObject[*corev1.ConfigMap](create, rbacmanagement.ConfigMapName)


### PR DESCRIPTION
## Description

Companion to **[calico-private#13388](https://github.com/tigera/calico-private/pull/13388)** (EV-6977). **That PR cannot merge until this one does.**

calico-private adds resources to the managed `calico-ui-*` role catalogue to close gaps against what `tigera-ui-user` and `tigera-network-admin` already ship. Kubernetes' privilege-escalation guard only lets `calico-kube-controllers` create a ClusterRole granting permissions it already holds, so each of those grants has to be mirrored in `rbacSyncControllerRules()` — which is exactly what that function exists for, per its own doc comment.

The failure without this change is not partial. The rbacsync controller ensures `cluster-context` first and returns on error, so the `gatewayapis` grant alone would abort the whole sync cycle — tier roles and LMA roles included — with a forbidden error on every tick.

### What's added

| Grant | Verbs | Managed role that needs it |
| --- | --- | --- |
| `operator.tigera.io/gatewayapis` | `get` | `calico-ui-cluster-context` |
| `applicationlayer.projectcalico.org` (6 WAF resources) | full CRUD | `calico-ui-waf-{view,mod}` |
| `gateway.networking.k8s.io/gateways,httproutes` | `get,list,watch` | `calico-ui-waf-{view,mod}` |
| `apps/deployments` | `get,list,watch,patch` | `calico-ui-waf-{view,mod}` |
| `policy.networking.k8s.io` (3 resources) | full CRUD | `calico-ui-admin-network-policies-{view,mod}` |
| `projectcalico.org/networks` | full CRUD | `calico-ui-egress-gateways-mod` |
| `projectcalico.org/securityeventwebhooks` | full CRUD | `calico-ui-webhooks-{view,mod}` |
| `crd.projectcalico.org/securityeventwebhooks` | `get,list,watch` | `calico-ui-webhooks-{view,mod}` |

Three of these deserve a second look:

- **`networks`** is already granted `watch,list,get` by the common rules, for the node controller's IPAM syncer. The egress-gateways *modify* role writes it, so the read-only grant does not clear the guard. It joins the existing `projectcalico.org` CRUD rule next to `externalnetworks`.
- **`apps/deployments` carries `patch`.** `calico-ui-waf-mod` toggles sidecar WAF by patching a deployment's pod template, which the console does against the apiserver directly rather than through ui-apis, so a read-only grant would not clear the guard for that role. Nothing else grants it: the base rules cover `apps/daemonsets` scoped to `calico-node`, and the migration role is read-only. This mirrors what `tigera-network-admin` already ships — see the [thread on calico-private#13388](https://github.com/tigera/calico-private/pull/13388#discussion_r3865685001) for the discussion of the cluster-wide scope and the follow-up it needs.
- **The WAF and Gateway API rules already exist** in `KubeControllersEnterpriseCommonRules` via `wafRules()` — but gated on `gatewayAPIPresent`. rbacsync needs them whenever RBAC management is enabled, independent of whether the GatewayAPI CR exists, so they are repeated in `rbacSyncControllerRules()` rather than leaning on that gate. Without that, the managed WAF roles would be creatable on Gateway API clusters and rejected by the escalation guard everywhere else. Open to instead widening the `wafRules()` gate to `gatewayAPIPresent || rbacManagementEnabled` if that reads better — it trades the duplication for a wider blast radius.

`securityeventwebhooks` moves out of the `projectcalico.org`-only list into its own rules now that it spans two API groups. The two groups are granted asymmetrically, mirroring the catalogue: the managed role writes through the aggregated `projectcalico.org` API, which validates the object, and only reads the CRD group behind it, so the escalation guard needs write on the former and reads on the latter. A test fails if the CRD group regains the write verbs.

Not needed, already held: `configmaps` (common rules — this is what covers the `coreruleset-default` read on the WAF roles), `services` including `watch` (base rules grant `get,list,update,watch`), and the two new `lma.tigera.io` log types (the existing `lma.tigera.io/cluster get` rule is unscoped by resource name).

I checked coverage in the other direction too: every API group and resource the catalogue grants — across `resourceroles.go`, `tierroles.go` and the LMA log roles — is held by the rendered role once this lands.

### Testing

- A `DescribeTable` asserting each new grant is present on the rendered `calico-kube-controllers` ClusterRole when the gate is on, one entry per resource.
- A test that `networks` carries the modify verbs specifically, not just the IPAM syncer's reads.
- A test that `apps/deployments` carries `patch`.
- A test that the `crd.projectcalico.org` group stays read-only for `securityeventwebhooks` while the aggregated group carries the write verbs.
- A negative test that `policy.networking.k8s.io` — granted by nothing else in the role — is absent when the feature is off.
- I confirmed the tests are not vacuous by reverting the `gatewayapis` and `networks` additions; both fail as intended.
- `go test ./pkg/enterprise/installation/...` passes.

Affects Calico Enterprise only, and only when RBAC management is enabled.

## Release Note

```release-note
None
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`
