### PR TITLE
Move the goldmane non-Calico cleanup behind an Enterprise modifier

### DIFF
--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -367,9 +367,7 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 		r.client,
 		r.scheme,
 		instance,
-		utils.WithModifier(func(c render.Component) render.Component {
-			return r.ext.Modify(c, ci.RenderInputs)
-		}),
+		utils.WithExtension(r.ext, ci.RenderInputs),
 	)
 
 	var holdCutover bool

--- a/pkg/controller/clusterconnection/clusterconnection_controller.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller.go
@@ -422,9 +422,7 @@ func (r *ReconcileConnection) Reconcile(ctx context.Context, request reconcile.R
 		r.cli,
 		r.scheme,
 		managementClusterConnection,
-		utils.WithModifier(func(c render.Component) render.Component {
-			return r.ext.Modify(c, ci.RenderInputs)
-		}),
+		utils.WithExtension(r.ext, ci.RenderInputs),
 	)
 	guardianCfg := &render.GuardianConfiguration{
 		URL:                         managementClusterConnection.Spec.ManagementClusterAddr,

--- a/pkg/controller/goldmane/controller.go
+++ b/pkg/controller/goldmane/controller.go
@@ -37,6 +37,7 @@ import (
 	"github.com/tigera/operator/pkg/controller/utils/imageset"
 	"github.com/tigera/operator/pkg/ctrlruntime"
 	"github.com/tigera/operator/pkg/dns"
+	"github.com/tigera/operator/pkg/extensions"
 	"github.com/tigera/operator/pkg/render"
 	rcertificatemanagement "github.com/tigera/operator/pkg/render/certificatemanagement"
 	"github.com/tigera/operator/pkg/render/goldmane"
@@ -127,6 +128,7 @@ func newReconciler(
 		status:        statusMgr,
 		clusterDomain: opts.ClusterDomain,
 		variant:       opts.Variant,
+		ext:           opts.Extensions.Goldmane(),
 	}
 	c.status.Run(opts.ShutdownContext)
 	return c
@@ -143,6 +145,7 @@ type Reconciler struct {
 	status        status.StatusManager
 	clusterDomain string
 	variant       operatorv1.ProductVariant
+	ext           extensions.GoldmaneExtension
 }
 
 // Reconcile reads that state of the cluster for a Goldmane object and makes changes based on the
@@ -256,7 +259,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 
-	ch := utils.NewComponentHandler(log, r.cli, r.scheme, goldmaneCR)
+	ri := render.Inputs{
+		Installation:  installationSpec,
+		ClusterDomain: r.clusterDomain,
+		TrustedBundle: trustedBundle,
+	}
+	ch := utils.NewComponentHandler(log, r.cli, r.scheme, goldmaneCR, utils.WithExtension(r.ext, ri))
 	cfg := &goldmane.Configuration{
 		PullSecrets:                 pullSecrets,
 		OpenShift:                   r.provider.IsOpenShift(),

--- a/pkg/controller/goldmane/controller_test.go
+++ b/pkg/controller/goldmane/controller_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/tigera/operator/pkg/controller/certificatemanager"
 	"github.com/tigera/operator/pkg/controller/status"
 	ctrlrfake "github.com/tigera/operator/pkg/ctrlruntime/client/fake"
+	"github.com/tigera/operator/pkg/extensions"
 	"github.com/tigera/operator/pkg/render"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
 	"github.com/tigera/operator/pkg/render/goldmane"
@@ -127,6 +128,7 @@ var _ = Describe("Goldmane controller tests", func() {
 			provider:      operatorv1.ProviderNone,
 			status:        mockStatus,
 			clusterDomain: "cluster.local",
+			ext:           extensions.Extensions{}.Goldmane(),
 		}
 	})
 

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1146,9 +1146,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		r.client,
 		r.scheme,
 		instance,
-		utils.WithModifier(func(c render.Component) render.Component {
-			return r.ext.Modify(c, ci.RenderInputs)
-		}),
+		utils.WithExtension(r.ext, ci.RenderInputs),
 	)
 
 	// Render namespaces first - this ensures that any other controllers blocked on namespace existence can proceed.

--- a/pkg/controller/installation/windows_controller.go
+++ b/pkg/controller/installation/windows_controller.go
@@ -377,9 +377,7 @@ func (r *ReconcileWindows) Reconcile(ctx context.Context, request reconcile.Requ
 		r.client,
 		r.scheme,
 		instance,
-		utils.WithModifier(func(c render.Component) render.Component {
-			return r.ext.Modify(c, ci.RenderInputs)
-		}),
+		utils.WithExtension(r.ext, ci.RenderInputs),
 	)
 	if err := handler.CreateOrUpdateOrDelete(ctx, component, nil); err != nil {
 		r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error creating / updating resource", err, reqLogger)

--- a/pkg/controller/utils/component.go
+++ b/pkg/controller/utils/component.go
@@ -97,6 +97,19 @@ func WithModifier(m ComponentModifier) ComponentHandlerOption {
 	return func(c *componentHandler) { c.modify = m }
 }
 
+// ComponentExtension is the part of a variant's extension that layers itself onto a
+// rendered component.
+type ComponentExtension interface {
+	Modify(c render.Component, ri render.Inputs) render.Component
+}
+
+// WithExtension runs every component through the variant's extension.
+func WithExtension(e ComponentExtension, ri render.Inputs) ComponentHandlerOption {
+	return WithModifier(func(c render.Component) render.Component {
+		return e.Modify(c, ri)
+	})
+}
+
 // cr is allowed to be nil in the case we don't want to put ownership on a resource,
 // this is useful for CRD management so that they are not removed automatically.
 func NewComponentHandler(log logr.Logger, cli client.Client, scheme *runtime.Scheme, cr metav1.Object, opts ...ComponentHandlerOption) ComponentHandler {

--- a/pkg/enterprise/goldmane/extension.go
+++ b/pkg/enterprise/goldmane/extension.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package goldmane
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/extensions"
+	"github.com/tigera/operator/pkg/render"
+	rgoldmane "github.com/tigera/operator/pkg/render/goldmane"
+)
+
+// Extension is the Calico Enterprise behavior for the goldmane controller.
+type Extension struct {
+	variant operatorv1.ProductVariant
+}
+
+var _ extensions.GoldmaneExtension = &Extension{}
+
+// New returns the goldmane extension for the variant the operator resolved.
+func New(variant operatorv1.ProductVariant) *Extension {
+	return &Extension{variant: variant}
+}
+
+// Modify dispatches over the components the goldmane controller renders.
+func (e *Extension) Modify(c render.Component, ri render.Inputs) render.Component {
+	switch c.(type) {
+	case *rgoldmane.Component:
+		return extensions.Decorate(c, ri, e.variant, deleteGoldmane)
+	default:
+		return c
+	}
+}
+
+// deleteGoldmane moves everything goldmane rendered to the delete list. Enterprise has
+// no goldmane, so an install upgraded from Calico cleans up after itself.
+func deleteGoldmane(create, del []client.Object) ([]client.Object, []client.Object) {
+	return nil, append(del, create...)
+}

--- a/pkg/enterprise/goldmane/extension_test.go
+++ b/pkg/enterprise/goldmane/extension_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package goldmane_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/enterprise"
+	eoptions "github.com/tigera/operator/pkg/enterprise/options"
+	"github.com/tigera/operator/pkg/render"
+	rgoldmane "github.com/tigera/operator/pkg/render/goldmane"
+	"github.com/tigera/operator/pkg/tls/certificatemanagement"
+)
+
+var _ = Describe("goldmane enterprise render extension", func() {
+	component := func(variant operatorv1.ProductVariant) render.Component {
+		return rgoldmane.Goldmane(&rgoldmane.Configuration{
+			Installation:          &operatorv1.InstallationSpec{Variant: variant},
+			TrustedCertBundle:     certificatemanagement.CreateTrustedBundle(nil),
+			GoldmaneServerKeyPair: certificatemanagement.NewKeyPair(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: rgoldmane.GoldmaneKeyPairSecret}}, nil, ""),
+			Goldmane:              &operatorv1.Goldmane{},
+		})
+	}
+
+	modify := func(variant operatorv1.ProductVariant) ([]client.Object, []client.Object) {
+		ext := enterprise.New(variant, eoptions.Options{}).Goldmane()
+		ri := render.Inputs{Installation: &operatorv1.InstallationSpec{Variant: variant}}
+		return ext.Modify(component(variant), ri).Objects()
+	}
+
+	It("deletes everything goldmane renders on Enterprise", func() {
+		create, del := modify(operatorv1.CalicoEnterprise)
+		Expect(create).To(BeEmpty())
+		Expect(del).NotTo(BeEmpty())
+	})
+
+	It("leaves the component alone on Calico", func() {
+		create, _ := modify(operatorv1.Calico)
+		Expect(create).NotTo(BeEmpty())
+	})
+})

--- a/pkg/enterprise/goldmane/suite_test.go
+++ b/pkg/enterprise/goldmane/suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package goldmane_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestGoldmane(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "pkg/enterprise/goldmane Suite")
+}

--- a/pkg/enterprise/register.go
+++ b/pkg/enterprise/register.go
@@ -19,6 +19,7 @@ import (
 	"github.com/tigera/operator/pkg/enterprise/apiserver"
 	"github.com/tigera/operator/pkg/enterprise/clusterconnection"
 	"github.com/tigera/operator/pkg/enterprise/csr"
+	"github.com/tigera/operator/pkg/enterprise/goldmane"
 	"github.com/tigera/operator/pkg/enterprise/installation"
 	"github.com/tigera/operator/pkg/enterprise/istio"
 	eoptions "github.com/tigera/operator/pkg/enterprise/options"
@@ -42,6 +43,7 @@ func New(variant operatorv1.ProductVariant, o eoptions.Options) extensions.Exten
 			Tiers:             tiers.New(o),
 			CSR:               csr.New(),
 			Istio:             istio.New(),
+			Goldmane:          goldmane.New(variant),
 		})
 	}
 

--- a/pkg/extensions/extensions.go
+++ b/pkg/extensions/extensions.go
@@ -24,6 +24,7 @@ type Set struct {
 	Tiers             TiersExtension
 	CSR               CSRExtension
 	Istio             IstioExtension
+	Goldmane          GoldmaneExtension
 }
 
 // Extensions is the variant behavior the operator runs with. The zero value extends
@@ -85,4 +86,11 @@ func (e Extensions) Istio() IstioExtension {
 		return noopIstio{}
 	}
 	return e.set.Istio
+}
+
+func (e Extensions) Goldmane() GoldmaneExtension {
+	if e.set.Goldmane == nil {
+		return noopGoldmane{}
+	}
+	return e.set.Goldmane
 }

--- a/pkg/extensions/goldmane.go
+++ b/pkg/extensions/goldmane.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Tigera, Inc. All rights reserved.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extensions
+
+import (
+	"github.com/tigera/operator/pkg/render"
+)
+
+// GoldmaneExtension is the variant's hook into the goldmane controller.
+type GoldmaneExtension interface {
+	// Modify layers the variant onto a component the controller rendered.
+	Modify(c render.Component, ri render.Inputs) render.Component
+}
+
+// noopGoldmane runs the core operator's behavior unchanged.
+type noopGoldmane struct{}
+
+func (noopGoldmane) Modify(c render.Component, _ render.Inputs) render.Component {
+	return c
+}

--- a/pkg/render/goldmane/component.go
+++ b/pkg/render/goldmane/component.go
@@ -123,15 +123,9 @@ func (c *Component) Objects() ([]client.Object, []client.Object) {
 
 	objs = append(objs, secret.ToRuntimeObjects(secret.CopyToNamespace(GoldmaneNamespace, c.cfg.PullSecrets...)...)...)
 
-	// Goldmane needs to be removed if the installation is not Calico, since it's not supported (yet!) for any other variant.
 	var objsToDelete []client.Object
-	if c.cfg.Installation.Variant == operatorv1.Calico {
-		if c.metricsPort() == 0 {
-			objsToDelete = append(objsToDelete, c.metricsService())
-		}
-	} else {
-		objsToDelete = objs
-		objs = nil
+	if c.metricsPort() == 0 {
+		objsToDelete = append(objsToDelete, c.metricsService())
 	}
 
 	objsToDelete = append(objsToDelete, c.deprecatedObjects()...)

--- a/pkg/render/goldmane/component_test.go
+++ b/pkg/render/goldmane/component_test.go
@@ -86,18 +86,6 @@ var _ = Describe("ComponentRendering", func() {
 			},
 			8, 1,
 		),
-		Entry("Should return objects to delete when variant is not Calico",
-			&goldmane.Configuration{
-				Installation: &operatorv1.InstallationSpec{
-					KubernetesProvider: operatorv1.ProviderGKE,
-					Variant:            operatorv1.CalicoEnterprise,
-				},
-				TrustedCertBundle:     certificatemanagement.CreateTrustedBundle(nil),
-				GoldmaneServerKeyPair: defaultTLSKeyPair,
-				Goldmane:              &operatorv1.Goldmane{},
-			},
-			0, 8,
-		),
 	)
 
 	DescribeTable("Goldmane Deployment", func(cfg *goldmane.Configuration, expected *appsv1.Deployment) {


### PR DESCRIPTION
Goldmane only ships on Calico, and the render enforced that itself: for any other variant it moved everything it had just built onto the delete list. That branch goes into an Enterprise modifier, matching the whisker split in https://github.com/tigera/operator/pull/5228.

Core renders goldmane unconditionally and keeps the one deletion that is not about the variant, the metrics service when no metrics port is configured. The Enterprise-only expectation moved out of the render test and into the extension's own test.

Related: [CORE-13421](https://tigera.atlassian.net/browse/CORE-13421)

```release-note
None
```


[CORE-13421]: https://tigera.atlassian.net/browse/CORE-13421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ