### PR TITLE
Resolve the combined calico image directly in Enterprise-only components

### DIFF
--- a/pkg/enterprise/apiserver/extension.go
+++ b/pkg/enterprise/apiserver/extension.go
@@ -303,7 +303,7 @@ func (e *Extension) ExtendInputs(ctx context.Context, ci controller.Inputs) (con
 	if err != nil {
 		return ci, nil, extensions.Degradedf(operatorv1.ResourceReadError, "error getting ImageSet: %w", err)
 	}
-	calicoImage, err := components.GetReference(components.CombinedCalicoImage(in), in.Registry, in.ImagePath, in.ImagePrefix, imageSet)
+	calicoImage, err := components.GetReference(components.ComponentTigeraCalico, in.Registry, in.ImagePath, in.ImagePrefix, imageSet)
 	if err != nil {
 		return ci, nil, extensions.Degradedf(operatorv1.ResourceUpdateError, "error with images from ImageSet: %w", err)
 	}

--- a/pkg/render/applicationlayer/applicationlayer.go
+++ b/pkg/render/applicationlayer/applicationlayer.go
@@ -132,7 +132,7 @@ func (c *component) ResolveImages(is *operatorv1.ImageSet) error {
 		errMsgs = append(errMsgs, err.Error())
 	}
 
-	c.config.calicoImage, err = components.GetReference(components.CombinedCalicoImage(c.config.Installation), reg, path, prefix, is)
+	c.config.calicoImage, err = components.GetReference(components.ComponentTigeraCalico, reg, path, prefix, is)
 	if err != nil {
 		errMsgs = append(errMsgs, err.Error())
 	}

--- a/pkg/render/intrusion_detection.go
+++ b/pkg/render/intrusion_detection.go
@@ -137,7 +137,7 @@ func (c *intrusionDetectionComponent) ResolveImages(is *operatorv1.ImageSet) err
 		errMsgs = append(errMsgs, err.Error())
 	}
 
-	c.calicoImage, err = components.GetReference(components.CombinedCalicoImage(c.cfg.Installation), reg, path, prefix, is)
+	c.calicoImage, err = components.GetReference(components.ComponentTigeraCalico, reg, path, prefix, is)
 	if err != nil {
 		errMsgs = append(errMsgs, err.Error())
 	}

--- a/pkg/render/logstorage/esgateway/esgateway.go
+++ b/pkg/render/logstorage/esgateway/esgateway.go
@@ -111,7 +111,7 @@ func (e *esGateway) ResolveImages(is *operatorv1.ImageSet) error {
 	var err error
 	errMsgs := []string{}
 
-	e.calicoImage, err = components.GetReference(components.CombinedCalicoImage(e.cfg.Installation), reg, path, prefix, is)
+	e.calicoImage, err = components.GetReference(components.ComponentTigeraCalico, reg, path, prefix, is)
 	if err != nil {
 		errMsgs = append(errMsgs, err.Error())
 	}

--- a/pkg/render/logstorage/esmetrics/elasticsearch_metrics.go
+++ b/pkg/render/logstorage/esmetrics/elasticsearch_metrics.go
@@ -82,7 +82,7 @@ func (e *elasticsearchMetrics) ResolveImages(is *operatorv1.ImageSet) error {
 	path := e.cfg.Installation.ImagePath
 	prefix := e.cfg.Installation.ImagePrefix
 
-	e.calicoImage, err = components.GetReference(components.CombinedCalicoImage(e.cfg.Installation), reg, path, prefix, is)
+	e.calicoImage, err = components.GetReference(components.ComponentTigeraCalico, reg, path, prefix, is)
 	if err != nil {
 		return err
 	}

--- a/pkg/render/logstorage/linseed/linseed.go
+++ b/pkg/render/logstorage/linseed/linseed.go
@@ -146,7 +146,7 @@ func (l *linseed) ResolveImages(is *operatorv1.ImageSet) error {
 	errMsgs := []string{}
 
 	// Calculate the image(s) to use for Linseed, given user registry configuration.
-	l.calicoImage, err = components.GetReference(components.CombinedCalicoImage(l.cfg.Installation), reg, path, prefix, is)
+	l.calicoImage, err = components.GetReference(components.ComponentTigeraCalico, reg, path, prefix, is)
 	if err != nil {
 		errMsgs = append(errMsgs, err.Error())
 	}

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -251,7 +251,7 @@ func (c *managerComponent) ResolveImages(is *operatorv1.ImageSet) error {
 		errMsgs = append(errMsgs, err.Error())
 	}
 
-	c.calicoImage, err = components.GetReference(components.CombinedCalicoImage(c.cfg.Installation), reg, path, prefix, is)
+	c.calicoImage, err = components.GetReference(components.ComponentTigeraCalico, reg, path, prefix, is)
 	if err != nil {
 		errMsgs = append(errMsgs, err.Error())
 	}

--- a/pkg/render/manager_cloud_test.go
+++ b/pkg/render/manager_cloud_test.go
@@ -15,6 +15,8 @@
 package render_test
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -71,7 +73,7 @@ var _ = Describe("Tigera Secure Cloud Manager rendering tests", func() {
 		})
 
 		It("should set image correctly", func() {
-			Expect(voltron.Image).Should(Equal(components.CalicoRegistry + components.CalicoImagePath + components.ComponentCalico.Image + ":" + components.ComponentCalico.Version))
+			Expect(voltron.Image).Should(Equal(fmt.Sprintf("%s%s%s:%s", components.TigeraRegistry, components.TigeraImagePath, components.ComponentTigeraCalico.Image, components.ComponentTigeraCalico.Version)))
 		})
 
 		It("should have env vars", func() {

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -127,9 +127,9 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 		manager := deployment.Spec.Template.Spec.Containers[3]
 
 		Expect(manager.Image).Should(Equal(components.TigeraRegistry + "tigera/manager:" + components.ComponentManager.Version))
-		Expect(uiAPIs.Image).Should(Equal(components.CalicoRegistry + "calico/calico:" + components.ComponentCalico.Version))
-		Expect(dashboard.Image).Should(Equal(components.CalicoRegistry + "calico/calico:" + components.ComponentCalico.Version))
-		Expect(voltron.Image).Should(Equal(components.CalicoRegistry + "calico/calico:" + components.ComponentCalico.Version))
+		Expect(uiAPIs.Image).Should(Equal(fmt.Sprintf("%s%s%s:%s", components.TigeraRegistry, components.TigeraImagePath, components.ComponentTigeraCalico.Image, components.ComponentTigeraCalico.Version)))
+		Expect(dashboard.Image).Should(Equal(fmt.Sprintf("%s%s%s:%s", components.TigeraRegistry, components.TigeraImagePath, components.ComponentTigeraCalico.Image, components.ComponentTigeraCalico.Version)))
+		Expect(voltron.Image).Should(Equal(fmt.Sprintf("%s%s%s:%s", components.TigeraRegistry, components.TigeraImagePath, components.ComponentTigeraCalico.Image, components.ComponentTigeraCalico.Version)))
 
 		// manager container
 		Expect(*manager.SecurityContext.AllowPrivilegeEscalation).To(BeFalse())

--- a/pkg/render/monitor/monitor.go
+++ b/pkg/render/monitor/monitor.go
@@ -202,7 +202,7 @@ func (mc *monitorComponent) ResolveImages(is *operatorv1.ImageSet) error {
 		errMsgs = append(errMsgs, err.Error())
 	}
 
-	mc.calicoImage, err = components.GetReference(components.CombinedCalicoImage(mc.cfg.Installation), reg, path, prefix, is)
+	mc.calicoImage, err = components.GetReference(components.ComponentTigeraCalico, reg, path, prefix, is)
 	if err != nil {
 		errMsgs = append(errMsgs, err.Error())
 	}

--- a/pkg/render/otelcollector/component.go
+++ b/pkg/render/otelcollector/component.go
@@ -171,7 +171,7 @@ func (c *component) ResolveImages(is *operatorv1.ImageSet) error {
 	prefix := c.cfg.Installation.ImagePrefix
 
 	var err error
-	c.image, err = components.GetReference(components.CombinedCalicoImage(c.cfg.Installation), reg, path, prefix, is)
+	c.image, err = components.GetReference(components.ComponentTigeraCalico, reg, path, prefix, is)
 	return err
 }
 

--- a/pkg/render/packet_capture_api.go
+++ b/pkg/render/packet_capture_api.go
@@ -106,7 +106,7 @@ func (pc *packetCaptureApiComponent) ResolveImages(is *operatorv1.ImageSet) erro
 	prefix := pc.cfg.Installation.ImagePrefix
 
 	var err error
-	pc.calicoImage, err = components.GetReference(components.CombinedCalicoImage(pc.cfg.Installation), reg, path, prefix, is)
+	pc.calicoImage, err = components.GetReference(components.ComponentTigeraCalico, reg, path, prefix, is)
 	if err != nil {
 		return err
 	}

--- a/pkg/render/policyrecommendation.go
+++ b/pkg/render/policyrecommendation.go
@@ -97,7 +97,7 @@ func (pr *policyRecommendationComponent) ResolveImages(is *operatorv1.ImageSet) 
 	prefix := pr.cfg.Installation.ImagePrefix
 
 	var err error
-	pr.calicoImage, err = components.GetReference(components.CombinedCalicoImage(pr.cfg.Installation), reg, path, prefix, is)
+	pr.calicoImage, err = components.GetReference(components.ComponentTigeraCalico, reg, path, prefix, is)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

The operator picks the Calico or Enterprise spelling of the combined calico image off the installation variant, and 23 places ask for it. Ten of those are components whose controller returns before it registers a reconciler unless the variant is Enterprise, so the Calico half of the lookup can never run: intrusion detection, policy recommendation, packet capture, manager, monitor, application layer, esgateway, esmetrics, linseed, otelcollector. Those take the Enterprise image directly.

No behavior change. Enterprise resolves the same image name it did before, and the branch that went away was unreachable in these files.

Deliberately left alone, because they are not Enterprise-only: the apiserver, its webhooks render, CSI, and guardian. Guardian resolves the Calico image on purpose.

Two manager specs asserted the Calico image for the ui-apis, dashboard and voltron containers. That held only because the fixture leaves the variant unset, so the lookup fell through to the Calico spelling; a real cluster only ever renders the manager for Enterprise. They now expect the Enterprise image.

The other thirteen call sites are reachable from both variants, or sit in a render still open in review. Those need the image overrides threaded into their configuration, the pattern node and kube-controllers already use, and stay on the parent ticket.

Related: [CORE-13451](https://tigera.atlassian.net/browse/CORE-13451)

```release-note
None
```


[CORE-13451]: https://tigera.atlassian.net/browse/CORE-13451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ