### PR TITLE
fix(apiserver): allow queryserver egress to Linseed via guardian on managed clusters

### DIFF
--- a/pkg/enterprise/apiserver/extension.go
+++ b/pkg/enterprise/apiserver/extension.go
@@ -735,9 +735,9 @@ func (c *apiServer) sidecarMutatingWebhookConfig() *admregv1.MutatingWebhookConf
 }
 
 // modifyAPIServerPolicy adds the enterprise additions to the API server network policy:
-// the OIDC egress rule (when an OIDC key validator is configured) and the L7 admission
-// controller ingress port (when sidecar injection is enabled). The base policy carries
-// neither.
+// the OIDC egress rule (when an OIDC key validator is configured), the query server's
+// egress to Linseed via Guardian (on a managed cluster) and the L7 admission controller
+// ingress port (when sidecar injection is enabled). The base policy carries none of these.
 func modifyAPIServerPolicy(ri render.Inputs, cfg *render.APIServerConfiguration, create, del []client.Object) ([]client.Object, []client.Object) {
 	c := &apiServer{cfg: cfg, data: apiServerData(ri)}
 
@@ -746,17 +746,20 @@ func modifyAPIServerPolicy(ri render.Inputs, cfg *render.APIServerConfiguration,
 		return create, del
 	}
 
-	// Insert the OIDC egress rule before the trailing Pass rule so it is evaluated.
 	if c.data.keyValidatorConfig != nil {
 		if parsedURL, err := url.Parse(c.data.keyValidatorConfig.Issuer()); err == nil {
-			oidc := networkpolicy.GetOIDCEgressRule(parsedURL)
-			egress := policy.Spec.Egress
-			if n := len(egress); n > 0 && egress[n-1].Action == v3.Pass {
-				policy.Spec.Egress = append(egress[:n-1:n-1], oidc, egress[n-1])
-			} else {
-				policy.Spec.Egress = append(egress, oidc)
-			}
+			insertEgressBeforePass(policy, networkpolicy.GetOIDCEgressRule(parsedURL))
 		}
+	}
+
+	// A managed cluster has no local Linseed; the query server reaches it through Guardian,
+	// matching the LINSEED_URL that LinseedEndpoint returns.
+	if c.data.managementClusterConnection != nil {
+		insertEgressBeforePass(policy, v3.Rule{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: render.GuardianEntityRule,
+		})
 	}
 
 	// Allow the kube-apiserver to reach the L7 admission controller.
@@ -769,6 +772,17 @@ func modifyAPIServerPolicy(ri render.Inputs, cfg *render.APIServerConfiguration,
 	}
 
 	return create, del
+}
+
+// insertEgressBeforePass inserts rule ahead of the policy's trailing Pass rule, so that it is
+// evaluated before the tier hands the traffic to subsequent tiers.
+func insertEgressBeforePass(policy *v3.NetworkPolicy, rule v3.Rule) {
+	egress := policy.Spec.Egress
+	if n := len(egress); n > 0 && egress[n-1].Action == v3.Pass {
+		policy.Spec.Egress = append(egress[:n-1:n-1], rule, egress[n-1])
+		return
+	}
+	policy.Spec.Egress = append(egress, rule)
 }
 
 // auditVolumes are the host-path audit log and audit policy volumes used by the

--- a/pkg/enterprise/apiserver/extension_test.go
+++ b/pkg/enterprise/apiserver/extension_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/tigera/operator/pkg/extensions"
 	"github.com/tigera/operator/pkg/extensions/extensionstest"
 	"github.com/tigera/operator/pkg/render"
+	"github.com/tigera/operator/pkg/render/common/networkpolicy"
 	"github.com/tigera/operator/pkg/render/common/rbacmanagement"
 	"github.com/tigera/operator/pkg/render/monitor"
 	"github.com/tigera/operator/pkg/render/webhooks"
@@ -836,6 +837,35 @@ var _ = Describe("API server enterprise policy modifier", func() {
 		n := len(policy.Spec.Egress)
 		Expect(n).To(BeNumerically(">", 0))
 		Expect(policy.Spec.Egress[n-1].Action).To(Equal(v3.Pass))
+	})
+
+	It("allows egress to Guardian on a managed cluster", func() {
+		ci := apiServerControllerInputs(operatorv1.CalicoEnterprise, nil,
+			&operatorv1.ManagementClusterConnection{ObjectMeta: metav1.ObjectMeta{Name: utils.DefaultEnterpriseInstanceKey.Name}})
+		eci, _, err := ext.APIServer().ExtendInputs(ctx, ci)
+		ri := eci.RenderInputs
+		Expect(err).NotTo(HaveOccurred())
+
+		policy := applyPolicy(ci, ri)
+		guardian := v3.Rule{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: render.GuardianEntityRule,
+		}
+		// The rule is only reached if it precedes the trailing Pass.
+		n := len(policy.Spec.Egress)
+		Expect(policy.Spec.Egress[n-1].Action).To(Equal(v3.Pass))
+		Expect(policy.Spec.Egress[n-2]).To(Equal(guardian))
+	})
+
+	It("omits the Guardian egress rule when the cluster is not managed", func() {
+		ci := apiServerControllerInputs(operatorv1.CalicoEnterprise, nil)
+		eci, _, err := ext.APIServer().ExtendInputs(ctx, ci)
+		ri := eci.RenderInputs
+		Expect(err).NotTo(HaveOccurred())
+
+		policy := applyPolicy(ci, ri)
+		Expect(policy.Spec.Egress).NotTo(ContainElement(HaveField("Destination", render.GuardianEntityRule)))
 	})
 
 	It("adds the L7 admission controller ingress port when sidecar injection is enabled", func() {


### PR DESCRIPTION
## Description

A managed cluster runs no local Linseed, so the query server reaches it through guardian —
the URL `LinseedEndpoint` returns as `LINSEED_URL`. The `calico-system.apiserver-access`
policy permitted only the local Linseed pods, whose selector matches nothing on a managed
cluster, so the connection fell through to the policy's trailing `Pass`. The `calico-system`
tier's default-deny excludes `calico-apiserver` by design, so the traffic is then evaluated
against the customer's tiers, where any default-deny drops it.

The Manager policy board renders empty and the API call fails:

```
GET /api/v1/namespaces/calico-system/services/https:calico-api:8080/proxy/policies -> 500
Error: failed to get policy activity from linseed: error connecting linseed API:
Post "https://guardian.calico-system.svc/api/v1/policy_activity": context deadline exceeded
```

This branches the egress rule on the same condition `LINSEED_URL` already uses in this file:
`render.GuardianEntityRule` when a `ManagementClusterConnection` is present, local Linseed
otherwise.

The inert local-Linseed rule stays in the base policy in `pkg/render/apiserver.go`. It selects
no pods on a managed cluster, and `APIServerConfiguration` carries no cluster type to branch
on. Moving it into the extension would correct the layering at the cost of churning the base
fixture, which is better done on master alone than in a change that cherry-picks to four
release branches.

`insertEgressBeforePass` is extracted rather than duplicated. The OIDC path already used the
capacity-capped `egress[:n-1:n-1]` slice to avoid aliasing the backing array; both callers now
share it. Behaviour is unchanged.

Introduced in #4571, which added the dependency, hardcoded the guardian URL for managed
clusters, and shipped an egress rule covering only the self-hosted destination. #4786 later
refactored the URL onto the `LinseedEndpoint` helper and #4871 moved it into
`pkg/enterprise/apiserver/`; neither added the missing rule. First shipped in operator
`v1.42.0`, so `release-v1.42` through `release-v1.44` need cherry-picks.

Addresses CI-2048.

### Testing

Verified end-to-end on a live Enterprise MCM managed cluster. A deny policy was applied in the
`default` tier selecting `calico-apiserver`, standing in for the customer's
`deny-calico-system`, and left in place for both runs. Only the operator image changed:

| operator image | guardian rule rendered | `GET /policies` |
| --- | --- | --- |
| original `v1.45.0-0.dev-23-g40788b9b6bef` | no | **HTTP 500** after 19.5s |
| this change | yes | **HTTP 200** in 0.58s, 13 policies, `calico-system` tier present |

The 500 carried the reported error verbatim:

```
failed to get policy activity from linseed: error connecting linseed API:
Post "https://guardian.calico-system.svc/api/v1/policy_activity": context deadline exceeded
```

Also checked at the dataplane, with a probe pod carrying the `k8s-app: calico-apiserver` label:
TCP to guardian succeeded only with the fix, while a control destination the policy does not
permit stayed blocked in both runs — confirming the deny was genuinely in force rather than the
cluster being permissive.

Two things the cluster surfaced that the unit tests could not. The rendered rule is port 8080
while the query server dials `https://guardian.calico-system.svc` on 443; that is correct,
because the guardian Service is `443 → targetPort 8080` and Calico enforces egress against the
post-DNAT pod port. And guardian's own ingress policy already has an unrestricted
`Allow ... ports=[8080]` rule, so there is no ingress-side gap and this egress-only change is
sufficient.

Unit tests: new spec asserting the guardian rule is rendered ahead of the trailing `Pass` when
a `ManagementClusterConnection` is present, and a companion spec asserting its absence
otherwise. Reverting the production change while keeping the tests fails the managed-cluster
spec. `pkg/enterprise/apiserver` 51/51, `pkg/controller/apiserver` 28/28, `pkg/render` green.
`make format-check` clean, `make static-checks` reports 0 issues.

Backports: #5260 (`release-v1.42`), #5261 (`release-v1.43`), #5262 (`release-v1.43-2`),
#5263 (`release-v1.44`). `release-v1.41` carries neither the egress rule nor `LINSEED_URL`, so
the affected range starts at `release-v1.42` (CE v3.23.1).

## Release Note

```release-note
Fixed the Manager policy board rendering empty on managed clusters, where the query server was not permitted egress to Linseed through guardian.
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
