### PR TITLE
Bump Go to 1.26.7 (release-v1.42)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ REPO?=tigera/operator
 PACKAGE_NAME?=github.com/tigera/operator
 LOCAL_USER_ID?=$(shell id -u $$USER)
 # The project Go version.
-GO_VERSION?=1.26.6
+GO_VERSION?=1.26.7
 # Version of Kubernetes to use for dependencies, tests, and kubectl.
 K8S_VERSION?=v1.36.3
 # The version of LLVM to use for the go-build image.

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/tigera/operator/api
 
-go 1.26.6
+go 1.26.7
 
 require (
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.80.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tigera/operator
 
-go 1.26.6
+go 1.26.7
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0


### PR DESCRIPTION
Moves `release-v1.42` to the newest Go 1.26.x so the stdlib compiled into the shipped operator binary stays current.

**This is not a CVE bump.** The August stdlib advisories (CVE-2026-39821, CVE-2026-46600) were fixed in Go 1.26.6, which this branch already builds with after #5202. Go 1.26.7 has no `Security` section in the release history at all — its entire content is one `net/http` backport, [golang/go#80927](https://github.com/golang/go/issues/80927): `ReadHeaderTimeout` stayed armed after an unencrypted HTTP/2 (h2c) handoff, so a long-lived h2c connection could be torn down mid-stream once the header deadline elapsed.

Flagging that explicitly because the previous two bumps on this branch were scan-driven and this one is not — it is routine currency, and worth taking on its own terms rather than waiting for the next scan.

### Changes

| File | |
|---|---|
| `Makefile` | `GO_VERSION?=` 1.26.6 -> 1.26.7 |
| `go.mod`, `api/go.mod` | `go` directive 1.26.6 -> 1.26.7 |

Those are the only three places this branch pins a Go version — `GO_BUILD_VER` and `CALICO_BUILD` derive from `GO_VERSION`, and there is no `GOTOOLCHAIN` override or separate lint image pin here (unlike `release-v1.40`, which carries both). The `go` directives move with `GO_VERSION`, matching the previous bump (1b0ff67fc). No dependency changes, so `go.sum` is untouched.

### No toolchain change needed

`calico/go-build` already publishes `1.26.7-llvm21.1.8-k8s1.36.3`, which matches this branch's `LLVM_VERSION` (21.1.8) and `K8S_VERSION` (v1.36.3). That tag came from projectcalico/toolchain#886, merged 2026-08-20 17:48 UTC and published 19:23 UTC.

Verified locally: the repo's pre-commit hook ran inside `calico/go-build:1.26.7-llvm21.1.8-k8s1.36.3-amd64` while preparing this branch, and the image reports `go version go1.26.7 linux/amd64`.

### Other branches

Not touched here, for the record:

- `release-v1.40` is on `GO_VERSION?=1.25.13`, so **1.25.14** is the bump that applies there. It also has `GOTOOLCHAIN=go1.26.6+auto` and a separate `CALICO_BUILD_LINT` pinned to `calico/go-build:1.26.6-...`, both of which would move to 1.26.7. Happy to raise that separately if wanted.
- `master`, `release-v1.43` and `release-v1.43-2` are all still on 1.26.5 and would need 1.26.6 first, which is the security bump — a different conversation from this one.

**Release note:**
```release-note
Built the operator image with Go 1.26.7, which fixes a net/http bug where ReadHeaderTimeout stayed active after an unencrypted HTTP/2 handoff.
```
