### PR TITLE
Default ApplicationLayer and ManagementCluster fields in the CRD schema

### DIFF
--- a/api/v1/applicationlayer_types.go
+++ b/api/v1/applicationlayer_types.go
@@ -24,13 +24,17 @@ import (
 type ApplicationLayerSpec struct {
 	// WebApplicationFirewall controls whether or not ModSecurity enforcement is enabled for the cluster.
 	// When enabled, Services may opt-in to having ingress traffic examed by ModSecurity.
+	// +kubebuilder:default=Disabled
 	WebApplicationFirewall *WAFStatusType `json:"webApplicationFirewall,omitempty"`
 	// Specification for application layer (L7) log collection.
+	// +kubebuilder:default={}
 	LogCollection *LogCollectionSpec `json:"logCollection,omitempty"`
 	// Application Layer Policy controls whether or not ALP enforcement is enabled for the cluster.
 	// When enabled, NetworkPolicies with HTTP Match rules may be defined to opt-in workloads for traffic enforcement on the application layer.
+	// +kubebuilder:default=Disabled
 	ApplicationLayerPolicy *ApplicationLayerPolicyStatusType `json:"applicationLayerPolicy,omitempty"`
 	// User-configurable settings for the Envoy proxy.
+	// +kubebuilder:default={}
 	EnvoySettings *EnvoySettings `json:"envoy,omitempty"`
 
 	// L7LogCollectorDaemonSet configures the L7LogCollector DaemonSet.
@@ -43,6 +47,7 @@ type ApplicationLayerSpec struct {
 	// such as WAF and ALP implemented using an injected sidecar instead of a per-host proxy.
 	// The per-host proxy will continue to be used for pods without this label.
 	// +optional
+	// +kubebuilder:default=Disabled
 	SidecarInjection *SidecarStatusType `json:"sidecarInjection,omitempty"`
 }
 
@@ -95,11 +100,13 @@ type LogCollectionSpec struct {
 	// This setting enables or disable log collection.
 	// Allowed values are Enabled or Disabled.
 	// +optional
+	// +kubebuilder:default=Disabled
 	CollectLogs *LogCollectionStatusType `json:"collectLogs,omitempty"`
 
 	// Interval in seconds for sending L7 log information for processing.
 	// +optional
 	// Default: 5 sec
+	// +kubebuilder:default=5
 	LogIntervalSeconds *int64 `json:"logIntervalSeconds,omitempty"`
 
 	// Maximum number of unique L7 logs that are sent LogIntervalSeconds.
@@ -107,6 +114,7 @@ type LogCollectionSpec struct {
 	// to felix for further processing, use negative number to ignore limits.
 	// +optional
 	// Default: -1
+	// +kubebuilder:default=-1
 	LogRequestsPerInterval *int64 `json:"logRequestsPerInterval,omitempty"`
 }
 

--- a/api/v1/managementcluster_types.go
+++ b/api/v1/managementcluster_types.go
@@ -30,6 +30,7 @@ type ManagementClusterSpec struct {
 
 	// TLS provides options for configuring how Managed Clusters can establish an mTLS connection with the Management Cluster.
 	// +optional
+	// +kubebuilder:default={}
 	TLS *TLS `json:"tls,omitempty"`
 }
 
@@ -51,6 +52,7 @@ type TLS struct {
 	// Default: calico-management-cluster-connection
 	//
 	// +kubebuilder:validation:Enum=calico-management-cluster-connection;manager-tls;tigera-management-cluster-connection
+	// +kubebuilder:default=calico-management-cluster-connection
 	// +optional
 	SecretName string `json:"secretName,omitempty"`
 }

--- a/pkg/controller/applicationlayer/applicationlayer_controller.go
+++ b/pkg/controller/applicationlayer/applicationlayer_controller.go
@@ -215,19 +215,13 @@ func (r *ReconcileApplicationLayer) Reconcile(ctx context.Context, request recon
 		}
 	}
 
-	preDefaultPatchFrom := client.MergeFrom(instance.DeepCopy())
-
+	// The CRD schema carries the spec defaults now. This covers a cluster whose CRDs the
+	// operator doesn't manage.
 	updateApplicationLayerWithDefaults(instance)
 
 	if err = validateApplicationLayer(instance); err != nil {
 		r.status.SetDegraded(operatorv1.ResourceValidationError, "", err, reqLogger)
 		return reconcile.Result{}, nil
-	}
-
-	// Write the application layer back to the datastore, so the controllers depending on this can reconcile.
-	if err = r.client.Patch(ctx, instance, preDefaultPatchFrom); err != nil {
-		r.status.SetDegraded(operatorv1.ResourceUpdateError, "Failed to write defaults to applicationLayer", err, reqLogger)
-		return reconcile.Result{}, err
 	}
 
 	installationSpec, err := utils.GetComputedInstallationSpec(ctx, r.client)

--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -571,15 +571,9 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 	var tunnelSecretPassthrough render.Component
 
 	if managementCluster != nil {
-		preDefaultPatchFrom := client.MergeFrom(managementCluster.DeepCopy())
+		// The CRD schema carries these defaults now. This covers a cluster whose CRDs the
+		// operator doesn't manage.
 		fillDefaults(managementCluster)
-
-		// Write the discovered configuration back to the API. This is essentially a poor-man's defaulting, and
-		// ensures that we don't surprise anyone by changing defaults in a future version of the operator.
-		if err := r.client.Patch(ctx, managementCluster, preDefaultPatchFrom); err != nil {
-			r.status.SetDegraded(operatorv1.ResourceUpdateError, "", err, logc)
-			return reconcile.Result{}, err
-		}
 
 		// Create a certificate for Voltron to use when serving TLS connections from managed clusters destined
 		// to Linseed. This certificate is used only for connections received over Voltron's mTLS tunnel targeting tigera-linseed.

--- a/pkg/imports/crds/operator/operator.tigera.io_applicationlayers.yaml
+++ b/pkg/imports/crds/operator/operator.tigera.io_applicationlayers.yaml
@@ -39,6 +39,7 @@ spec:
               description: ApplicationLayerSpec defines the desired state of ApplicationLayer
               properties:
                 applicationLayerPolicy:
+                  default: Disabled
                   description: |-
                     Application Layer Policy controls whether or not ALP enforcement is enabled for the cluster.
                     When enabled, NetworkPolicies with HTTP Match rules may be defined to opt-in workloads for traffic enforcement on the application layer.
@@ -47,6 +48,7 @@ spec:
                     - Disabled
                   type: string
                 envoy:
+                  default: {}
                   description: User-configurable settings for the Envoy proxy.
                   properties:
                     useRemoteAddress:
@@ -317,9 +319,11 @@ spec:
                       type: object
                   type: object
                 logCollection:
+                  default: {}
                   description: Specification for application layer (L7) log collection.
                   properties:
                     collectLogs:
+                      default: Disabled
                       description: |-
                         This setting enables or disable log collection.
                         Allowed values are Enabled or Disabled.
@@ -328,12 +332,14 @@ spec:
                         - Disabled
                       type: string
                     logIntervalSeconds:
+                      default: 5
                       description: |-
                         Interval in seconds for sending L7 log information for processing.
                         Default: 5 sec
                       format: int64
                       type: integer
                     logRequestsPerInterval:
+                      default: -1
                       description: |-
                         Maximum number of unique L7 logs that are sent LogIntervalSeconds.
                         Adjust this to limit the number of L7 logs sent per LogIntervalSeconds
@@ -343,6 +349,7 @@ spec:
                       type: integer
                   type: object
                 sidecarInjection:
+                  default: Disabled
                   description: |-
                     SidecarInjection controls whether or not sidecar injection is enabled for the cluster.
                     When enabled, pods with the label
@@ -354,6 +361,7 @@ spec:
                     - Disabled
                   type: string
                 webApplicationFirewall:
+                  default: Disabled
                   description: |-
                     WebApplicationFirewall controls whether or not ModSecurity enforcement is enabled for the cluster.
                     When enabled, Services may opt-in to having ingress traffic examed by ModSecurity.

--- a/pkg/imports/crds/operator/operator.tigera.io_managementclusters.yaml
+++ b/pkg/imports/crds/operator/operator.tigera.io_managementclusters.yaml
@@ -47,11 +47,13 @@ spec:
                     Valid examples are: "0.0.0.0:31000", "example.com:32000", "[::1]:32500"
                   type: string
                 tls:
+                  default: {}
                   description:
                     TLS provides options for configuring how Managed Clusters
                     can establish an mTLS connection with the Management Cluster.
                   properties:
                     secretName:
+                      default: calico-management-cluster-connection
                       description: |-
                         SecretName indicates the name of the secret in the tigera-operator namespace that contains the private key and certificate that the management cluster uses when it listens for incoming connections.
                         When set to calico-management-cluster-connection voltron will use the same cert bundle which Guardian client certs are signed with.


### PR DESCRIPTION
## Description

Follow-on to #5203. The other CRs have the same problem: the operator defaults a field, patches it back, and becomes the field manager, so a server-side apply from Helm or Argo conflicts. Installation had to record its defaults in the status because its defaulting needs cluster state and because of the overlay, and neither applies here, so these are plain CRD schema defaults.

This covers ApplicationLayer and ManagementCluster, the two CRs where schema defaults replace the write-back completely:

- every value matches what the controller was defaulting, so an object that already has the value stored is unaffected
- both controllers keep defaulting in memory, which still covers a cluster whose CRDs the operator doesn't manage
- the spec write-back is gone from both, which is what releases field ownership

One behavior change, in ApplicationLayer: the L7 log interval and requests-per-interval were only defaulted when log collection was enabled, and they now always default. Nothing renders them unless log collection is on, so the only difference is the two fields appearing in the spec.

Increments left for follow-ups, all for a reason rather than for size:

- Monitor: the external Prometheus scrape parameters are a map of string to list, and controller-gen emits the default as a string rather than a list, so the schema default would be invalid
- ManagementClusterConnection: the tunnel CA is fine, but the Enterprise extension also defaults the impersonation permissions in the spec, and that field distinguishes unset from empty
- LogCollector: process path collection and syslog encryption are fine, but the syslog log types default only exists to fill in objects created before that field, and it is a required field
- Authentication: the OIDC email verification and LDAP name attribute are fine, but the username and groups prefixes are copied from another field, which a schema default can't do

Each of those keeps its write-back until the whole CR can drop it, since a schema default that doesn't let us remove the patch doesn't release ownership.

Related: #5102

Related: [CORE-13615](https://tigera.atlassian.net/browse/CORE-13615)

## Release Note

```release-note
Fixes server-side apply conflicts on ApplicationLayer and ManagementCluster fields between the operator and the tool that manages the resource, such as Helm or Argo CD.
```

## For PR author

- [x] Tests for change.
- [x] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`



[CORE-13615]: https://tigera.atlassian.net/browse/CORE-13615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ