### PR TITLE
[release-v1.42] Default calico-node to the node's own DNS resolver

### DIFF
--- a/api/v1/calico_node_types.go
+++ b/api/v1/calico_node_types.go
@@ -86,7 +86,8 @@ type CalicoNodeDaemonSetPodSpec struct {
 	// +optional
 	Tolerations []v1.Toleration `json:"tolerations"`
 
-	// DNSPolicy is the DNS policy for the calico-node pods.
+	// DNSPolicy is the DNS policy for the calico-node pods. Defaults to Default, which uses the node's
+	// own resolver, since calico-node runs before cluster DNS is reachable.
 	// +kubebuilder:validation:Enum="";Default;ClusterFirst;ClusterFirstWithHostNet;None
 	// +optional
 	DNSPolicy *v1.DNSPolicy `json:"dnsPolicy,omitempty"`

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1504,15 +1504,8 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		goldmaneRunning = goldmaneCR != nil
 	}
 
-	// Calico node DNS configuration and policy should be inherited from the tigera/operator Deployment by default since:
-	//
-	// - they are both host networked and run prior to CNI being installed (and thus beofre kube-dns is available)
-	// - they both need access to in-cluster serivces via kube-dns, as well as external services such as the API server.
-	//
-	// So, they will require the same DNS configuration.
-	//
-	// Users can override this with explicit configuration in the Installation resource, but using the operator as
-	// a baseline is a reasonable default.
+	// calico/node runs before CNI is installed, so cluster DNS is not yet reachable on the node. Use the
+	// node's own resolver, and inherit the operator's DNS settings only when it has an explicit dnsConfig.
 	operatorDeployment := &appsv1.Deployment{}
 	defaultDNSPolicy := corev1.DNSDefault
 	var defaultDNSConfig *corev1.PodDNSConfig
@@ -1522,7 +1515,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 			return reconcile.Result{}, err
 		}
 		reqLogger.Info("Operator Deployment not found, using default DNS configuration")
-	} else {
+	} else if operatorDeployment.Spec.Template.Spec.DNSConfig != nil {
 		defaultDNSPolicy = operatorDeployment.Spec.Template.Spec.DNSPolicy
 		defaultDNSConfig = operatorDeployment.Spec.Template.Spec.DNSConfig
 	}

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -393,6 +393,66 @@ var _ = Describe("Testing core-controller installation", func() {
 			})
 		})
 
+		Context("DNS configuration", func() {
+			operatorDeployment := func(policy corev1.DNSPolicy, dnsConfig *corev1.PodDNSConfig) *appsv1.Deployment {
+				return &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{Name: common.OperatorName(), Namespace: common.OperatorNamespace()},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{DNSPolicy: policy, DNSConfig: dnsConfig},
+						},
+					},
+				}
+			}
+
+			nodeDaemonSet := func() appsv1.DaemonSet {
+				_, err := r.Reconcile(ctx, reconcile.Request{})
+				Expect(err).ShouldNot(HaveOccurred())
+
+				ds := appsv1.DaemonSet{}
+				key := types.NamespacedName{Name: common.NodeDaemonSetName, Namespace: common.CalicoNamespace}
+				Expect(c.Get(ctx, key, &ds)).NotTo(HaveOccurred())
+				return ds
+			}
+
+			It("should use the node's resolver when the operator has no explicit dnsConfig", func() {
+				Expect(c.Create(ctx, operatorDeployment(corev1.DNSClusterFirstWithHostNet, nil))).NotTo(HaveOccurred())
+
+				ds := nodeDaemonSet()
+				Expect(ds.Spec.Template.Spec.DNSPolicy).To(Equal(corev1.DNSDefault))
+				Expect(ds.Spec.Template.Spec.DNSConfig).To(BeNil())
+			})
+
+			It("should inherit the operator's DNS settings when it has an explicit dnsConfig", func() {
+				dnsConfig := &corev1.PodDNSConfig{Nameservers: []string{"10.96.0.10", "169.254.169.253"}}
+				Expect(c.Create(ctx, operatorDeployment(corev1.DNSNone, dnsConfig))).NotTo(HaveOccurred())
+
+				ds := nodeDaemonSet()
+				Expect(ds.Spec.Template.Spec.DNSPolicy).To(Equal(corev1.DNSNone))
+				Expect(ds.Spec.Template.Spec.DNSConfig).To(Equal(dnsConfig))
+			})
+
+			It("should use the node's resolver when the operator Deployment is missing", func() {
+				ds := nodeDaemonSet()
+				Expect(ds.Spec.Template.Spec.DNSPolicy).To(Equal(corev1.DNSDefault))
+				Expect(ds.Spec.Template.Spec.DNSConfig).To(BeNil())
+			})
+		})
+
+		It("degrades with a configuration reason when the extension rejects the configuration", func() {
+			mockStatus.On("SetDegraded", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+
+			port := 0
+			Expect(c.Create(ctx, &v3.FelixConfiguration{
+				ObjectMeta: metav1.ObjectMeta{Name: "default"},
+				Spec:       v3.FelixConfigurationSpec{PrometheusReporterPort: &port},
+			})).NotTo(HaveOccurred())
+
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).To(HaveOccurred())
+			mockStatus.AssertCalled(GinkgoT(), "SetDegraded", operator.InvalidConfigurationError, "invalid metrics port: felixConfiguration prometheusReporterPort=0 not supported", mock.Anything, mock.Anything)
+		})
+
 		Context("image tests", func() {
 			It("should use builtin images", func() {
 				_, err := r.Reconcile(ctx, reconcile.Request{})

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -439,7 +439,7 @@ var _ = Describe("Testing core-controller installation", func() {
 			})
 		})
 
-		It("degrades with a configuration reason when the extension rejects the configuration", func() {
+		It("degrades with a configuration reason when the metrics port is invalid", func() {
 			mockStatus.On("SetDegraded", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 
 			port := 0
@@ -450,7 +450,7 @@ var _ = Describe("Testing core-controller installation", func() {
 
 			_, err := r.Reconcile(ctx, reconcile.Request{})
 			Expect(err).To(HaveOccurred())
-			mockStatus.AssertCalled(GinkgoT(), "SetDegraded", operator.InvalidConfigurationError, "invalid metrics port: felixConfiguration prometheusReporterPort=0 not supported", mock.Anything, mock.Anything)
+			mockStatus.AssertCalled(GinkgoT(), "SetDegraded", operator.InvalidConfigurationError, "invalid metrics port", mock.Anything, mock.Anything)
 		})
 
 		Context("image tests", func() {

--- a/pkg/imports/crds/operator/operator.tigera.io_installations.yaml
+++ b/pkg/imports/crds/operator/operator.tigera.io_installations.yaml
@@ -2723,9 +2723,9 @@ spec:
                                       x-kubernetes-list-type: atomic
                                   type: object
                                 dnsPolicy:
-                                  description:
-                                    DNSPolicy is the DNS policy for the calico-node
-                                    pods.
+                                  description: |-
+                                    DNSPolicy is the DNS policy for the calico-node pods. Defaults to Default, which uses the node's
+                                    own resolver, since calico-node runs before cluster DNS is reachable.
                                   enum:
                                     - ""
                                     - Default

--- a/pkg/imports/crds/operator/operator.tigera.io_installations.yaml
+++ b/pkg/imports/crds/operator/operator.tigera.io_installations.yaml
@@ -11595,9 +11595,9 @@ spec:
                                           x-kubernetes-list-type: atomic
                                       type: object
                                     dnsPolicy:
-                                      description:
-                                        DNSPolicy is the DNS policy for the
-                                        calico-node pods.
+                                      description: |-
+                                        DNSPolicy is the DNS policy for the calico-node pods. Defaults to Default, which uses the node's
+                                        own resolver, since calico-node runs before cluster DNS is reachable.
                                       enum:
                                         - ""
                                         - Default

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -157,7 +157,7 @@ type NodeConfiguration struct {
 func Node(cfg *NodeConfiguration) Component {
 	// Configure default values for any fields that might not be set.
 	if cfg.DefaultDNSPolicy == "" {
-		cfg.DefaultDNSPolicy = corev1.DNSClusterFirstWithHostNet
+		cfg.DefaultDNSPolicy = corev1.DNSDefault
 	}
 	return &nodeComponent{cfg: cfg}
 }

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -3114,6 +3114,17 @@ var _ = Describe("Node rendering tests", func() {
 					},
 				}
 
+				It("should default to the node's own DNS resolver", func() {
+					component := render.Node(&cfg)
+					resources, _ := component.Objects()
+					dsResource := rtest.GetResource(resources, "calico-node", "calico-system", "apps", "v1", "DaemonSet")
+					Expect(dsResource).ToNot(BeNil())
+
+					ds := dsResource.(*appsv1.DaemonSet)
+					Expect(ds.Spec.Template.Spec.DNSPolicy).To(Equal(corev1.DNSDefault))
+					Expect(ds.Spec.Template.Spec.DNSConfig).To(BeNil())
+				})
+
 				It("should handle calicoNodeDaemonSet overrides", func() {
 					var minReadySeconds int32 = 20
 


### PR DESCRIPTION
## Description

Backport of https://github.com/tigera/operator/pull/5246.

calico-node runs before CNI is installed, so cluster DNS is not reachable on the node when it starts. It inherited the operator's `ClusterFirstWithHostNet` policy, leaving the CoreDNS ClusterIP as its only resolver, which deadlocks the rollout on a cluster where the Kubernetes API server is reachable only by name. It defaults to the node's own resolver instead, and inherits the operator's DNS settings only when the operator has an explicit `dnsConfig`.

## Release Note

```release-note
Fixed a deadlock on clusters where the Kubernetes API server is reachable only by name, by defaulting calico-node to the node's own DNS resolver.
```
