### PR TITLE
Resolve every variant image through one override set

### DIFF
--- a/pkg/controller/apiserver/apiserver_controller.go
+++ b/pkg/controller/apiserver/apiserver_controller.go
@@ -51,6 +51,7 @@ import (
 	"github.com/tigera/operator/pkg/ctrlruntime"
 	"github.com/tigera/operator/pkg/dns"
 	"github.com/tigera/operator/pkg/extensions"
+	"github.com/tigera/operator/pkg/imageoverride"
 	"github.com/tigera/operator/pkg/render"
 	rcertificatemanagement "github.com/tigera/operator/pkg/render/certificatemanagement"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
@@ -73,6 +74,7 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 		migrationWatchReady: &utils.ReadyFlag{},
 		opts:                opts,
 		ext:                 opts.Extensions.APIServer(),
+		images:              opts.Extensions.Images(),
 	}
 	r.status.Run(opts.ShutdownContext)
 
@@ -191,6 +193,7 @@ type ReconcileAPIServer struct {
 	migrationWatchReady *utils.ReadyFlag
 	opts                options.ControllerOptions
 	ext                 extensions.APIServerExtension
+	images              *imageoverride.Overrides
 }
 
 // Reconcile reads that state of the cluster for a APIServer object and makes changes based on the state read
@@ -396,6 +399,7 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 		KubernetesVersion:            r.opts.KubernetesVersion,
 		ClusterDomain:                r.opts.ClusterDomain,
 		RequiresAggregationServer:    !r.opts.UseV3CRDs,
+		ImageOverrides:               r.images,
 		HoldAPIServiceCutover:        holdCutover,
 	}
 
@@ -434,11 +438,12 @@ func (r *ReconcileAPIServer) Reconcile(ctx context.Context, request reconcile.Re
 		}
 
 		webhooksCfg := webhooks.Configuration{
-			PullSecrets:  pullSecrets,
-			KeyPair:      webhooksTLS,
-			Installation: installationSpec,
-			APIServer:    &instance.Spec,
-			OpenShift:    r.opts.DetectedProvider.IsOpenShift(),
+			PullSecrets:    pullSecrets,
+			KeyPair:        webhooksTLS,
+			Installation:   installationSpec,
+			APIServer:      &instance.Spec,
+			OpenShift:      r.opts.DetectedProvider.IsOpenShift(),
+			ImageOverrides: r.images,
 		}
 		components = append(components, webhooks.Component(&webhooksCfg))
 		certKeyPairOptions = append(certKeyPairOptions, rcertificatemanagement.NewKeyPairOption(webhooksTLS, true, true))

--- a/pkg/controller/apiserver/apiserver_controller_test.go
+++ b/pkg/controller/apiserver/apiserver_controller_test.go
@@ -166,6 +166,7 @@ var _ = Describe("apiserver controller tests", func() {
 
 			r := ReconcileAPIServer{
 				ext:                 testExtensions.APIServer(),
+				images:              testExtensions.Images(),
 				client:              cli,
 				scheme:              scheme,
 				status:              mockStatus,
@@ -227,6 +228,7 @@ var _ = Describe("apiserver controller tests", func() {
 
 			r := ReconcileAPIServer{
 				ext:                 testExtensions.APIServer(),
+				images:              testExtensions.Images(),
 				client:              cli,
 				scheme:              scheme,
 				status:              mockStatus,
@@ -282,6 +284,7 @@ var _ = Describe("apiserver controller tests", func() {
 
 			r := ReconcileAPIServer{
 				ext:                 testExtensions.APIServer(),
+				images:              testExtensions.Images(),
 				client:              cli,
 				scheme:              scheme,
 				status:              mockStatus,
@@ -309,6 +312,7 @@ var _ = Describe("apiserver controller tests", func() {
 
 			r := ReconcileAPIServer{
 				ext:                 testExtensions.APIServer(),
+				images:              testExtensions.Images(),
 				client:              cli,
 				scheme:              scheme,
 				status:              mockStatus,
@@ -343,6 +347,7 @@ var _ = Describe("apiserver controller tests", func() {
 
 			r := ReconcileAPIServer{
 				ext:                 testExtensions.APIServer(),
+				images:              testExtensions.Images(),
 				client:              cli,
 				scheme:              scheme,
 				status:              mockStatus,
@@ -364,6 +369,7 @@ var _ = Describe("apiserver controller tests", func() {
 
 			r := ReconcileAPIServer{
 				ext:                 testExtensions.APIServer(),
+				images:              testExtensions.Images(),
 				client:              cli,
 				scheme:              scheme,
 				status:              mockStatus,
@@ -390,6 +396,7 @@ var _ = Describe("apiserver controller tests", func() {
 
 			r := ReconcileAPIServer{
 				ext:                 testExtensions.APIServer(),
+				images:              testExtensions.Images(),
 				client:              cli,
 				scheme:              scheme,
 				status:              mockStatus,
@@ -414,6 +421,7 @@ var _ = Describe("apiserver controller tests", func() {
 
 			r := ReconcileAPIServer{
 				ext:                 testExtensions.APIServer(),
+				images:              testExtensions.Images(),
 				client:              cli,
 				scheme:              scheme,
 				status:              mockStatus,
@@ -441,6 +449,7 @@ var _ = Describe("apiserver controller tests", func() {
 
 			r := ReconcileAPIServer{
 				ext:                 testExtensions.APIServer(),
+				images:              testExtensions.Images(),
 				client:              cli,
 				scheme:              scheme,
 				status:              mockStatus,
@@ -470,6 +479,7 @@ var _ = Describe("apiserver controller tests", func() {
 
 			r := ReconcileAPIServer{
 				ext:                 testExtensions.APIServer(),
+				images:              testExtensions.Images(),
 				client:              cli,
 				scheme:              scheme,
 				status:              mockStatus,
@@ -497,6 +507,7 @@ var _ = Describe("apiserver controller tests", func() {
 
 			r := ReconcileAPIServer{
 				ext:                 testExtensions.APIServer(),
+				images:              testExtensions.Images(),
 				client:              cli,
 				scheme:              scheme,
 				status:              mockStatus,
@@ -525,6 +536,7 @@ var _ = Describe("apiserver controller tests", func() {
 
 			r := ReconcileAPIServer{
 				ext:                 testExtensions.APIServer(),
+				images:              testExtensions.Images(),
 				client:              cli,
 				scheme:              scheme,
 				status:              mockStatus,
@@ -569,6 +581,7 @@ var _ = Describe("apiserver controller tests", func() {
 			Expect(cli.Create(ctx, ts)).NotTo(HaveOccurred())
 			r := ReconcileAPIServer{
 				ext:                 testExtensions.APIServer(),
+				images:              testExtensions.Images(),
 				client:              cli,
 				scheme:              scheme,
 				status:              mockStatus,
@@ -603,6 +616,7 @@ var _ = Describe("apiserver controller tests", func() {
 			}
 			r := ReconcileAPIServer{
 				ext:                 testExtensions.APIServer(),
+				images:              testExtensions.Images(),
 				client:              cli,
 				scheme:              scheme,
 				status:              mockStatus,
@@ -657,6 +671,7 @@ var _ = Describe("apiserver controller tests", func() {
 			Expect(cli.Create(ctx, ts)).NotTo(HaveOccurred())
 			r := ReconcileAPIServer{
 				ext:                 testExtensions.APIServer(),
+				images:              testExtensions.Images(),
 				client:              cli,
 				scheme:              scheme,
 				status:              mockStatus,
@@ -728,6 +743,7 @@ var _ = Describe("apiserver controller tests", func() {
 			Expect(cli.Create(ctx, ts)).NotTo(HaveOccurred())
 			r := ReconcileAPIServer{
 				ext:                 testExtensions.APIServer(),
+				images:              testExtensions.Images(),
 				client:              cli,
 				scheme:              scheme,
 				status:              mockStatus,
@@ -834,6 +850,7 @@ var _ = Describe("apiserver controller tests", func() {
 
 				r := ReconcileAPIServer{
 					ext:                 testExtensions.APIServer(),
+					images:              testExtensions.Images(),
 					client:              cli,
 					scheme:              scheme,
 					status:              mockStatus,
@@ -865,6 +882,7 @@ var _ = Describe("apiserver controller tests", func() {
 
 				r := ReconcileAPIServer{
 					ext:                 testExtensions.APIServer(),
+					images:              testExtensions.Images(),
 					client:              cli,
 					scheme:              scheme,
 					status:              mockStatus,
@@ -987,6 +1005,7 @@ var _ = Describe("apiserver controller tests", func() {
 
 			r := ReconcileAPIServer{
 				ext:                 testExtensions.APIServer(),
+				images:              testExtensions.Images(),
 				client:              cli,
 				scheme:              scheme,
 				status:              mockStatus,
@@ -1033,6 +1052,7 @@ var _ = Describe("apiserver controller tests", func() {
 
 			r := ReconcileAPIServer{
 				ext:                 testExtensions.APIServer(),
+				images:              testExtensions.Images(),
 				client:              cli,
 				scheme:              scheme,
 				status:              mockStatus,
@@ -1063,6 +1083,7 @@ var _ = Describe("apiserver controller tests", func() {
 
 			r := ReconcileAPIServer{
 				ext:                 testExtensions.APIServer(),
+				images:              testExtensions.Images(),
 				client:              cli,
 				scheme:              scheme,
 				status:              mockStatus,
@@ -1122,6 +1143,7 @@ var _ = Describe("apiserver controller tests", func() {
 
 			r = ReconcileAPIServer{
 				ext:                 testExtensions.APIServer(),
+				images:              testExtensions.Images(),
 				client:              cli,
 				scheme:              scheme,
 				status:              mockStatus,

--- a/pkg/controller/clusterconnection/clusterconnection_controller.go
+++ b/pkg/controller/clusterconnection/clusterconnection_controller.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/tigera/operator/pkg/imageoverride"
 	rcertificatemanagement "github.com/tigera/operator/pkg/render/certificatemanagement"
 
 	"golang.org/x/net/http/httpproxy"
@@ -151,6 +152,7 @@ func newReconciler(
 		clusterInfoWatchReady: clusterInfoWatchReady,
 		opts:                  opts,
 		ext:                   opts.Extensions.ClusterConnection(),
+		images:                opts.Extensions.Images(),
 	}
 	c.status.Run(opts.ShutdownContext)
 	return c
@@ -171,6 +173,7 @@ type ReconcileConnection struct {
 	lastAvailabilityTransition metav1.Time
 	opts                       options.ControllerOptions
 	ext                        extensions.ClusterConnectionExtension
+	images                     *imageoverride.Overrides
 }
 
 // Reconcile reads that state of the cluster for a ManagementClusterConnection object and makes changes based on the
@@ -437,6 +440,7 @@ func (r *ReconcileConnection) Reconcile(ctx context.Context, request reconcile.R
 		GuardianClientKeyPair:       guardianKeyPair,
 		Version:                     managedClusterVersion,
 		IncludeEgressNetworkPolicy:  includeEgressNetworkPolicy,
+		ImageOverrides:              r.images,
 	}
 
 	certComponent := rcertificatemanagement.CertificateManagement(&rcertificatemanagement.Config{

--- a/pkg/controller/gatewayapi/gatewayapi_controller.go
+++ b/pkg/controller/gatewayapi/gatewayapi_controller.go
@@ -53,6 +53,7 @@ import (
 	"github.com/tigera/operator/pkg/controller/utils/imageset"
 	"github.com/tigera/operator/pkg/ctrlruntime"
 	"github.com/tigera/operator/pkg/extensions"
+	"github.com/tigera/operator/pkg/imageoverride"
 	"github.com/tigera/operator/pkg/render"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
 	"github.com/tigera/operator/pkg/render/gatewayapi"
@@ -79,6 +80,7 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 		clusterDomain:       opts.ClusterDomain,
 		variant:             opts.Variant,
 		ext:                 opts.Extensions.GatewayAPI(),
+		images:              opts.Extensions.Images(),
 		multiTenant:         opts.MultiTenant,
 		newComponentHandler: utils.NewComponentHandler,
 	}
@@ -184,6 +186,7 @@ type ReconcileGatewayAPI struct {
 	clusterDomain       string
 	variant             operatorv1.ProductVariant
 	ext                 extensions.GatewayAPIExtension
+	images              *imageoverride.Overrides
 	multiTenant         bool
 	newComponentHandler func(log logr.Logger, client client.Client, scheme *runtime.Scheme, cr metav1.Object, opts ...utils.ComponentHandlerOption) utils.ComponentHandler
 	watchEnvoyProxy     func(namespacedName operatorv1.NamespacedName) error
@@ -352,7 +355,7 @@ func (r *ReconcileGatewayAPI) Reconcile(ctx context.Context, request reconcile.R
 		CurrentGatewayClasses:  set.New[string](),
 		IncludeV3NetworkPolicy: includeV3NetworkPolicy,
 		TrustedBundle:          trustedBundle,
-		ImageOverrides:         r.ext.Images(),
+		ImageOverrides:         r.images,
 	}
 
 	if gatewayAPI.Spec.EnvoyGatewayConfigRef != nil {

--- a/pkg/controller/goldmane/controller.go
+++ b/pkg/controller/goldmane/controller.go
@@ -38,6 +38,7 @@ import (
 	"github.com/tigera/operator/pkg/ctrlruntime"
 	"github.com/tigera/operator/pkg/dns"
 	"github.com/tigera/operator/pkg/extensions"
+	"github.com/tigera/operator/pkg/imageoverride"
 	"github.com/tigera/operator/pkg/render"
 	rcertificatemanagement "github.com/tigera/operator/pkg/render/certificatemanagement"
 	"github.com/tigera/operator/pkg/render/goldmane"
@@ -129,6 +130,7 @@ func newReconciler(
 		clusterDomain: opts.ClusterDomain,
 		variant:       opts.Variant,
 		ext:           opts.Extensions.Goldmane(),
+		images:        opts.Extensions.Images(),
 	}
 	c.status.Run(opts.ShutdownContext)
 	return c
@@ -146,6 +148,7 @@ type Reconciler struct {
 	clusterDomain string
 	variant       operatorv1.ProductVariant
 	ext           extensions.GoldmaneExtension
+	images        *imageoverride.Overrides
 }
 
 // Reconcile reads that state of the cluster for a Goldmane object and makes changes based on the
@@ -274,6 +277,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		ManagementClusterConnection: mgmtClusterConnectionCR,
 		ClusterDomain:               r.clusterDomain,
 		Goldmane:                    goldmaneCR,
+		ImageOverrides:              r.images,
 	}
 
 	components := []render.Component{certComponent, goldmane.Goldmane(cfg)}

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1232,6 +1232,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		MigrateNamespaces:  needsNamespaceMigration,
 		ClusterDomain:      r.opts.ClusterDomain,
 		FelixConfiguration: felixConfiguration,
+		ImageOverrides:     r.images,
 	}
 	components = append(components, render.Typha(&typhaCfg))
 
@@ -1396,9 +1397,10 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 	components = append(components, render.Node(&nodeCfg))
 
 	csiCfg := render.CSIConfiguration{
-		Installation: &defaulted.Spec,
-		Terminating:  installationMarkedForDeletion,
-		OpenShift:    defaulted.Spec.KubernetesProvider.IsOpenShift(),
+		Installation:   &defaulted.Spec,
+		Terminating:    installationMarkedForDeletion,
+		OpenShift:      defaulted.Spec.KubernetesProvider.IsOpenShift(),
+		ImageOverrides: r.images,
 	}
 	components = append(components, render.CSI(&csiCfg))
 

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -70,6 +70,7 @@ import (
 	"github.com/tigera/operator/pkg/controller/utils/imageset"
 	"github.com/tigera/operator/pkg/ctrlruntime"
 	"github.com/tigera/operator/pkg/extensions"
+	"github.com/tigera/operator/pkg/imageoverride"
 	"github.com/tigera/operator/pkg/imports/admission"
 	"github.com/tigera/operator/pkg/imports/crds"
 	"github.com/tigera/operator/pkg/render"
@@ -281,6 +282,7 @@ func newReconciler(mgr manager.Manager, opts options.ControllerOptions) (*Reconc
 		newComponentHandler: utils.NewComponentHandler,
 		opts:                opts,
 		ext:                 opts.Extensions.Installation(),
+		images:              opts.Extensions.Images(),
 	}
 	r.status.Run(opts.ShutdownContext)
 	r.typhaAutoscaler.Start(opts.ShutdownContext)
@@ -332,6 +334,7 @@ type ReconcileInstallation struct {
 	migrationWatchReady *utils.ReadyFlag
 	opts                options.ControllerOptions
 	ext                 extensions.InstallationExtension
+	images              *imageoverride.Overrides
 
 	// newComponentHandler returns a new component handler. Useful stub for unit testing.
 	newComponentHandler func(log logr.Logger, client client.Client, scheme *runtime.Scheme, cr metav1.Object, opts ...utils.ComponentHandlerOption) utils.ComponentHandler
@@ -1355,7 +1358,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		CanRemoveCNIFinalizer: canRemoveCNI,
 		FelixConfiguration:    felixConfiguration,
 		V3CRDs:                r.opts.UseV3CRDs,
-		ImageOverrides:        r.ext.Images(),
+		ImageOverrides:        r.images,
 	}
 
 	if bgpConfiguration.Spec.BindMode != nil {
@@ -1409,7 +1412,7 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 		TrustedBundle:          typhaNodeTLS.TrustedBundle,
 		Namespace:              common.CalicoNamespace,
 		BindingNamespaces:      []string{common.CalicoNamespace},
-		ImageOverrides:         r.ext.Images(),
+		ImageOverrides:         r.images,
 	}
 	components = append(components, kubecontrollers.NewCalicoKubeControllers(&kubeControllersCfg))
 

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -160,7 +160,8 @@ var _ = Describe("Testing core-controller installation", func() {
 
 			// As the parameters in the client changes, we expect the outcomes of the reconcile loops to change.
 			r = ReconcileInstallation{
-				ext: testExtensions.Installation(),
+				ext:    testExtensions.Installation(),
+				images: testExtensions.Images(),
 				opts: options.ControllerOptions{
 					Extensions:       testExtensions,
 					DetectedProvider: operator.ProviderNone,
@@ -775,7 +776,8 @@ var _ = Describe("Testing core-controller installation", func() {
 
 			// As the parameters in the client changes, we expect the outcomes of the reconcile loops to change.
 			r = ReconcileInstallation{
-				ext: testExtensions.Installation(),
+				ext:    testExtensions.Installation(),
+				images: testExtensions.Images(),
 				opts: options.ControllerOptions{
 					Extensions:       testExtensions,
 					DetectedProvider: operator.ProviderNone,
@@ -956,7 +958,8 @@ var _ = Describe("Testing core-controller installation", func() {
 
 			// As the parameters in the client changes, we expect the outcomes of the reconcile loops to change.
 			r = ReconcileInstallation{
-				ext: testExtensions.Installation(),
+				ext:    testExtensions.Installation(),
+				images: testExtensions.Images(),
 				opts: options.ControllerOptions{
 					Extensions:       testExtensions,
 					DetectedProvider: operator.ProviderNone,
@@ -2288,7 +2291,8 @@ var _ = Describe("Testing core-controller installation", func() {
 
 			// As the parameters in the client changes, we expect the outcomes of the reconcile loops to change.
 			r = ReconcileInstallation{
-				ext: testExtensions.Installation(),
+				ext:    testExtensions.Installation(),
+				images: testExtensions.Images(),
 				opts: options.ControllerOptions{
 					Extensions:       testExtensions,
 					DetectedProvider: operator.ProviderNone,
@@ -2402,7 +2406,8 @@ var _ = Describe("Testing core-controller installation", func() {
 
 			componentHandler = newFakeComponentHandler()
 			r = ReconcileInstallation{
-				ext: testExtensions.Installation(),
+				ext:    testExtensions.Installation(),
+				images: testExtensions.Images(),
 				opts: options.ControllerOptions{
 					Extensions:       testExtensions,
 					DetectedProvider: operator.ProviderNone,
@@ -2570,7 +2575,8 @@ var _ = Describe("updateMutatingAdmissionPolicies", func() {
 
 	It("should create v1 MAPs when v1 is served", func() {
 		r = ReconcileInstallation{
-			ext: testExtensions.Installation(),
+			ext:    testExtensions.Installation(),
+			images: testExtensions.Images(),
 			opts: options.ControllerOptions{
 				Extensions:   testExtensions,
 				ManageCRDs:   true,
@@ -2605,7 +2611,8 @@ var _ = Describe("updateMutatingAdmissionPolicies", func() {
 
 	It("should create v1beta1 MAPs when only v1beta1 is served", func() {
 		r = ReconcileInstallation{
-			ext: testExtensions.Installation(),
+			ext:    testExtensions.Installation(),
+			images: testExtensions.Images(),
 			opts: options.ControllerOptions{
 				Extensions:   testExtensions,
 				ManageCRDs:   true,
@@ -2638,7 +2645,8 @@ var _ = Describe("updateMutatingAdmissionPolicies", func() {
 
 	It("should create v1alpha1 MAPs when only v1alpha1 is served", func() {
 		r = ReconcileInstallation{
-			ext: testExtensions.Installation(),
+			ext:    testExtensions.Installation(),
+			images: testExtensions.Images(),
 			opts: options.ControllerOptions{
 				Extensions:   testExtensions,
 				ManageCRDs:   true,
@@ -2671,7 +2679,8 @@ var _ = Describe("updateMutatingAdmissionPolicies", func() {
 
 	It("should not create MAPs when no served version exists and should set degraded", func() {
 		r = ReconcileInstallation{
-			ext: testExtensions.Installation(),
+			ext:    testExtensions.Installation(),
+			images: testExtensions.Images(),
 			opts: options.ControllerOptions{
 				Extensions:   testExtensions,
 				ManageCRDs:   true,
@@ -2693,7 +2702,8 @@ var _ = Describe("updateMutatingAdmissionPolicies", func() {
 
 	It("should not create MAPs when v3CRDs=false", func() {
 		r = ReconcileInstallation{
-			ext: testExtensions.Installation(),
+			ext:    testExtensions.Installation(),
+			images: testExtensions.Images(),
 			opts: options.ControllerOptions{
 				Extensions:   testExtensions,
 				ManageCRDs:   true,
@@ -2714,7 +2724,8 @@ var _ = Describe("updateMutatingAdmissionPolicies", func() {
 
 	It("should not create MAPs when manageCRDs=false", func() {
 		r = ReconcileInstallation{
-			ext: testExtensions.Installation(),
+			ext:    testExtensions.Installation(),
+			images: testExtensions.Images(),
 			opts: options.ControllerOptions{
 				Extensions:   testExtensions,
 				ManageCRDs:   false,
@@ -2748,7 +2759,8 @@ var _ = Describe("updateMutatingAdmissionPolicies", func() {
 		}
 
 		r = ReconcileInstallation{
-			ext: testExtensions.Installation(),
+			ext:    testExtensions.Installation(),
+			images: testExtensions.Images(),
 			opts: options.ControllerOptions{
 				Extensions:   testExtensions,
 				ManageCRDs:   true,
@@ -2794,7 +2806,8 @@ var _ = Describe("updateMutatingAdmissionPolicies", func() {
 		}
 
 		r = ReconcileInstallation{
-			ext: testExtensions.Installation(),
+			ext:    testExtensions.Installation(),
+			images: testExtensions.Images(),
 			opts: options.ControllerOptions{
 				Extensions:   testExtensions,
 				ManageCRDs:   true,
@@ -2816,7 +2829,8 @@ var _ = Describe("updateMutatingAdmissionPolicies", func() {
 
 	It("should work with Enterprise variant", func() {
 		r = ReconcileInstallation{
-			ext: testExtensions.Installation(),
+			ext:    testExtensions.Installation(),
+			images: testExtensions.Images(),
 			opts: options.ControllerOptions{
 				Extensions:   testExtensions,
 				ManageCRDs:   true,
@@ -2891,7 +2905,8 @@ var _ = Describe("updateValidatingAdmissionPolicies", func() {
 
 	It("should create v1 VAPs when v1 is served", func() {
 		r = ReconcileInstallation{
-			ext: testExtensions.Installation(),
+			ext:    testExtensions.Installation(),
+			images: testExtensions.Images(),
 			opts: options.ControllerOptions{
 				Extensions:   testExtensions,
 				ManageCRDs:   true,
@@ -2926,7 +2941,8 @@ var _ = Describe("updateValidatingAdmissionPolicies", func() {
 
 	It("should create v1beta1 VAPs when only v1beta1 is served", func() {
 		r = ReconcileInstallation{
-			ext: testExtensions.Installation(),
+			ext:    testExtensions.Installation(),
+			images: testExtensions.Images(),
 			opts: options.ControllerOptions{
 				Extensions:   testExtensions,
 				ManageCRDs:   true,
@@ -2959,7 +2975,8 @@ var _ = Describe("updateValidatingAdmissionPolicies", func() {
 
 	It("should create v1alpha1 VAPs when only v1alpha1 is served", func() {
 		r = ReconcileInstallation{
-			ext: testExtensions.Installation(),
+			ext:    testExtensions.Installation(),
+			images: testExtensions.Images(),
 			opts: options.ControllerOptions{
 				Extensions:   testExtensions,
 				ManageCRDs:   true,
@@ -2980,7 +2997,8 @@ var _ = Describe("updateValidatingAdmissionPolicies", func() {
 
 	It("should skip without degrading when no served version exists", func() {
 		r = ReconcileInstallation{
-			ext: testExtensions.Installation(),
+			ext:    testExtensions.Installation(),
+			images: testExtensions.Images(),
 			opts: options.ControllerOptions{
 				Extensions:   testExtensions,
 				ManageCRDs:   true,
@@ -3002,7 +3020,8 @@ var _ = Describe("updateValidatingAdmissionPolicies", func() {
 
 	It("should not create VAPs when v3CRDs=false", func() {
 		r = ReconcileInstallation{
-			ext: testExtensions.Installation(),
+			ext:    testExtensions.Installation(),
+			images: testExtensions.Images(),
 			opts: options.ControllerOptions{
 				Extensions:   testExtensions,
 				ManageCRDs:   true,
@@ -3036,7 +3055,8 @@ var _ = Describe("updateValidatingAdmissionPolicies", func() {
 		}
 
 		r = ReconcileInstallation{
-			ext: testExtensions.Installation(),
+			ext:    testExtensions.Installation(),
+			images: testExtensions.Images(),
 			opts: options.ControllerOptions{
 				Extensions:   testExtensions,
 				ManageCRDs:   true,
@@ -3064,7 +3084,8 @@ var _ = Describe("updateValidatingAdmissionPolicies", func() {
 
 	It("should work with Enterprise variant", func() {
 		r = ReconcileInstallation{
-			ext: testExtensions.Installation(),
+			ext:    testExtensions.Installation(),
+			images: testExtensions.Images(),
 			opts: options.ControllerOptions{
 				Extensions:   testExtensions,
 				ManageCRDs:   true,

--- a/pkg/controller/installation/windows_controller.go
+++ b/pkg/controller/installation/windows_controller.go
@@ -50,6 +50,7 @@ import (
 	"github.com/tigera/operator/pkg/controller/utils/imageset"
 	"github.com/tigera/operator/pkg/ctrlruntime"
 	"github.com/tigera/operator/pkg/extensions"
+	"github.com/tigera/operator/pkg/imageoverride"
 	"github.com/tigera/operator/pkg/render"
 )
 
@@ -170,6 +171,7 @@ type ReconcileWindows struct {
 	ipamConfigWatchReady *utils.ReadyFlag
 	opts                 options.ControllerOptions
 	ext                  extensions.WindowsExtension
+	images               *imageoverride.Overrides
 }
 
 // newWindowsReconciler returns a new reconcile.Reconciler
@@ -185,6 +187,7 @@ func newWindowsReconciler(mgr manager.Manager, opts options.ControllerOptions) (
 		ipamConfigWatchReady: &utils.ReadyFlag{},
 		opts:                 opts,
 		ext:                  opts.Extensions.Windows(),
+		images:               opts.Extensions.Images(),
 	}
 	r.status.Run(opts.ShutdownContext)
 	return r, nil
@@ -351,7 +354,7 @@ func (r *ReconcileWindows) Reconcile(ctx context.Context, request reconcile.Requ
 		ClusterDomain:  r.opts.ClusterDomain,
 		TLS:            typhaNodeTLS,
 		VXLANVNI:       *felixConfiguration.Spec.VXLANVNI,
-		ImageOverrides: r.ext.Images(),
+		ImageOverrides: r.images,
 	}
 	component = render.Windows(&windowsCfg)
 

--- a/pkg/controller/istio/istio_controller.go
+++ b/pkg/controller/istio/istio_controller.go
@@ -233,7 +233,7 @@ func (r *ReconcileIstio) Reconcile(ctx context.Context, request reconcile.Reques
 		Istio:          instance,
 		IstioNamespace: istio.IstioNamespace,
 		Scheme:         r.scheme,
-		ImageOverrides: r.ext.Istio().Images(),
+		ImageOverrides: r.ext.Images(),
 	}
 	istioComponentCRDs, istioComponent, err := istio.Istio(istioCfg)
 	if err != nil {

--- a/pkg/controller/istio/istio_controller_test.go
+++ b/pkg/controller/istio/istio_controller_test.go
@@ -45,6 +45,7 @@ import (
 	ctrlrfake "github.com/tigera/operator/pkg/ctrlruntime/client/fake"
 	eistio "github.com/tigera/operator/pkg/enterprise/istio"
 	"github.com/tigera/operator/pkg/extensions"
+	"github.com/tigera/operator/pkg/imageoverride"
 	"github.com/tigera/operator/pkg/render/istio"
 	"github.com/tigera/operator/test"
 )
@@ -933,13 +934,15 @@ var _ = Describe("Istio controller tests", func() {
 				},
 			}
 			Expect(cli.Create(ctx, imageSet)).NotTo(HaveOccurred())
+			istioImages := imageoverride.New()
+			eistio.RegisterImages(istioImages, operatorv1.CalicoEnterprise)
 
 			r := &ReconcileIstio{
 				Client:   cli,
 				scheme:   scheme,
 				provider: operatorv1.ProviderNone,
 				status:   mockStatus,
-				ext:      extensions.New(extensions.Set{Istio: eistio.New(operatorv1.CalicoEnterprise)}),
+				ext:      extensions.New(extensions.Set{Istio: eistio.New(operatorv1.CalicoEnterprise), Images: istioImages}),
 			}
 
 			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "default"}})

--- a/pkg/controller/logstorage/kubecontrollers/es_kube_controllers.go
+++ b/pkg/controller/logstorage/kubecontrollers/es_kube_controllers.go
@@ -48,6 +48,7 @@ import (
 	"github.com/tigera/operator/pkg/enterprise/cloudconfig"
 	entkubecontrollers "github.com/tigera/operator/pkg/enterprise/kubecontrollers"
 	eutils "github.com/tigera/operator/pkg/enterprise/utils"
+	"github.com/tigera/operator/pkg/imageoverride"
 	"github.com/tigera/operator/pkg/render"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
 	"github.com/tigera/operator/pkg/render/kubecontrollers"
@@ -68,6 +69,7 @@ type ESKubeControllersController struct {
 	multiTenant     bool
 	cloud           bool
 	tierWatchReady  *utils.ReadyFlag
+	images          *imageoverride.Overrides
 }
 
 func Add(mgr manager.Manager, opts options.ControllerOptions) error {
@@ -93,6 +95,7 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 		elasticExternal: opts.ElasticExternal,
 		multiTenant:     opts.MultiTenant,
 		cloud:           opts.Cloud,
+		images:          opts.Extensions.Images(),
 		tierWatchReady:  &utils.ReadyFlag{},
 	}
 	r.status.Run(opts.ShutdownContext)
@@ -354,6 +357,7 @@ func (r *ESKubeControllersController) Reconcile(ctx context.Context, request rec
 		TrustedBundle:                trustedBundle,
 		Namespace:                    helper.InstallNamespace(),
 		BindingNamespaces:            namespaces,
+		ImageOverrides:               r.images,
 	}
 	esKubeControllersCfg := entkubecontrollers.Configuration{
 		KubeControllersConfiguration: &kubeControllersCfg,

--- a/pkg/controller/logstorage/kubecontrollers/es_kube_controllers_test.go
+++ b/pkg/controller/logstorage/kubecontrollers/es_kube_controllers_test.go
@@ -46,7 +46,9 @@ import (
 	"github.com/tigera/operator/pkg/controller/utils"
 	ctrlrfake "github.com/tigera/operator/pkg/ctrlruntime/client/fake"
 	"github.com/tigera/operator/pkg/dns"
+	"github.com/tigera/operator/pkg/enterprise"
 	entkubecontrollers "github.com/tigera/operator/pkg/enterprise/kubecontrollers"
+	eoptions "github.com/tigera/operator/pkg/enterprise/options"
 	"github.com/tigera/operator/pkg/render"
 	"github.com/tigera/operator/pkg/render/logstorage"
 	"github.com/tigera/operator/pkg/render/logstorage/esgateway"
@@ -74,6 +76,7 @@ func NewControllerWithShims(
 		ShutdownContext:  context.TODO(),
 		MultiTenant:      multiTenant,
 		Variant:          operatorv1.CalicoEnterprise,
+		Extensions:       enterprise.New(operatorv1.CalicoEnterprise, eoptions.Options{}),
 	}
 
 	r := &ESKubeControllersController{
@@ -84,6 +87,7 @@ func NewControllerWithShims(
 		variant:        opts.Variant,
 		tierWatchReady: tierWatchReady,
 		multiTenant:    multiTenant,
+		images:         opts.Extensions.Images(),
 	}
 	r.status.Run(opts.ShutdownContext)
 	return r, nil

--- a/pkg/controller/whisker/controller.go
+++ b/pkg/controller/whisker/controller.go
@@ -40,6 +40,7 @@ import (
 	"github.com/tigera/operator/pkg/ctrlruntime"
 	"github.com/tigera/operator/pkg/dns"
 	"github.com/tigera/operator/pkg/extensions"
+	"github.com/tigera/operator/pkg/imageoverride"
 	"github.com/tigera/operator/pkg/render"
 	rcertificatemanagement "github.com/tigera/operator/pkg/render/certificatemanagement"
 	"github.com/tigera/operator/pkg/render/goldmane"
@@ -133,6 +134,7 @@ func newReconciler(
 		clusterDomain: opts.ClusterDomain,
 		variant:       opts.Variant,
 		ext:           opts.Extensions.Whisker(),
+		images:        opts.Extensions.Images(),
 	}
 	c.status.Run(opts.ShutdownContext)
 	return c
@@ -149,6 +151,7 @@ type Reconciler struct {
 	clusterDomain string
 	variant       operatorv1.ProductVariant
 	ext           extensions.WhiskerExtension
+	images        *imageoverride.Overrides
 }
 
 // Reconcile reads that state of the cluster for a Whisker object and makes changes based on the
@@ -263,6 +266,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		WhiskerBackendKeyPair: backendKeyPair,
 		Whisker:               whiskerCR,
 		ClusterDomain:         r.clusterDomain,
+		ImageOverrides:        r.images,
 	}
 
 	clusterInfo := &v3.ClusterInformation{}

--- a/pkg/enterprise/clusterconnection/guardian_render_test.go
+++ b/pkg/enterprise/clusterconnection/guardian_render_test.go
@@ -17,6 +17,8 @@ package clusterconnection_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/tigera/operator/pkg/enterprise"
+	eoptions "github.com/tigera/operator/pkg/enterprise/options"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -105,6 +107,7 @@ var _ = Describe("Guardian enterprise rendering tests", func() {
 			OpenShift:                   openshift,
 			ManagementClusterConnection: &operatorv1.ManagementClusterConnection{},
 			IncludeEgressNetworkPolicy:  true,
+			ImageOverrides:              enterprise.New(operatorv1.CalicoEnterprise, eoptions.Options{}).Images(),
 		}
 	}
 

--- a/pkg/enterprise/gatewayapi/extension.go
+++ b/pkg/enterprise/gatewayapi/extension.go
@@ -43,23 +43,20 @@ const legacyNamespace = "tigera-gateway"
 // Extension is the Calico Enterprise behavior for the gateway API controller.
 type Extension struct {
 	variant operatorv1.ProductVariant
-	images  *imageoverride.Overrides
 }
 
 var _ extensions.GatewayAPIExtension = &Extension{}
 
 // New returns the gateway API extension for the variant the operator resolved.
 func New(variant operatorv1.ProductVariant) *Extension {
-	images := imageoverride.New()
-	images.Register(variant, gatewayapi.ComponentNameEnvoyGateway, components.ComponentGatewayAPIEnvoyGateway)
-	images.Register(variant, gatewayapi.ComponentNameEnvoyProxy, components.ComponentGatewayAPIEnvoyProxy)
-	images.Register(variant, gatewayapi.ComponentNameEnvoyRatelimit, components.ComponentGatewayAPIEnvoyRatelimit)
-
-	return &Extension{variant: variant, images: images}
+	return &Extension{variant: variant}
 }
 
-func (e *Extension) Images() *imageoverride.Overrides {
-	return e.images
+// RegisterImages adds the images the gateway API components resolve.
+func RegisterImages(o *imageoverride.Overrides, variant operatorv1.ProductVariant) {
+	o.Register(variant, gatewayapi.ComponentNameEnvoyGateway, components.ComponentGatewayAPIEnvoyGateway)
+	o.Register(variant, gatewayapi.ComponentNameEnvoyProxy, components.ComponentGatewayAPIEnvoyProxy)
+	o.Register(variant, gatewayapi.ComponentNameEnvoyRatelimit, components.ComponentGatewayAPIEnvoyRatelimit)
 }
 
 // gatewayAPIRenderData is the controller-produced data the gateway API extension hands

--- a/pkg/enterprise/gatewayapi/extension_test.go
+++ b/pkg/enterprise/gatewayapi/extension_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/controller"
+	"github.com/tigera/operator/pkg/imageoverride"
 	"github.com/tigera/operator/pkg/render"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
 	"github.com/tigera/operator/pkg/render/gatewayapi"
@@ -62,7 +63,8 @@ func testScheme() *runtime.Scheme {
 func enterpriseComponent(cfg *gatewayapi.GatewayAPIImplementationConfig) render.Component {
 	ext := New(operatorv1.CalicoEnterprise)
 	cfg.Scheme = testScheme()
-	cfg.ImageOverrides = ext.Images()
+	cfg.ImageOverrides = imageoverride.New()
+	RegisterImages(cfg.ImageOverrides, operatorv1.CalicoEnterprise)
 
 	comp, err := gatewayapi.GatewayAPIImplementationComponent(cfg)
 	Expect(err).NotTo(HaveOccurred())

--- a/pkg/enterprise/installation/extension.go
+++ b/pkg/enterprise/installation/extension.go
@@ -32,7 +32,6 @@ import (
 type Extension struct {
 	variant operatorv1.ProductVariant
 	opts    eoptions.Options
-	images  *imageoverride.Overrides
 
 	// typhaAutoscaler scales the non-cluster-host Typha deployment. Nil until the
 	// first reconcile that sees a NonClusterHost resource.
@@ -43,24 +42,22 @@ var _ extensions.InstallationExtension = &Extension{}
 
 // New returns the installation extension for the variant the operator resolved.
 func New(variant operatorv1.ProductVariant, opts eoptions.Options) *Extension {
-	images := imageoverride.New()
-	images.Register(variant, render.ComponentNameNode, components.ComponentTigeraNode)
+	return &Extension{variant: variant, opts: opts}
+}
+
+// RegisterImages adds the images the installation controller's components resolve.
+func RegisterImages(o *imageoverride.Overrides, variant operatorv1.ProductVariant, opts eoptions.Options) {
+	o.Register(variant, render.ComponentNameNode, components.ComponentTigeraNode)
 
 	// The node component renders the cni-plugins init container; its image resolves
 	// through its own override key.
-	images.Register(variant, render.ComponentNameCNIPlugins, components.ComponentTigeraCNIPlugins)
+	o.Register(variant, render.ComponentNameCNIPlugins, components.ComponentTigeraCNIPlugins)
 
 	if opts.Cloud {
 		// Calico Cloud runs kube-controllers from the combined image, which carries the
 		// Cloud behavior the mono image lacks.
-		images.Register(variant, render.ComponentNameKubeControllers, components.CalicoCloudImage())
+		o.Register(variant, render.ComponentNameKubeControllers, components.CalicoCloudImage())
 	}
-
-	return &Extension{variant: variant, opts: opts, images: images}
-}
-
-func (e *Extension) Images() *imageoverride.Overrides {
-	return e.images
 }
 
 // Modify dispatches over the components the installation controller renders.

--- a/pkg/enterprise/installation/node_test.go
+++ b/pkg/enterprise/installation/node_test.go
@@ -37,12 +37,12 @@ import (
 var _ = Describe("node enterprise image override", func() {
 	It("selects the enterprise node image for the enterprise variant", func() {
 		ent := &operatorv1.InstallationSpec{Variant: operatorv1.CalicoEnterprise}
-		Expect(ext.Installation().Images().Resolve("node", components.ComponentCalicoNode, ent)).To(Equal(components.ComponentTigeraNode))
+		Expect(ext.Images().Resolve("node", components.ComponentCalicoNode, ent)).To(Equal(components.ComponentTigeraNode))
 	})
 
 	It("leaves the default in place for the Calico variant", func() {
 		calico := &operatorv1.InstallationSpec{Variant: operatorv1.Calico}
-		Expect(ext.Installation().Images().Resolve("node", components.ComponentCalicoNode, calico)).To(Equal(components.ComponentCalicoNode))
+		Expect(ext.Images().Resolve("node", components.ComponentCalicoNode, calico)).To(Equal(components.ComponentCalicoNode))
 	})
 })
 

--- a/pkg/enterprise/istio/extension.go
+++ b/pkg/enterprise/istio/extension.go
@@ -35,24 +35,21 @@ import (
 // Extension is the Calico Enterprise behavior for the istio controller.
 type Extension struct {
 	variant operatorv1.ProductVariant
-	images  *imageoverride.Overrides
 }
 
 var _ extensions.IstioExtension = &Extension{}
 
 // New returns the istio extension for the variant the operator resolved.
 func New(variant operatorv1.ProductVariant) *Extension {
-	images := imageoverride.New()
-	images.Register(variant, ristio.ComponentNamePilot, components.ComponentIstioPilot)
-	images.Register(variant, ristio.ComponentNameInstallCNI, components.ComponentIstioInstallCNI)
-	images.Register(variant, ristio.ComponentNameZTunnel, components.ComponentIstioZTunnel)
-	images.Register(variant, ristio.ComponentNameProxyv2, components.ComponentIstioProxyv2)
-
-	return &Extension{variant: variant, images: images}
+	return &Extension{variant: variant}
 }
 
-func (e *Extension) Images() *imageoverride.Overrides {
-	return e.images
+// RegisterImages adds the images the istio components resolve.
+func RegisterImages(o *imageoverride.Overrides, variant operatorv1.ProductVariant) {
+	o.Register(variant, ristio.ComponentNamePilot, components.ComponentIstioPilot)
+	o.Register(variant, ristio.ComponentNameInstallCNI, components.ComponentIstioInstallCNI)
+	o.Register(variant, ristio.ComponentNameZTunnel, components.ComponentIstioZTunnel)
+	o.Register(variant, ristio.ComponentNameProxyv2, components.ComponentIstioProxyv2)
 }
 
 // PolicySyncRequired reports whether the ApplicationLayer flow needs the policy-sync

--- a/pkg/enterprise/istio/extension.go
+++ b/pkg/enterprise/istio/extension.go
@@ -88,7 +88,7 @@ func (e *Extension) ExtendInputs(ctx context.Context, ci controller.Inputs) (con
 	// The l7-collector runs as a subcommand of the combined calico binary, so waypoint
 	// pods resolve it from the node cache that calico-node already populated and need no
 	// pull secret in their namespace.
-	image, err := components.GetReference(components.CombinedCalicoImage(in), in.Registry, in.ImagePath, in.ImagePrefix, imageSet)
+	image, err := components.GetReference(components.ComponentTigeraCalico, in.Registry, in.ImagePath, in.ImagePrefix, imageSet)
 	if err != nil {
 		return ci, extensions.Degradedf(operatorv1.ResourceUpdateError, "error with images from ImageSet: %w", err)
 	}

--- a/pkg/enterprise/istio/extension_test.go
+++ b/pkg/enterprise/istio/extension_test.go
@@ -36,6 +36,7 @@ import (
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/controller"
+	"github.com/tigera/operator/pkg/imageoverride"
 	"github.com/tigera/operator/pkg/render"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
 	ristio "github.com/tigera/operator/pkg/render/istio"
@@ -92,7 +93,7 @@ var _ = Describe("Istio extension", func() {
 			},
 			IstioNamespace: ristio.IstioNamespace,
 			Scheme:         testScheme(),
-			ImageOverrides: ext.Images(),
+			ImageOverrides: istioImages(),
 		}
 		ri = render.Inputs{Installation: install}
 	})
@@ -224,4 +225,11 @@ func expectedImage(c components.Component, in *operatorv1.InstallationSpec, is *
 	image, err := components.GetReference(c, in.Registry, in.ImagePath, in.ImagePrefix, is)
 	Expect(err).ShouldNot(HaveOccurred())
 	return image
+}
+
+// istioImages is the override set the operator builds for an Enterprise install.
+func istioImages() *imageoverride.Overrides {
+	o := imageoverride.New()
+	RegisterImages(o, operatorv1.CalicoEnterprise)
+	return o
 }

--- a/pkg/enterprise/kubecontrollers/es_kube_controllers_test.go
+++ b/pkg/enterprise/kubecontrollers/es_kube_controllers_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/tigera/operator/pkg/controller/k8sapi"
 	ctrlrfake "github.com/tigera/operator/pkg/ctrlruntime/client/fake"
 	"github.com/tigera/operator/pkg/dns"
+	"github.com/tigera/operator/pkg/imageoverride"
 	"github.com/tigera/operator/pkg/render"
 	rtest "github.com/tigera/operator/pkg/render/common/test"
 	rkc "github.com/tigera/operator/pkg/render/kubecontrollers"
@@ -104,6 +105,8 @@ var _ = Describe("es-kube-controllers rendering tests", func() {
 		certificateManager, err := certificatemanager.Create(cli, nil, dns.DefaultClusterDomain, common.OperatorNamespace(), certificatemanager.AllowCACreation())
 		Expect(err).NotTo(HaveOccurred())
 
+		images := imageoverride.New()
+		images.Register(operatorv1.CalicoEnterprise, render.ComponentNameCalico, components.ComponentTigeraCalico)
 		cfg = Configuration{
 			KubeControllersConfiguration: &rkc.KubeControllersConfiguration{
 				K8sServiceEp:      k8sServiceEp,
@@ -113,6 +116,7 @@ var _ = Describe("es-kube-controllers rendering tests", func() {
 				TrustedBundle:     certificateManager.CreateTrustedBundle(),
 				Namespace:         common.CalicoNamespace,
 				BindingNamespaces: []string{common.CalicoNamespace},
+				ImageOverrides:    images,
 			},
 		}
 	})

--- a/pkg/enterprise/register.go
+++ b/pkg/enterprise/register.go
@@ -28,6 +28,7 @@ import (
 	"github.com/tigera/operator/pkg/enterprise/whisker"
 	"github.com/tigera/operator/pkg/enterprise/windows"
 	"github.com/tigera/operator/pkg/extensions"
+	"github.com/tigera/operator/pkg/imageoverride"
 )
 
 // New builds the Calico Enterprise extensions. After the monorepo split this is what
@@ -48,6 +49,7 @@ func New(variant operatorv1.ProductVariant, o eoptions.Options) extensions.Exten
 			Goldmane:          goldmane.New(variant),
 			Whisker:           whisker.New(variant),
 			GatewayAPI:        gatewayapi.New(variant),
+			Images:            images(variant, o),
 		})
 	}
 
@@ -57,4 +59,14 @@ func New(variant operatorv1.ProductVariant, o eoptions.Options) extensions.Exten
 	}
 
 	return extensions.Extensions{}
+}
+
+// images is every component whose image differs for Enterprise.
+func images(variant operatorv1.ProductVariant, o eoptions.Options) *imageoverride.Overrides {
+	set := imageoverride.New()
+	installation.RegisterImages(set, variant, o)
+	windows.RegisterImages(set, variant)
+	gatewayapi.RegisterImages(set, variant)
+	istio.RegisterImages(set, variant)
+	return set
 }

--- a/pkg/enterprise/register.go
+++ b/pkg/enterprise/register.go
@@ -16,6 +16,7 @@ package enterprise
 
 import (
 	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/enterprise/apiserver"
 	"github.com/tigera/operator/pkg/enterprise/clusterconnection"
 	"github.com/tigera/operator/pkg/enterprise/csr"
@@ -29,6 +30,7 @@ import (
 	"github.com/tigera/operator/pkg/enterprise/windows"
 	"github.com/tigera/operator/pkg/extensions"
 	"github.com/tigera/operator/pkg/imageoverride"
+	"github.com/tigera/operator/pkg/render"
 )
 
 // New builds the Calico Enterprise extensions. After the monorepo split this is what
@@ -64,6 +66,7 @@ func New(variant operatorv1.ProductVariant, o eoptions.Options) extensions.Exten
 // images is every component whose image differs for Enterprise.
 func images(variant operatorv1.ProductVariant, o eoptions.Options) *imageoverride.Overrides {
 	set := imageoverride.New()
+	set.Register(variant, render.ComponentNameCalico, components.ComponentTigeraCalico)
 	installation.RegisterImages(set, variant, o)
 	windows.RegisterImages(set, variant)
 	gatewayapi.RegisterImages(set, variant)

--- a/pkg/enterprise/windows/extension.go
+++ b/pkg/enterprise/windows/extension.go
@@ -43,22 +43,19 @@ import (
 // Extension is the Calico Enterprise behavior for the windows controller.
 type Extension struct {
 	variant operatorv1.ProductVariant
-	images  *imageoverride.Overrides
 }
 
 var _ extensions.WindowsExtension = &Extension{}
 
 // New returns the windows extension for the variant the operator resolved.
 func New(variant operatorv1.ProductVariant) *Extension {
-	images := imageoverride.New()
-	images.Register(variant, render.ComponentNameWindowsNodeImg, components.ComponentTigeraNodeWindows)
-	images.Register(variant, render.ComponentNameWindowsCNIImg, components.ComponentTigeraCNIWindows)
-
-	return &Extension{variant: variant, images: images}
+	return &Extension{variant: variant}
 }
 
-func (e *Extension) Images() *imageoverride.Overrides {
-	return e.images
+// RegisterImages adds the images the windows components resolve.
+func RegisterImages(o *imageoverride.Overrides, variant operatorv1.ProductVariant) {
+	o.Register(variant, render.ComponentNameWindowsNodeImg, components.ComponentTigeraNodeWindows)
+	o.Register(variant, render.ComponentNameWindowsCNIImg, components.ComponentTigeraCNIWindows)
 }
 
 // Modify dispatches over the components the windows controller renders.

--- a/pkg/enterprise/windows/extension_test.go
+++ b/pkg/enterprise/windows/extension_test.go
@@ -48,13 +48,13 @@ var _ = Describe("windows enterprise image override", func() {
 	calico := &operatorv1.InstallationSpec{Variant: operatorv1.Calico}
 
 	It("selects the enterprise windows images for the enterprise variant", func() {
-		Expect(ext.Windows().Images().Resolve(render.ComponentNameWindowsNodeImg, components.ComponentCalicoNodeWindows, ent)).To(Equal(components.ComponentTigeraNodeWindows))
-		Expect(ext.Windows().Images().Resolve(render.ComponentNameWindowsCNIImg, components.ComponentCalicoCNIWindows, ent)).To(Equal(components.ComponentTigeraCNIWindows))
+		Expect(ext.Images().Resolve(render.ComponentNameWindowsNodeImg, components.ComponentCalicoNodeWindows, ent)).To(Equal(components.ComponentTigeraNodeWindows))
+		Expect(ext.Images().Resolve(render.ComponentNameWindowsCNIImg, components.ComponentCalicoCNIWindows, ent)).To(Equal(components.ComponentTigeraCNIWindows))
 	})
 
 	It("leaves the defaults in place for the Calico variant", func() {
-		Expect(ext.Windows().Images().Resolve(render.ComponentNameWindowsNodeImg, components.ComponentCalicoNodeWindows, calico)).To(Equal(components.ComponentCalicoNodeWindows))
-		Expect(ext.Windows().Images().Resolve(render.ComponentNameWindowsCNIImg, components.ComponentCalicoCNIWindows, calico)).To(Equal(components.ComponentCalicoCNIWindows))
+		Expect(ext.Images().Resolve(render.ComponentNameWindowsNodeImg, components.ComponentCalicoNodeWindows, calico)).To(Equal(components.ComponentCalicoNodeWindows))
+		Expect(ext.Images().Resolve(render.ComponentNameWindowsCNIImg, components.ComponentCalicoCNIWindows, calico)).To(Equal(components.ComponentCalicoCNIWindows))
 	})
 })
 

--- a/pkg/enterprise/windows/windows_render_test.go
+++ b/pkg/enterprise/windows/windows_render_test.go
@@ -190,7 +190,7 @@ var _ = Describe("Windows enterprise rendering tests", func() {
 			ClusterDomain:  defaultClusterDomain,
 			TLS:            typhaNodeTLS,
 			VXLANVNI:       4096,
-			ImageOverrides: ext.Windows().Images(),
+			ImageOverrides: ext.Images(),
 		}
 	})
 

--- a/pkg/extensions/extensions.go
+++ b/pkg/extensions/extensions.go
@@ -14,6 +14,10 @@
 
 package extensions
 
+import (
+	"github.com/tigera/operator/pkg/imageoverride"
+)
+
 // Set is the extensions a variant supplies, one per extended controller. What it
 // leaves unset runs the core behavior.
 type Set struct {
@@ -27,6 +31,10 @@ type Set struct {
 	Goldmane          GoldmaneExtension
 	Whisker           WhiskerExtension
 	GatewayAPI        GatewayAPIExtension
+
+	// Images maps a component name to the image the variant runs for it. One set for
+	// the whole operator, since the variant is fixed for the process lifetime.
+	Images *imageoverride.Overrides
 }
 
 // Extensions is the variant behavior the operator runs with. The zero value extends
@@ -109,4 +117,10 @@ func (e Extensions) GatewayAPI() GatewayAPIExtension {
 		return noopGatewayAPI{}
 	}
 	return e.set.GatewayAPI
+}
+
+// Images returns the variant's image overrides. A nil set resolves every component to
+// the default the caller passes.
+func (e Extensions) Images() *imageoverride.Overrides {
+	return e.set.Images
 }

--- a/pkg/extensions/extensions_test.go
+++ b/pkg/extensions/extensions_test.go
@@ -85,7 +85,7 @@ var _ = Describe("the zero value Extensions", func() {
 		var e extensions.Extensions
 
 		Expect(e.Installation().ProductVersion()).NotTo(BeEmpty())
-		Expect(e.Installation().Images()).To(BeNil())
+		Expect(e.Images()).To(BeNil())
 		Expect(e.Windows().Watches(nil)).NotTo(HaveOccurred())
 
 		ci, keyPairs, err := e.ClusterConnection().ExtendInputs(context.Background(), controller.Inputs{})

--- a/pkg/extensions/gatewayapi.go
+++ b/pkg/extensions/gatewayapi.go
@@ -21,14 +21,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/tigera/operator/pkg/controller"
-	"github.com/tigera/operator/pkg/imageoverride"
 	"github.com/tigera/operator/pkg/render"
 )
 
 // GatewayAPIExtension is the variant's hook into the gateway API controller.
 type GatewayAPIExtension interface {
 	// Images overrides the images the gateway API render resolves.
-	Images() *imageoverride.Overrides
 
 	// ExtendInputs resolves what the modifier needs but cannot read for itself.
 	ExtendInputs(ctx context.Context, ci controller.Inputs) (controller.Inputs, error)
@@ -43,10 +41,6 @@ type GatewayAPIExtension interface {
 
 // noopGatewayAPI runs the core operator's behavior unchanged.
 type noopGatewayAPI struct{}
-
-func (noopGatewayAPI) Images() *imageoverride.Overrides {
-	return nil
-}
 
 func (noopGatewayAPI) ExtendInputs(_ context.Context, ci controller.Inputs) (controller.Inputs, error) {
 	return ci, nil

--- a/pkg/extensions/installation.go
+++ b/pkg/extensions/installation.go
@@ -23,7 +23,6 @@ import (
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/controller"
 	"github.com/tigera/operator/pkg/ctrlruntime"
-	"github.com/tigera/operator/pkg/imageoverride"
 	"github.com/tigera/operator/pkg/render"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 )
@@ -46,7 +45,6 @@ type InstallationExtension interface {
 	ProductVersion() string
 
 	// Images overrides the images the rendered components resolve to.
-	Images() *imageoverride.Overrides
 
 	// Modify layers the variant onto a component the controller rendered.
 	Modify(c render.Component, ri render.Inputs) render.Component
@@ -69,10 +67,6 @@ func (noopInstallation) DefaultFelixConfiguration(*operatorv1.InstallationSpec, 
 
 func (noopInstallation) ProductVersion() string {
 	return components.CalicoRelease
-}
-
-func (noopInstallation) Images() *imageoverride.Overrides {
-	return nil
 }
 
 func (noopInstallation) Modify(c render.Component, _ render.Inputs) render.Component {

--- a/pkg/extensions/istio.go
+++ b/pkg/extensions/istio.go
@@ -20,7 +20,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/tigera/operator/pkg/controller"
-	"github.com/tigera/operator/pkg/imageoverride"
 	"github.com/tigera/operator/pkg/render"
 )
 
@@ -31,7 +30,6 @@ type IstioExtension interface {
 	PolicySyncRequired(ctx context.Context, c client.Client) (bool, error)
 
 	// Images overrides the images the istio render resolves.
-	Images() *imageoverride.Overrides
 
 	// ExtendInputs resolves what the modifier needs but cannot read for itself.
 	ExtendInputs(ctx context.Context, ci controller.Inputs) (controller.Inputs, error)
@@ -45,10 +43,6 @@ type noopIstio struct{}
 
 func (noopIstio) PolicySyncRequired(context.Context, client.Client) (bool, error) {
 	return false, nil
-}
-
-func (noopIstio) Images() *imageoverride.Overrides {
-	return nil
 }
 
 func (noopIstio) ExtendInputs(_ context.Context, ci controller.Inputs) (controller.Inputs, error) {

--- a/pkg/extensions/windows.go
+++ b/pkg/extensions/windows.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/tigera/operator/pkg/controller"
 	"github.com/tigera/operator/pkg/ctrlruntime"
-	"github.com/tigera/operator/pkg/imageoverride"
 	"github.com/tigera/operator/pkg/render"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
 )
@@ -31,7 +30,6 @@ type WindowsExtension interface {
 
 	// Modify layers the variant onto a component the controller rendered.
 	Modify(c render.Component, ri render.Inputs) render.Component
-	Images() *imageoverride.Overrides
 }
 
 // noopWindows runs the core operator's behavior unchanged.
@@ -42,10 +40,6 @@ func (noopWindows) ExtendInputs(_ context.Context, ci controller.Inputs) (contro
 }
 
 func (noopWindows) Watches(ctrlruntime.Controller) error {
-	return nil
-}
-
-func (noopWindows) Images() *imageoverride.Overrides {
 	return nil
 }
 

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -35,6 +35,7 @@ import (
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/controller/k8sapi"
+	"github.com/tigera/operator/pkg/imageoverride"
 	rcomp "github.com/tigera/operator/pkg/render/common/components"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
@@ -161,6 +162,8 @@ type APIServerConfiguration struct {
 	// HoldAPIServiceCutover leaves the previous API server in service, so its
 	// APIService and the resources it needs are left alone.
 	HoldAPIServiceCutover bool
+
+	ImageOverrides *imageoverride.Overrides
 }
 
 type apiServerComponent struct {
@@ -181,7 +184,7 @@ func (c *apiServerComponent) ResolveImages(is *operatorv1.ImageSet) error {
 	// API server container, and a variant modifier needs it for the query server
 	// container and the deployment skeleton it may render itself.
 	var err error
-	c.calicoImage, err = components.GetReference(components.CombinedCalicoImage(c.cfg.Installation), reg, path, prefix, is)
+	c.calicoImage, err = components.GetReference(c.cfg.ImageOverrides.Resolve(ComponentNameCalico, components.ComponentCalico, c.cfg.Installation), reg, path, prefix, is)
 	if err != nil {
 		return err
 	}

--- a/pkg/render/component.go
+++ b/pkg/render/component.go
@@ -94,4 +94,8 @@ const (
 	ComponentNameWindowsCNIImg  = "windows-cni-image"
 
 	ComponentNameKubeControllers = "kube-controllers"
+
+	// ComponentNameCalico keys the combined calico image; most components run one of
+	// its binaries.
+	ComponentNameCalico = "calico"
 )

--- a/pkg/render/csi.go
+++ b/pkg/render/csi.go
@@ -28,6 +28,7 @@ import (
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
+	"github.com/tigera/operator/pkg/imageoverride"
 	rcomp "github.com/tigera/operator/pkg/render/common/components"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/securitycontext"
@@ -46,6 +47,8 @@ type CSIConfiguration struct {
 	Installation *operatorv1.InstallationSpec
 	Terminating  bool
 	OpenShift    bool
+
+	ImageOverrides *imageoverride.Overrides
 }
 
 type csiComponent struct {
@@ -376,7 +379,7 @@ func (c *csiComponent) ResolveImages(is *operatorv1.ImageSet) error {
 	path := c.cfg.Installation.ImagePath
 	prefix := c.cfg.Installation.ImagePrefix
 	var err error
-	c.calicoImage, err = components.GetReference(components.CombinedCalicoImage(c.cfg.Installation), reg, path, prefix, is)
+	c.calicoImage, err = components.GetReference(c.cfg.ImageOverrides.Resolve(ComponentNameCalico, components.ComponentCalico, c.cfg.Installation), reg, path, prefix, is)
 	if err != nil {
 		return err
 	}

--- a/pkg/render/csi_test.go
+++ b/pkg/render/csi_test.go
@@ -18,6 +18,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/tigera/operator/pkg/enterprise"
+	eoptions "github.com/tigera/operator/pkg/enterprise/options"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -298,6 +301,7 @@ var _ = Describe("CSI rendering tests", func() {
 
 	It("should use private images when Variant = enterprise", func() {
 		cfg.Installation.Variant = operatorv1.CalicoEnterprise
+		cfg.ImageOverrides = enterprise.New(operatorv1.CalicoEnterprise, eoptions.Options{}).Images()
 		comp := render.CSI(&cfg)
 		Expect(comp.ResolveImages(nil)).To(BeNil())
 		createObjs, _ := comp.Objects()

--- a/pkg/render/goldmane/component.go
+++ b/pkg/render/goldmane/component.go
@@ -22,6 +22,7 @@ import (
 	v3 "github.com/tigera/api/pkg/apis/projectcalico/v3"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
+	"github.com/tigera/operator/pkg/imageoverride"
 	"github.com/tigera/operator/pkg/render"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
 	"github.com/tigera/operator/pkg/render/common/securitycontext"
@@ -78,6 +79,8 @@ type Configuration struct {
 	ManagementClusterConnection *operatorv1.ManagementClusterConnection
 	ClusterDomain               string
 	Goldmane                    *operatorv1.Goldmane
+
+	ImageOverrides *imageoverride.Overrides
 }
 
 type Component struct {
@@ -92,7 +95,7 @@ func (c *Component) ResolveImages(is *operatorv1.ImageSet) error {
 	prefix := c.cfg.Installation.ImagePrefix
 
 	var err error
-	c.calicoImage, err = components.GetReference(components.CombinedCalicoImage(c.cfg.Installation), reg, path, prefix, is)
+	c.calicoImage, err = components.GetReference(c.cfg.ImageOverrides.Resolve(render.ComponentNameCalico, components.ComponentCalico, c.cfg.Installation), reg, path, prefix, is)
 	return err
 }
 

--- a/pkg/render/guardian.go
+++ b/pkg/render/guardian.go
@@ -34,6 +34,7 @@ import (
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
+	"github.com/tigera/operator/pkg/imageoverride"
 	rcomponents "github.com/tigera/operator/pkg/render/common/components"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
@@ -125,6 +126,8 @@ type GuardianConfiguration struct {
 	// Version stores the version of the cluster, as reported by the ClusterInformation object. It is used to restart
 	// guardian when the version changes, which triggers the management cluster to re-check for version skew.
 	Version string
+
+	ImageOverrides *imageoverride.Overrides
 }
 
 // GuardianRenderData is the variant-specific Guardian input a controller extension
@@ -162,7 +165,7 @@ func (c *guardianComponent) ResolveImages(is *operatorv1.ImageSet) error {
 	path := c.cfg.Installation.ImagePath
 	prefix := c.cfg.Installation.ImagePrefix
 	var err error
-	c.calicoImage, err = components.GetReference(components.CombinedCalicoImage(c.cfg.Installation), reg, path, prefix, is)
+	c.calicoImage, err = components.GetReference(c.cfg.ImageOverrides.Resolve(ComponentNameCalico, components.ComponentCalico, c.cfg.Installation), reg, path, prefix, is)
 	return err
 }
 

--- a/pkg/render/kubecontrollers/kube-controllers.go
+++ b/pkg/render/kubecontrollers/kube-controllers.go
@@ -222,7 +222,8 @@ func (c *kubeControllersComponent) ResolveImages(is *operatorv1.ImageSet) error 
 	path := c.cfg.Installation.ImagePath
 	prefix := c.cfg.Installation.ImagePrefix
 	var err error
-	image := c.cfg.ImageOverrides.Resolve(render.ComponentNameKubeControllers, components.CombinedCalicoImage(c.cfg.Installation), c.cfg.Installation)
+	calico := c.cfg.ImageOverrides.Resolve(render.ComponentNameCalico, components.ComponentCalico, c.cfg.Installation)
+	image := c.cfg.ImageOverrides.Resolve(render.ComponentNameKubeControllers, calico, c.cfg.Installation)
 	c.calicoImage, err = components.GetReference(image, reg, path, prefix, is)
 	if err != nil {
 		return err

--- a/pkg/render/kubecontrollers/kube-controllers_test.go
+++ b/pkg/render/kubecontrollers/kube-controllers_test.go
@@ -17,6 +17,9 @@ package kubecontrollers_test
 import (
 	"fmt"
 
+	"github.com/tigera/operator/pkg/enterprise"
+	eoptions "github.com/tigera/operator/pkg/enterprise/options"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -298,6 +301,7 @@ var _ = Describe("kube-controllers rendering tests", func() {
 		// Override configuration to match expected Enterprise config.
 		instance.Variant = operatorv1.CalicoEnterprise
 		cfg.MetricsPort = 9094
+		cfg.ImageOverrides = enterprise.New(operatorv1.CalicoEnterprise, eoptions.Options{}).Images()
 
 		component := kubecontrollers.NewCalicoKubeControllers(&cfg)
 		Expect(component.ResolveImages(nil)).To(BeNil())

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -146,9 +146,6 @@ type NodeConfiguration struct {
 
 	V3CRDs bool
 
-	// ImageOverrides lets a variant swap the node and cni-plugins images. The
-	// controller wires in the operator's image overrides; nil resolves to the
-	// core images.
 	ImageOverrides *imageoverride.Overrides
 }
 
@@ -200,7 +197,7 @@ func (c *nodeComponent) ResolveImages(is *operatorv1.ImageSet) error {
 		return imageName
 	}
 
-	c.calicoImage = appendIfErr(components.GetReference(components.CombinedCalicoImage(c.cfg.Installation), reg, path, prefix, is))
+	c.calicoImage = appendIfErr(components.GetReference(c.cfg.ImageOverrides.Resolve(ComponentNameCalico, components.ComponentCalico, c.cfg.Installation), reg, path, prefix, is))
 	nodeImage := c.cfg.ImageOverrides.Resolve(ComponentNameNode, components.ComponentCalicoNode, c.cfg.Installation)
 	c.nodeImage = appendIfErr(components.GetReference(nodeImage, reg, path, prefix, is))
 	if c.installUpstreamPlugins() {

--- a/pkg/render/typha.go
+++ b/pkg/render/typha.go
@@ -32,6 +32,7 @@ import (
 	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/controller/k8sapi"
 	"github.com/tigera/operator/pkg/controller/migration"
+	"github.com/tigera/operator/pkg/imageoverride"
 	rcomp "github.com/tigera/operator/pkg/render/common/components"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	"github.com/tigera/operator/pkg/render/common/networkpolicy"
@@ -81,6 +82,8 @@ type TyphaConfiguration struct {
 	// FelixConfiguration is the cluster's default FelixConfiguration. Typha binds to the
 	// port one below Felix's health port.
 	FelixConfiguration *v3.FelixConfiguration
+
+	ImageOverrides *imageoverride.Overrides
 }
 
 // Typha creates the typha daemonset and other resources for the daemonset to operate normally.
@@ -101,7 +104,7 @@ func (c *typhaComponent) ResolveImages(is *operatorv1.ImageSet) error {
 	path := c.cfg.Installation.ImagePath
 	prefix := c.cfg.Installation.ImagePrefix
 	var err error
-	c.calicoImage, err = components.GetReference(components.CombinedCalicoImage(c.cfg.Installation), reg, path, prefix, is)
+	c.calicoImage, err = components.GetReference(c.cfg.ImageOverrides.Resolve(ComponentNameCalico, components.ComponentCalico, c.cfg.Installation), reg, path, prefix, is)
 	return err
 }
 

--- a/pkg/render/webhooks/render.go
+++ b/pkg/render/webhooks/render.go
@@ -23,6 +23,7 @@ import (
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
+	"github.com/tigera/operator/pkg/imageoverride"
 	"github.com/tigera/operator/pkg/render"
 	rcomp "github.com/tigera/operator/pkg/render/common/components"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
@@ -59,6 +60,8 @@ type Configuration struct {
 	Installation *operatorv1.InstallationSpec
 	APIServer    *operatorv1.APIServerSpec
 	OpenShift    bool
+
+	ImageOverrides *imageoverride.Overrides
 }
 
 // WebhooksComponent is the webhooks component paired with the configuration it rendered
@@ -90,7 +93,7 @@ func (c *component) ResolveImages(is *operatorv1.ImageSet) error {
 	prefix := c.cfg.Installation.ImagePrefix
 
 	var err error
-	c.calicoImage, err = components.GetReference(components.CombinedCalicoImage(c.cfg.Installation), reg, path, prefix, is)
+	c.calicoImage, err = components.GetReference(c.cfg.ImageOverrides.Resolve(render.ComponentNameCalico, components.ComponentCalico, c.cfg.Installation), reg, path, prefix, is)
 	return err
 }
 

--- a/pkg/render/webhooks/render_test.go
+++ b/pkg/render/webhooks/render_test.go
@@ -17,6 +17,9 @@ package webhooks_test
 import (
 	"fmt"
 
+	"github.com/tigera/operator/pkg/enterprise"
+	eoptions "github.com/tigera/operator/pkg/enterprise/options"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -135,6 +138,7 @@ var _ = Describe("Webhooks rendering tests", func() {
 
 	It("should render all resources for Enterprise with the correct image", func() {
 		installation.Variant = operatorv1.CalicoEnterprise
+		cfg.ImageOverrides = enterprise.New(operatorv1.CalicoEnterprise, eoptions.Options{}).Images()
 		component := webhooks.Component(cfg)
 		Expect(component.ResolveImages(nil)).NotTo(HaveOccurred())
 		resources, _ := component.Objects()

--- a/pkg/render/whisker/component.go
+++ b/pkg/render/whisker/component.go
@@ -31,6 +31,7 @@ import (
 	operatorv1 "github.com/tigera/operator/api/v1"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/components"
+	"github.com/tigera/operator/pkg/imageoverride"
 	"github.com/tigera/operator/pkg/render"
 	rcomp "github.com/tigera/operator/pkg/render/common/components"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
@@ -91,6 +92,8 @@ type Configuration struct {
 	CalicoVersion         string
 	ClusterType           string
 	ClusterDomain         string
+
+	ImageOverrides *imageoverride.Overrides
 }
 
 type Component struct {
@@ -111,7 +114,7 @@ func (c *Component) ResolveImages(is *operatorv1.ImageSet) error {
 	if err != nil {
 		return err
 	}
-	c.calicoImage, err = components.GetReference(components.CombinedCalicoImage(c.cfg.Installation), reg, path, prefix, is)
+	c.calicoImage, err = components.GetReference(c.cfg.ImageOverrides.Resolve(render.ComponentNameCalico, components.ComponentCalico, c.cfg.Installation), reg, path, prefix, is)
 	return err
 }
 

--- a/pkg/render/windows.go
+++ b/pkg/render/windows.go
@@ -67,9 +67,6 @@ type WindowsConfiguration struct {
 	TLS           *TyphaNodeTLS
 	VXLANVNI      int
 
-	// ImageOverrides lets a variant swap the windows node and CNI images. The
-	// controller wires in the operator's image overrides; nil resolves to the
-	// core images.
 	ImageOverrides *imageoverride.Overrides
 }
 

--- a/test/mainline_test.go
+++ b/test/mainline_test.go
@@ -47,6 +47,8 @@ import (
 	"github.com/tigera/operator/pkg/apis"
 	"github.com/tigera/operator/pkg/common"
 	"github.com/tigera/operator/pkg/controller/options"
+	"github.com/tigera/operator/pkg/enterprise"
+	eoptions "github.com/tigera/operator/pkg/enterprise/options"
 	"github.com/tigera/operator/pkg/imports/crds"
 	"github.com/tigera/operator/pkg/render"
 )
@@ -337,6 +339,7 @@ func setupManager(manageCRDs bool, multiTenant bool, variant operator.ProductVar
 	err := controller.AddToManager(mgr, options.ControllerOptions{
 		DetectedProvider: operator.ProviderNone,
 		Variant:          variant,
+		Extensions:       enterprise.New(variant, eoptions.Options{}),
 		ManageCRDs:       manageCRDs,
 		ShutdownContext:  ctx,
 		K8sClientset:     clientset,


### PR DESCRIPTION
## Description

The operator held four separate sets of variant image overrides, one per extension that happened to need them, each with its own accessor. That works only for components whose controller has an extension carrying a set, and the combined calico image is wanted by components across several that do not: clusterconnection, apiserver, whisker, goldmane.

Adding a fifth, sixth and seventh set is the wrong direction, and it has a quiet failure mode: miss one registration and an Enterprise install silently runs the Calico image for that component.

The variant cannot change without restarting the process, so the mapping from component name to image is a property of whole operator process:

- one set now, hanging off the extensions the operator was built with
- each Enterprise package registers into it rather than owning one
- controllers read it from their options
- four constructors and four interface methods become one

The second commit uses it. Enterprise registers a key for the combined image, and every component that runs one of its binaries resolves through the override set: typha, csi, guardian, apiserver, webhooks, whisker, goldmane, node, kube-controllers, es-kube-controllers.

The CSR init image is the one caller left that branches on the variant itself. The core certificate manager has no way to reach the override set and 27 call sites would have to opt in, so that one is its own change.

No behavior change: the same keys resolve to the same images. The Enterprise render tests and the mainline FVs now build the extensions they were skipping, since the variant field alone no longer selects an image.

Related: [CORE-13461](https://tigera.atlassian.net/browse/CORE-13461)

```release-note
None
```


[CORE-13461]: https://tigera.atlassian.net/browse/CORE-13461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
