### PR TITLE
[release-v1.39] Use a host alias for calico/node to access Goldmane

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -80,6 +80,7 @@ import (
 	relasticsearch "github.com/tigera/operator/pkg/render/common/elasticsearch"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
 	"github.com/tigera/operator/pkg/render/common/resourcequota"
+	"github.com/tigera/operator/pkg/render/goldmane"
 	"github.com/tigera/operator/pkg/render/kubecontrollers"
 	"github.com/tigera/operator/pkg/render/monitor"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
@@ -347,6 +348,9 @@ func secondaryResources() []client.Object {
 		&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: render.CalicoCNIPluginObjectName}},
 		&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: kubecontrollers.KubeControllerRole}},
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: common.CalicoNamespace}},
+
+		// We care about the Goldmane Service for providing host aliases to calico/node.
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: goldmane.GoldmaneServiceName, Namespace: common.CalicoNamespace}},
 	}
 }
 
@@ -1237,15 +1241,21 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		nodeAppArmorProfile = val
 	}
 
-	components := []render.Component{}
+	// Create a component handler to create or update the rendered components.
+	handler := r.newComponentHandler(log, r.client, r.scheme, instance)
 
+	// Render namespaces first - this ensures that any other controllers blocked on namespace existence can proceed.
 	namespaceCfg := &render.NamespaceConfiguration{
 		Installation: &instance.Spec,
 		PullSecrets:  pullSecrets,
 	}
-	// Render namespaces for Calico and Enterprise components.
-	components = append(components, render.Namespaces(namespaceCfg))
+	if err := handler.CreateOrUpdateOrDelete(ctx, render.Namespaces(namespaceCfg), nil); err != nil {
+		r.status.SetDegraded(operator.ResourceUpdateError, "Error creating / updating namespaces", err, reqLogger)
+		return reconcile.Result{}, err
+	}
 
+	// Build the list of components to render, in rendering order.
+	components := []render.Component{}
 	if newActiveCM != nil && !installationMarkedForDeletion {
 		log.Info("adding active configmap")
 		components = append(components, render.NewPassthrough(newActiveCM))
@@ -1407,6 +1417,26 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		goldmaneRunning = goldmaneCR != nil
 	}
 
+	// Get the Goldmane Service in order to find its cluster IP.
+	goldmaneIP := ""
+	if goldmaneRunning {
+		goldmaneService := &corev1.Service{}
+		if err := r.client.Get(ctx, types.NamespacedName{Name: goldmane.GoldmaneServiceName, Namespace: common.CalicoNamespace}, goldmaneService); err != nil {
+			if !apierrors.IsNotFound(err) {
+				r.status.SetDegraded(operator.ResourceReadError, "Unable to read Goldmane Service", err, reqLogger)
+				return reconcile.Result{}, err
+			} else {
+				// Service not found - Goldmane is probably still starting. Wait for it to appear. This helps prevent us from rolling out calico/node twice
+				// during initial installation - once when we first Reconcile and again when we detect the Goldmane Service, which triggers
+				// us adding host aliases to the calico/node DaemonSet.
+				r.status.SetDegraded(operator.ResourceNotFound, "Goldmane enabled, waiting for Service to receive an IP", nil, reqLogger)
+				return reconcile.Result{}, nil
+			}
+		} else {
+			goldmaneIP = goldmaneService.Spec.ClusterIP
+		}
+	}
+
 	// Build a configuration for rendering calico/node.
 	nodeCfg := render.NodeConfiguration{
 		GoldmaneRunning:               goldmaneRunning,
@@ -1418,6 +1448,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		TLS:                           typhaNodeTLS,
 		ClusterDomain:                 r.clusterDomain,
 		Nameservers:                   r.nameservers,
+		GoldmaneIP:                    goldmaneIP,
 		NodeReporterMetricsPort:       nodeReporterMetricsPort,
 		BGPLayouts:                    bgpLayout,
 		NodeAppArmorProfile:           nodeAppArmorProfile,
@@ -1498,8 +1529,6 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		return reconcile.Result{}, err
 	}
 
-	// Create a component handler to create or update the rendered components.
-	handler := r.newComponentHandler(log, r.client, r.scheme, instance)
 	for _, component := range components {
 		if err := handler.CreateOrUpdateOrDelete(ctx, component, nil); err != nil {
 			r.status.SetDegraded(operator.ResourceUpdateError, "Error creating / updating resource", err, reqLogger)

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -68,6 +68,8 @@ const (
 	CalicoNodeObjectName          = "calico-node"
 	CalicoCNIPluginObjectName     = "calico-cni-plugin"
 	BPFVolumeName                 = "bpffs"
+
+	goldmaneDomainName = "goldmane.calico-system.svc"
 )
 
 var (
@@ -101,6 +103,9 @@ type NodeConfiguration struct {
 	TLS             *TyphaNodeTLS
 	ClusterDomain   string
 	Nameservers     []string
+
+	// Goldmane IP, to avoid DNS resolution using kube-dns.
+	GoldmaneIP string
 
 	// Optional fields.
 	LogCollector            *operatorv1.LogCollector
@@ -964,6 +969,16 @@ func (c *nodeComponent) nodeDaemonset(cniCfgMap *corev1.ConfigMap) *appsv1.Daemo
 		annotations[bgpBindModeHashAnnotation] = rmeta.AnnotationHash(c.cfg.BindMode)
 	}
 
+	var hostAliases []corev1.HostAlias
+	if c.cfg.GoldmaneIP != "" {
+		hostAliases = []corev1.HostAlias{
+			{
+				Hostnames: []string{goldmaneDomainName},
+				IP:        c.cfg.GoldmaneIP,
+			},
+		}
+	}
+
 	// Determine the name to use for the calico/node daemonset. For mixed-mode, we run the enterprise DaemonSet
 	// with its own name so as to not conflict.
 	ds := appsv1.DaemonSet{
@@ -981,10 +996,11 @@ func (c *nodeComponent) nodeDaemonset(cniCfgMap *corev1.ConfigMap) *appsv1.Daemo
 					Tolerations:                   rmeta.TolerateAll,
 					Affinity:                      affinity,
 					ImagePullSecrets:              c.cfg.Installation.ImagePullSecrets,
+					HostAliases:                   hostAliases,
 					ServiceAccountName:            CalicoNodeObjectName,
 					TerminationGracePeriodSeconds: &terminationGracePeriod,
 					HostNetwork:                   true,
-					DNSPolicy:                     corev1.DNSClusterFirstWithHostNet,
+					DNSPolicy:                     corev1.DNSDefault,
 					InitContainers:                initContainers,
 					Containers:                    []corev1.Container{nodeContainer},
 					Volumes:                       c.nodeVolumes(),
@@ -1429,12 +1445,13 @@ func (c *nodeComponent) nodeEnvVars() []corev1.EnvVar {
 		{Name: "NO_DEFAULT_POOLS", Value: "true"},
 	}
 
-	// Only append goldmane variables if goldmane is running.
-	if c.cfg.GoldmaneRunning {
+	// Only append goldmane variables if goldmane is running and we have a valid IP address,
+	// as we rely on an explicitly configured host alias to resolve the goldmane service.
+	if c.cfg.GoldmaneRunning && c.cfg.GoldmaneIP != "" {
 		nodeEnv = append(nodeEnv,
 			corev1.EnvVar{
 				Name:  "FELIX_FLOWLOGSGOLDMANESERVER",
-				Value: "goldmane.calico-system.svc:7443",
+				Value: fmt.Sprintf("%s:7443", goldmaneDomainName),
 			},
 			corev1.EnvVar{
 				Name:  "FELIX_FLOWLOGSFLUSHINTERVAL",


### PR DESCRIPTION
## Description

Backport of https://github.com/tigera/operator/pull/4104.

calico-node points Felix at `goldmane.calico-system.svc` for flow logs, but it runs with the `Default` DNS policy on this branch, so that name does not resolve from the node. The operator reads the Goldmane Service ClusterIP and gives calico-node a host alias for it, and waits for the Service to get an IP before rendering the DaemonSet.

## Release Note

```release-note
Fixed flow log delivery to Goldmane on clusters where calico-node cannot resolve in-cluster Service names.
```
