### PR TITLE
Authorize fluentd-era managed-cluster log collectors on management clusters (EV-6989)

### DIFF
--- a/pkg/controller/logcollector/logcollector_controller.go
+++ b/pkg/controller/logcollector/logcollector_controller.go
@@ -676,6 +676,7 @@ func (r *ReconcileLogCollector) Reconcile(ctx context.Context, request reconcile
 		FluentBitKeyPair:              fluentBitKeyPair,
 		TrustedBundle:                 trustedBundle,
 		ManagedCluster:                managedCluster,
+		ManagementCluster:             managementCluster != nil,
 		UseSyslogCertificate:          useSyslogCertificate,
 		Tenant:                        tenant,
 		ExternalElastic:               r.opts.ElasticExternal,

--- a/pkg/render/logcollector/eks_log_forwarder.go
+++ b/pkg/render/logcollector/eks_log_forwarder.go
@@ -282,25 +282,26 @@ func (c *fluentBitComponent) eksLogForwarderClusterRoleBinding() *rbacv1.Cluster
 	}
 }
 
-func (c *fluentBitComponent) eksLogForwarderClusterRole() *rbacv1.ClusterRole {
-	rules := []rbacv1.PolicyRule{
+// eksLogForwarderLinseedRules grants the narrower Linseed access an EKS log
+// forwarder needs: it reads audit logs to find where it left off, and writes
+// only kube audit logs.
+func eksLogForwarderLinseedRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
 		{
-			// Add read access to Linseed APIs.
 			APIGroups: []string{"linseed.tigera.io"},
-			Resources: []string{
-				"auditlogs",
-			},
-			Verbs: []string{"get"},
+			Resources: []string{"auditlogs"},
+			Verbs:     []string{"get"},
 		},
 		{
-			// Add write access to Linseed APIs to flush eks kube audit logs.
 			APIGroups: []string{"linseed.tigera.io"},
-			Resources: []string{
-				"kube_auditlogs",
-			},
-			Verbs: []string{"create"},
+			Resources: []string{"kube_auditlogs"},
+			Verbs:     []string{"create"},
 		},
 	}
+}
+
+func (c *fluentBitComponent) eksLogForwarderClusterRole() *rbacv1.ClusterRole {
+	rules := eksLogForwarderLinseedRules()
 
 	return &rbacv1.ClusterRole{
 		TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},

--- a/pkg/render/logcollector/fluentbit_test.go
+++ b/pkg/render/logcollector/fluentbit_test.go
@@ -1529,6 +1529,50 @@ var _ = Describe("Tigera Secure Fluent Bit rendering tests", func() {
 			rtest.ExpectResources(deleteResources, legacyFluentdDeleteResources())
 		})
 
+		It("should render the legacy log collector RBAC on a management cluster", func() {
+			cfg.ManagementCluster = true
+
+			createResources, deleteResources := logcollector.FluentBitShared(cfg).Objects()
+			rtest.ExpectResources(createResources, []client.Object{
+				&v3.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: logcollector.FluentBitPolicyName, Namespace: render.LogCollectorNamespace}},
+				&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "tigera-linseed-legacy-log-collector"}},
+				&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "tigera-linseed-legacy-log-collector"}},
+				&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "tigera-linseed-legacy-eks-log-forwarder"}},
+				&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "tigera-linseed-legacy-eks-log-forwarder"}},
+			})
+
+			// The legacy fluentd cleanup still runs, but the RBAC that authorizes
+			// fluentd clients in managed clusters is not part of it.
+			for _, obj := range deleteResources {
+				Expect(obj.GetName()).NotTo(Equal("tigera-linseed-legacy-log-collector"))
+			}
+
+			// Linseed resolves a managed-cluster client to its service account, so
+			// the binding has to name the fluentd-era accounts.
+			crb := rtest.GetResource(createResources, "tigera-linseed-legacy-log-collector", "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding").(*rbacv1.ClusterRoleBinding)
+			Expect(crb.Subjects).To(ConsistOf(
+				rbacv1.Subject{Kind: "ServiceAccount", Name: "fluentd-node", Namespace: "tigera-fluentd"},
+				rbacv1.Subject{Kind: "ServiceAccount", Name: "fluentd-node-windows", Namespace: "tigera-fluentd"},
+			))
+
+			// The fluentd-era EKS forwarder had narrower access, so it keeps its own role.
+			eksCRB := rtest.GetResource(createResources, "tigera-linseed-legacy-eks-log-forwarder", "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding").(*rbacv1.ClusterRoleBinding)
+			Expect(eksCRB.Subjects).To(ConsistOf(
+				rbacv1.Subject{Kind: "ServiceAccount", Name: "eks-log-forwarder", Namespace: "tigera-fluentd"},
+			))
+			eksCR := rtest.GetResource(createResources, "tigera-linseed-legacy-eks-log-forwarder", "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
+			Expect(eksCR.Rules).To(Equal([]rbacv1.PolicyRule{
+				{APIGroups: []string{"linseed.tigera.io"}, Resources: []string{"auditlogs"}, Verbs: []string{"get"}},
+				{APIGroups: []string{"linseed.tigera.io"}, Resources: []string{"kube_auditlogs"}, Verbs: []string{"create"}},
+			}))
+
+			cr := rtest.GetResource(createResources, "tigera-linseed-legacy-log-collector", "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
+			Expect(cr.Rules).To(HaveLen(1))
+			Expect(cr.Rules[0].APIGroups).To(Equal([]string{"linseed.tigera.io"}))
+			Expect(cr.Rules[0].Verbs).To(Equal([]string{"create"}))
+			Expect(cr.Rules[0].Resources).To(ContainElement("flowlogs"))
+		})
+
 		It("should produce disjoint resources across the shared, Linux and Windows components", func() {
 			// The controller renders all three from one configuration. Turn on
 			// every gated feature so each component emits its full resource set,
@@ -1664,5 +1708,9 @@ func legacyFluentdDeleteResources() []client.Object {
 		&rbacv1.ClusterRoleBinding{TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}, ObjectMeta: metav1.ObjectMeta{Name: "tigera-fluentd"}},
 		&rbacv1.ClusterRoleBinding{TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}, ObjectMeta: metav1.ObjectMeta{Name: "tigera-fluentd-windows"}},
 		&corev1.Secret{TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: "tigera-fluentd-prometheus-tls", Namespace: common.OperatorNamespace()}},
+		&rbacv1.ClusterRole{TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"}, ObjectMeta: metav1.ObjectMeta{Name: "tigera-linseed-legacy-log-collector"}},
+		&rbacv1.ClusterRoleBinding{TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}, ObjectMeta: metav1.ObjectMeta{Name: "tigera-linseed-legacy-log-collector"}},
+		&rbacv1.ClusterRole{TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"}, ObjectMeta: metav1.ObjectMeta{Name: "tigera-linseed-legacy-eks-log-forwarder"}},
+		&rbacv1.ClusterRoleBinding{TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}, ObjectMeta: metav1.ObjectMeta{Name: "tigera-linseed-legacy-eks-log-forwarder"}},
 	}
 }

--- a/pkg/render/logcollector/logcollector.go
+++ b/pkg/render/logcollector/logcollector.go
@@ -86,7 +86,14 @@ const (
 	FluentBitConfConfigMapName       = "calico-fluent-bit-conf"
 	EKSLogForwarderConfConfigMapName = "eks-log-forwarder-conf"
 
-	legacyFluentdNamespace = "tigera-fluentd"
+	legacyFluentdNamespace       = "tigera-fluentd"
+	legacyFluentdNodeName        = "fluentd-node"
+	legacyFluentdNodeWindowsName = "fluentd-node-windows"
+
+	// legacyLogCollectorClientName and legacyEKSLogForwarderClientName name the RBAC
+	// that authorizes fluentd-era log collectors in managed clusters.
+	legacyLogCollectorClientName    = "tigera-linseed-legacy-log-collector"
+	legacyEKSLogForwarderClientName = "tigera-linseed-legacy-eks-log-forwarder"
 
 	fluentBitName        = "calico-fluent-bit"
 	fluentBitWindowsName = "calico-fluent-bit-windows"
@@ -155,6 +162,12 @@ type FluentBitConfiguration struct {
 	FluentBitKeyPair certificatemanagement.KeyPairInterface
 	TrustedBundle    certificatemanagement.TrustedBundle
 	ManagedCluster   bool
+
+	// ManagementCluster is true when this cluster manages others. Linseed authorizes a
+	// managed cluster's log writes with a SubjectAccessReview against this cluster, so a
+	// management cluster carries RBAC for its managed clusters' log collectors as well as
+	// its own.
+	ManagementCluster bool
 
 	// Set if running as a multi-tenant management cluster. Configures the management cluster's
 	// own fluent-bit daemonset.
@@ -309,6 +322,21 @@ func (s *fluentBitSharedComponent) Objects() ([]client.Object, []client.Object) 
 	} else {
 		toDelete = append(toDelete, c.externalLinseedService())
 		toDelete = append(toDelete, c.externalLinseedRoleBinding())
+	}
+
+	// Managed clusters that have not upgraded past fluentd still write logs as their
+	// fluentd service accounts, and Linseed authorizes them here. Standalone and managed
+	// clusters have no managed clusters of their own, so they drop the RBAC.
+	legacyClientRBAC := []client.Object{
+		c.legacyLogCollectorClientClusterRole(),
+		c.legacyLogCollectorClientClusterRoleBinding(),
+		c.legacyEKSLogForwarderClientClusterRole(),
+		c.legacyEKSLogForwarderClientClusterRoleBinding(),
+	}
+	if c.cfg.ManagementCluster {
+		objs = append(objs, legacyClientRBAC...)
+	} else {
+		toDelete = append(toDelete, legacyClientRBAC...)
 	}
 
 	// Clean up the legacy fluentd installation on upgrade. Deleting the

--- a/pkg/render/logcollector/rbac.go
+++ b/pkg/render/logcollector/rbac.go
@@ -56,25 +56,7 @@ func (c *fluentBitComponent) fluentBitClusterRole() *rbacv1.ClusterRole {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: c.fluentBitName(),
 		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				// Add write access to Linseed APIs.
-				APIGroups: []string{"linseed.tigera.io"},
-				Resources: []string{
-					"flowlogs",
-					"kube_auditlogs",
-					"ee_auditlogs",
-					"dnslogs",
-					"l7logs",
-					"events",
-					"bgplogs",
-					"waflogs",
-					"runtimereports",
-					"policyactivity",
-				},
-				Verbs: []string{"create"},
-			},
-		},
+		Rules: []rbacv1.PolicyRule{linseedWriteRule()},
 	}
 
 	if c.cfg.Installation.KubernetesProvider.IsOpenShift() {
@@ -86,4 +68,81 @@ func (c *fluentBitComponent) fluentBitClusterRole() *rbacv1.ClusterRole {
 		})
 	}
 	return role
+}
+
+// linseedWriteRule grants create on every Linseed log API a log collector ships to.
+func linseedWriteRule() rbacv1.PolicyRule {
+	return rbacv1.PolicyRule{
+		APIGroups: []string{"linseed.tigera.io"},
+		Resources: []string{
+			"flowlogs",
+			"kube_auditlogs",
+			"ee_auditlogs",
+			"dnslogs",
+			"l7logs",
+			"events",
+			"bgplogs",
+			"waflogs",
+			"runtimereports",
+			"policyactivity",
+		},
+		Verbs: []string{"create"},
+	}
+}
+
+// legacyLogCollectorClientClusterRole grants the Linseed write access needed by a fluentd
+// log collector.
+func (c *fluentBitComponent) legacyLogCollectorClientClusterRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: legacyLogCollectorClientName},
+		Rules:      []rbacv1.PolicyRule{linseedWriteRule()},
+	}
+}
+
+// legacyLogCollectorClientClusterRoleBinding binds the fluentd service accounts of managed
+// clusters. Linseed resolves a managed-cluster client to
+// system:serviceaccount:<namespace>:<name> and runs the SubjectAccessReview against this
+// cluster, so these names need a local binding even though nothing by those names runs
+// here. A managed cluster's token carries its own cluster ID, so the binding cannot widen
+// what any one cluster may write.
+func (c *fluentBitComponent) legacyLogCollectorClientClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+	return legacyClientClusterRoleBinding(legacyLogCollectorClientName, legacyFluentdNodeName, legacyFluentdNodeWindowsName)
+}
+
+// legacyEKSLogForwarderClientClusterRole and ...Binding do the same for a
+// fluentd-era EKS log forwarder, which had narrower access than the node
+// collectors.
+func (c *fluentBitComponent) legacyEKSLogForwarderClientClusterRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: legacyEKSLogForwarderClientName},
+		Rules:      eksLogForwarderLinseedRules(),
+	}
+}
+
+func (c *fluentBitComponent) legacyEKSLogForwarderClientClusterRoleBinding() *rbacv1.ClusterRoleBinding {
+	return legacyClientClusterRoleBinding(legacyEKSLogForwarderClientName, EKSLogForwarderName)
+}
+
+func legacyClientClusterRoleBinding(name string, serviceAccounts ...string) *rbacv1.ClusterRoleBinding {
+	subjects := make([]rbacv1.Subject, 0, len(serviceAccounts))
+	for _, sa := range serviceAccounts {
+		subjects = append(subjects, rbacv1.Subject{
+			Kind:      "ServiceAccount",
+			Name:      sa,
+			Namespace: legacyFluentdNamespace,
+		})
+	}
+
+	return &rbacv1.ClusterRoleBinding{
+		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     name,
+		},
+		Subjects: subjects,
+	}
 }


### PR DESCRIPTION
## Description

Bug fix for EV-6989 (operator half; pairs with the tigera/calico-private linseed PR).

Linseed authorizes a managed cluster's log writes with a SubjectAccessReview against the management cluster, so the management cluster needs RBAC naming the managed cluster's log collector service accounts. Before the fluent-bit migration this worked by coincidence: the management cluster ran fluentd itself, so its `tigera-fluentd` ClusterRoleBinding covered managed clusters too. The migration's legacy cleanup deletes exactly that binding, so a v3.24.0-or-earlier managed cluster gets its linseed token but every log write is denied (`User not authorized ... user="system:serviceaccount:tigera-fluentd:fluentd-node"`).

This PR renders dedicated legacy-client RBAC on management clusters instead of reviving the deleted objects, so the cleanup and the compatibility RBAC cannot fight over one object:

- `tigera-linseed-legacy-log-collector` binds `fluentd-node` / `fluentd-node-windows` with the same Linseed write rule fluent-bit uses (now shared via `linseedWriteRule()`).
- `tigera-linseed-legacy-eks-log-forwarder` binds `eks-log-forwarder` with the narrower rules the EKS forwarder has always had (shared via `eksLogForwarderLinseedRules()`).

Both render only when a ManagementCluster CR exists and are cleaned up everywhere else. The grants were checked against a live v3.23.1 cluster's `ClusterRole/tigera-fluentd` and match exactly.

Testing:
- Unit tests: new spec asserting the RBAC on management clusters (subjects, rules, and exclusion from the legacy cleanup); 40/40 render + 27/27 controller specs pass.
- Live MCM validation on gcp-kubeadm: management cluster on master + this change, one v3.23.1 managed cluster (fluentd) and one master managed cluster (fluent-bit). Reproduced the EV-6989 failure on stock images, then confirmed with the fix: operator creates the RBAC, zero linseed authorization denials, both clusters' logs land in the management cluster's Elasticsearch, fluent-bit cluster unaffected.

Affected components: LogCollector controller / render (management clusters only).

Fixes https://tigera.atlassian.net/browse/EV-6989

## Release Note

```release-note
NONE
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
