### PR TITLE
Write the chosen IP pools to the Installation spec

### DIFF
--- a/api/v1/installation_types.go
+++ b/api/v1/installation_types.go
@@ -695,10 +695,9 @@ type CalicoNetworkSpec struct {
 	// +optional
 	ClusterRoutingMode *ClusterRoutingMode `json:"clusterRoutingMode,omitempty"`
 
-	// IPPools contains a list of IP pools to manage. If nil, the operator chooses: on a cluster with no
-	// operator-managed pools it creates a single IPv4 pool, and on a cluster that already has them it keeps
-	// the pools in use. Provide an empty list to manage IP pools out-of-band; the operator then deletes the
-	// pools it owns and creates none.
+	// IPPools contains a list of IP pools to manage. If nil, the operator fills this field in: a single IPv4
+	// pool on a cluster with no IP pools, or an empty list on a cluster that already has them, which leaves
+	// those pools to whoever created them.
 	// IP pools in this list will be reconciled by the operator and should not be modified out-of-band.
 	// +optional
 	// +kubebuilder:validation:MaxItems=25

--- a/api/v1/installation_types.go
+++ b/api/v1/installation_types.go
@@ -695,10 +695,9 @@ type CalicoNetworkSpec struct {
 	// +optional
 	ClusterRoutingMode *ClusterRoutingMode `json:"clusterRoutingMode,omitempty"`
 
-	// IPPools contains a list of IP pools to manage. If left unset, the operator fills it in with the pools
-	// it already owns, or with the platform's pod CIDRs or a built-in default on a cluster that has none. A
-	// cluster with pools the operator does not own gets an empty list. Provide an empty list to manage IP
-	// pools out-of-band; the operator then deletes the pools it owns and creates none.
+	// IPPools contains a list of IP pools to manage. If unset, the operator fills it in with defaults based
+	// on cluster state. Provide an empty list to manage IP pools out-of-band; the operator then deletes the
+	// pools it owns and creates none.
 	// IP pools in this list will be reconciled by the operator and should not be modified out-of-band.
 	// +optional
 	// +kubebuilder:validation:MaxItems=25
@@ -888,7 +887,6 @@ type IPPool struct {
 	Name string `json:"name,omitempty"`
 
 	// CIDR contains the address range for the IP Pool in classless inter-domain routing format.
-	// MaxLength keeps the rule below inside the CEL cost budget.
 	// +kubebuilder:validation:MaxLength=43
 	// +kubebuilder:validation:XValidation:rule="isCIDR(self) && string(cidr(self).masked()) == self",message="cidr must be in canonical form, for example 192.168.0.0/16 or fd00:10:244::/64"
 	CIDR string `json:"cidr"`

--- a/api/v1/installation_types.go
+++ b/api/v1/installation_types.go
@@ -888,6 +888,9 @@ type IPPool struct {
 	Name string `json:"name,omitempty"`
 
 	// CIDR contains the address range for the IP Pool in classless inter-domain routing format.
+	// MaxLength keeps the rule below inside the CEL cost budget.
+	// +kubebuilder:validation:MaxLength=43
+	// +kubebuilder:validation:XValidation:rule="isCIDR(self) && string(cidr(self).masked()) == self",message="cidr must be in canonical form, for example 192.168.0.0/16 or fd00:10:244::/64"
 	CIDR string `json:"cidr"`
 
 	// Encapsulation specifies the encapsulation type that will be used with

--- a/api/v1/installation_types.go
+++ b/api/v1/installation_types.go
@@ -701,6 +701,8 @@ type CalicoNetworkSpec struct {
 	// IP pools in this list will be reconciled by the operator and should not be modified out-of-band.
 	// +optional
 	// +kubebuilder:validation:MaxItems=25
+	// +listType=map
+	// +listMapKey=cidr
 	IPPools []IPPool `json:"ipPools"`
 
 	// MTU specifies the maximum transmission unit to use on the pod network.

--- a/api/v1/installation_types.go
+++ b/api/v1/installation_types.go
@@ -695,9 +695,10 @@ type CalicoNetworkSpec struct {
 	// +optional
 	ClusterRoutingMode *ClusterRoutingMode `json:"clusterRoutingMode,omitempty"`
 
-	// IPPools contains a list of IP pools to manage. If nil, the operator fills this field in: a single IPv4
-	// pool on a cluster with no IP pools, or an empty list on a cluster that already has them, which leaves
-	// those pools to whoever created them.
+	// IPPools contains a list of IP pools to manage. If left unset, the operator fills it in with the pools
+	// it already owns, or with the platform's pod CIDRs or a built-in default on a cluster that has none. A
+	// cluster with pools the operator does not own gets an empty list. Provide an empty list to manage IP
+	// pools out-of-band; the operator then deletes the pools it owns and creates none.
 	// IP pools in this list will be reconciled by the operator and should not be modified out-of-band.
 	// +optional
 	// +kubebuilder:validation:MaxItems=25

--- a/pkg/controller/installation/cel_validation_test.go
+++ b/pkg/controller/installation/cel_validation_test.go
@@ -142,4 +142,48 @@ var _ = Describe("Installation CRD CEL validation", Serial, func() {
 			Expect(err.Error()).To(ContainSubstring("no more than one autodetection method"))
 		})
 	})
+	Describe("IP pool CIDR", func() {
+		newPoolInstallation := func(cidr string) *operator.Installation {
+			return &operator.Installation{
+				ObjectMeta: metav1.ObjectMeta{Name: "default"},
+				Spec: operator.InstallationSpec{
+					CalicoNetwork: &operator.CalicoNetworkSpec{
+						IPPools: []operator.IPPool{{CIDR: cidr}},
+					},
+				},
+			}
+		}
+
+		AfterEach(func() {
+			inst := &operator.Installation{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+			err := c.Delete(ctx, inst)
+			if err != nil {
+				GinkgoLogr.Error(err, "Failed to delete Installation in AfterEach")
+			}
+		})
+
+		DescribeTable("should allow a canonical CIDR",
+			func(cidr string) {
+				Expect(c.Create(ctx, newPoolInstallation(cidr))).To(Succeed())
+			},
+			Entry("IPv4", "192.168.0.0/16"),
+			Entry("IPv4 single address", "10.65.0.1/32"),
+			Entry("IPv6", "fd00:10:244::/64"),
+			Entry("IPv6 with a compressed run", "fd20:5213:94f6:1e9:1f::/96"),
+		)
+
+		DescribeTable("should reject a CIDR that isn't canonical",
+			func(cidr string) {
+				err := c.Create(ctx, newPoolInstallation(cidr))
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("cidr must be in canonical form"))
+			},
+			// Two spellings of one pool would otherwise claim separate entries in the list, which
+			// is keyed on the CIDR.
+			Entry("host bits set", "192.168.0.1/16"),
+			Entry("IPv6 with leading zeros", "fd20:5213:94f6:01e9:001f::/96"),
+			Entry("not a CIDR at all", "192.168.0.0"),
+			Entry("empty", ""),
+		)
+	})
 })

--- a/pkg/controller/installation/validation.go
+++ b/pkg/controller/installation/validation.go
@@ -411,9 +411,13 @@ func validateCustomResource(instance *operatorv1.Installation) error {
 				return fmt.Errorf("installation spec.ServiceCIDRs must be provided when using Calico CNI on Windows")
 			}
 			if instance.Spec.CalicoNetwork != nil {
-				if v4pool := render.GetIPv4Pool(instance.Spec.CalicoNetwork.IPPools); v4pool != nil {
-					if v4pool.Encapsulation != operatorv1.EncapsulationVXLAN && v4pool.Encapsulation != operatorv1.EncapsulationNone {
-						return fmt.Errorf("IPv4 IPPool encapsulation %s is not supported by Calico for Windows", v4pool.Encapsulation)
+				for _, pool := range instance.Spec.CalicoNetwork.IPPools {
+					if !render.IsIPv4Pool(pool) {
+						continue
+					}
+
+					if pool.Encapsulation != operatorv1.EncapsulationVXLAN && pool.Encapsulation != operatorv1.EncapsulationNone {
+						return fmt.Errorf("IPv4 IPPool encapsulation %s is not supported by Calico for Windows", pool.Encapsulation)
 					}
 				}
 			}

--- a/pkg/controller/ippool/defaults.go
+++ b/pkg/controller/ippool/defaults.go
@@ -66,6 +66,19 @@ func cidrToName(cidr string) (string, error) {
 	return name, nil
 }
 
+// hasUnownedPools reports whether the cluster has any IP pool the operator did not create.
+func hasUnownedPools(pools *v3.IPPoolList) bool {
+	if pools == nil {
+		return false
+	}
+	for i := range pools.Items {
+		if !hasOwnerLabel(&pools.Items[i]) {
+			return true
+		}
+	}
+	return false
+}
+
 // fillDefaults fills in IP pool defaults on the Installation object. Defaulting of fields other than IP pools occurs
 // in pkg/controller/installation/
 func fillDefaults(ctx context.Context, client client.Client, spec *operator.InstallationSpec, currentPools *v3.IPPoolList) error {
@@ -75,9 +88,8 @@ func fillDefaults(ctx context.Context, client client.Client, spec *operator.Inst
 		return fmt.Errorf("cannot perform IP pool defaulting until CNI configuration is available")
 	}
 
-	// Only add default CIDRs if there are no existing pools in the cluster. If there are existing pools in the cluster,
-	// then we assume that the user has configured them correctly out-of-band and we should not install any others.
-	if currentPools == nil || len(currentPools.Items) == 0 {
+	// A pool the operator created is its own earlier default, not a sign that pools are managed out-of-band.
+	if !hasUnownedPools(currentPools) {
 		if spec.KubernetesProvider.IsOpenShift() {
 			// If configured to run in openshift, then also fetch the openshift configuration API.
 			log.V(1).Info("Fetching OpenShift network configuration")

--- a/pkg/controller/ippool/defaults.go
+++ b/pkg/controller/ippool/defaults.go
@@ -66,19 +66,6 @@ func cidrToName(cidr string) (string, error) {
 	return name, nil
 }
 
-// hasUnownedPools reports whether the cluster has any IP pool the operator did not create.
-func hasUnownedPools(pools *v3.IPPoolList) bool {
-	if pools == nil {
-		return false
-	}
-	for i := range pools.Items {
-		if !hasOwnerLabel(&pools.Items[i]) {
-			return true
-		}
-	}
-	return false
-}
-
 // fillDefaults fills in IP pool defaults on the Installation object. Defaulting of fields other than IP pools occurs
 // in pkg/controller/installation/
 func fillDefaults(ctx context.Context, client client.Client, spec *operator.InstallationSpec, currentPools *v3.IPPoolList) error {
@@ -88,8 +75,9 @@ func fillDefaults(ctx context.Context, client client.Client, spec *operator.Inst
 		return fmt.Errorf("cannot perform IP pool defaulting until CNI configuration is available")
 	}
 
-	// A pool the operator created is its own earlier default, not a sign that pools are managed out-of-band.
-	if !hasUnownedPools(currentPools) {
+	// Only add default CIDRs if there are no existing pools in the cluster. If there are existing pools in the cluster,
+	// then we assume that the user has configured them correctly out-of-band and we should not install any others.
+	if currentPools == nil || len(currentPools.Items) == 0 {
 		if spec.KubernetesProvider.IsOpenShift() {
 			// If configured to run in openshift, then also fetch the openshift configuration API.
 			log.V(1).Info("Fetching OpenShift network configuration")

--- a/pkg/controller/ippool/defaults.go
+++ b/pkg/controller/ippool/defaults.go
@@ -75,8 +75,8 @@ func fillDefaults(ctx context.Context, client client.Client, spec *operator.Inst
 		return fmt.Errorf("cannot perform IP pool defaulting until CNI configuration is available")
 	}
 
-	// Platform CIDRs and the built-in default only apply to a cluster with no IP pools at all. On any other
-	// cluster the caller has already decided which pools to manage.
+	// Only add default CIDRs if there are no existing pools in the cluster. On a cluster that already has
+	// pools, the caller has decided which ones to manage.
 	if currentPools == nil || len(currentPools.Items) == 0 {
 		if spec.KubernetesProvider.IsOpenShift() {
 			// If configured to run in openshift, then also fetch the openshift configuration API.

--- a/pkg/controller/ippool/defaults.go
+++ b/pkg/controller/ippool/defaults.go
@@ -75,8 +75,8 @@ func fillDefaults(ctx context.Context, client client.Client, spec *operator.Inst
 		return fmt.Errorf("cannot perform IP pool defaulting until CNI configuration is available")
 	}
 
-	// Only add default CIDRs if there are no existing pools in the cluster. If there are existing pools in the cluster,
-	// then we assume that the user has configured them correctly out-of-band and we should not install any others.
+	// Platform CIDRs and the built-in default only apply to a cluster with no IP pools at all. On any other
+	// cluster the caller has already decided which pools to manage.
 	if currentPools == nil || len(currentPools.Items) == 0 {
 		if spec.KubernetesProvider.IsOpenShift() {
 			// If configured to run in openshift, then also fetch the openshift configuration API.
@@ -136,14 +136,6 @@ func fillDefaults(ctx context.Context, client client.Client, spec *operator.Inst
 				}
 			}
 		}
-	} else if spec.CalicoNetwork == nil || spec.CalicoNetwork.IPPools == nil {
-		// There are existing IP pools in the cluster, and the installation hasn't specified any. This means IP pools are
-		// being managed out-of-band of the operator API. So, default the installation field to an empty list,
-		// which means "Don't install any IP pools".
-		if spec.CalicoNetwork == nil {
-			spec.CalicoNetwork = &operator.CalicoNetworkSpec{}
-		}
-		spec.CalicoNetwork.IPPools = []operator.IPPool{}
 	}
 
 	// If there are no CalicoNetwork settings, return early. The code after this point

--- a/pkg/controller/ippool/pool_controller.go
+++ b/pkg/controller/ippool/pool_controller.go
@@ -148,8 +148,28 @@ func hasOwnerLabel(pool *v3.IPPool) bool {
 	return false
 }
 
-// writePoolMembership applies the pools this controller chose to the Installation spec, which is the
-// one default this controller does not send to the status.
+// ownedPoolMembership returns the pool list to use when nobody declared one. A pool the operator
+// does not own means IP pools are managed out-of-band; nil means the cluster has no pools at all.
+func ownedPoolMembership(currentPools *v3.IPPoolList) []operatorv1.IPPool {
+	if currentPools == nil || len(currentPools.Items) == 0 {
+		return nil
+	}
+
+	owned := []operatorv1.IPPool{}
+	for i := range currentPools.Items {
+		if !hasOwnerLabel(&currentPools.Items[i]) {
+			return []operatorv1.IPPool{}
+		}
+
+		pool := operatorv1.IPPool{}
+		FromProjectCalico(&pool, currentPools.Items[i])
+		owned = append(owned, pool)
+	}
+	return owned
+}
+
+// writePoolMembership applies the pools this controller chose to the Installation spec, the one
+// default that does not go to the status.
 func (r *Reconciler) writePoolMembership(ctx context.Context, installation *operatorv1.Installation, pools []operatorv1.IPPool) error {
 	content, err := poolListContent(pools)
 	if err != nil {
@@ -169,21 +189,25 @@ func (r *Reconciler) writePoolMembership(ctx context.Context, installation *oper
 			},
 		},
 	}}
-	if err := r.client.Apply(ctx, client.ApplyConfigurationFromUnstructured(desired), client.FieldOwner(poolFieldManager)); err != nil {
+	// Take the field from whoever holds it. Anyone editing the Installation with kubectl claims the
+	// pool list, and this only runs when nobody has declared pools, so there is no intent to overwrite.
+	opts := []client.ApplyOption{client.FieldOwner(poolFieldManager), client.ForceOwnership}
+	if err := r.client.Apply(ctx, client.ApplyConfigurationFromUnstructured(desired), opts...); err != nil {
 		return err
 	}
 
-	// Carry the applied state forward, so the status write that follows doesn't conflict on resourceVersion.
-	installation.SetResourceVersion(desired.GetResourceVersion())
-	if installation.Spec.CalicoNetwork == nil {
-		installation.Spec.CalicoNetwork = &operatorv1.CalicoNetworkSpec{}
+	// Adopt the merged object from the apply response, since the copy we read may be older than what
+	// the server now holds.
+	applied := &operatorv1.Installation{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(desired.Object, applied); err != nil {
+		return fmt.Errorf("decode applied Installation: %w", err)
 	}
-	installation.Spec.CalicoNetwork.IPPools = pools
+	*installation = *applied
 	return nil
 }
 
-// poolListContent renders the IP pool list for an apply request, which must carry only the fields this
-// controller means to own.
+// poolListContent renders the fully defaulted IP pool list as the content of an apply request, which
+// claims ownership of every field it sets.
 func poolListContent(pools []operatorv1.IPPool) ([]any, error) {
 	raw, err := json.Marshal(pools)
 	if err != nil {
@@ -269,15 +293,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		declared = utils.OverrideInstallationSpec(declared, *overlay)
 	}
 
-	poolsDeclared := declared.CalicoNetwork != nil && declared.CalicoNetwork.IPPools != nil
-	if poolsDeclared {
-		// Pool membership comes from the spec, since the computed config lags a write-back by a reconcile.
-		if computed.CalicoNetwork == nil {
-			computed.CalicoNetwork = &operatorv1.CalicoNetworkSpec{}
-		}
-		computed.CalicoNetwork.IPPools = declared.CalicoNetwork.DeepCopy().IPPools
-	}
-
 	if computed.CNI == nil || computed.CNI.Type == "" {
 		r.status.SetDegraded(operatorv1.ResourceNotReady, "Waiting for CNI type to be configured on Installation", nil, reqLogger)
 		return reconcile.Result{}, nil
@@ -296,6 +311,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		}
 	}
 
+	// Decide which pools to manage before defaulting, and decide it from the cluster rather than the
+	// computed config, which lags this controller's own write by a reconcile.
+	poolsDeclared := declared.CalicoNetwork != nil && declared.CalicoNetwork.IPPools != nil
+	if computed.CalicoNetwork == nil {
+		computed.CalicoNetwork = &operatorv1.CalicoNetworkSpec{}
+	}
+	if poolsDeclared {
+		computed.CalicoNetwork.IPPools = declared.CalicoNetwork.DeepCopy().IPPools
+	} else {
+		computed.CalicoNetwork.IPPools = ownedPoolMembership(currentPools)
+	}
+
 	if err = fillDefaults(ctx, r.client, computed, currentPools); err != nil {
 		r.status.SetDegraded(operatorv1.ResourceReadError, "error filling IP pool defaults", err, reqLogger)
 		return reconcile.Result{}, err
@@ -305,8 +332,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 
-	if !poolsDeclared && computed.CalicoNetwork != nil && computed.CalicoNetwork.IPPools != nil {
-		// Nobody declared pools, so the chosen list goes on the spec, where whoever edits it next can see it.
+	if !poolsDeclared && computed.CalicoNetwork.IPPools != nil {
+		// Nobody declared pools, so the chosen list goes back on the spec, where whoever edits it next can see it.
 		if err := r.writePoolMembership(ctx, installation, computed.CalicoNetwork.DeepCopy().IPPools); err != nil {
 			r.status.SetDegraded(operatorv1.ResourceUpdateError, "Failed to write IP pools to the Installation", err, reqLogger)
 			return reconcile.Result{}, err

--- a/pkg/controller/ippool/pool_controller.go
+++ b/pkg/controller/ippool/pool_controller.go
@@ -333,7 +333,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	if !poolsDeclared && computed.CalicoNetwork.IPPools != nil {
-		// Nobody declared pools, so the chosen list goes back on the spec, where whoever edits it next can see it.
+		// The spec didn't declare any pools, so the chosen list goes back on the spec, where whoever edits it next can see it.
 		if err := r.writePoolMembership(ctx, installation, computed.CalicoNetwork.DeepCopy().IPPools); err != nil {
 			r.status.SetDegraded(operatorv1.ResourceUpdateError, "Failed to write IP pools to the Installation", err, reqLogger)
 			return reconcile.Result{}, err

--- a/pkg/controller/ippool/pool_controller.go
+++ b/pkg/controller/ippool/pool_controller.go
@@ -143,7 +143,17 @@ func hasOwnerLabel(pool *v3.IPPool) bool {
 	return false
 }
 
-// recordDefaults adds the pool defaults to the Installation status, leaving the spec untouched.
+// writePoolMembership writes the pools this controller chose into the Installation spec, which is the
+// one default this controller does not send to the status.
+func (r *Reconciler) writePoolMembership(ctx context.Context, installation *operatorv1.Installation, pools []operatorv1.IPPool) error {
+	if installation.Spec.CalicoNetwork == nil {
+		installation.Spec.CalicoNetwork = &operatorv1.CalicoNetworkSpec{}
+	}
+	installation.Spec.CalicoNetwork.IPPools = pools
+	return r.client.Update(ctx, installation)
+}
+
+// recordDefaults adds per-pool field defaults to the Installation status, leaving the spec untouched.
 func (r *Reconciler) recordDefaults(ctx context.Context, installation *operatorv1.Installation, declared, computed operatorv1.InstallationSpec) error {
 	recorded, err := utils.MergeRecordedDefaults(installation.Status.Defaults, declared, computed,
 		utils.DefaultsScope{Owned: []string{utils.PoolDefaultsPath}})
@@ -216,6 +226,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		declared = utils.OverrideInstallationSpec(declared, *overlay)
 	}
 
+	poolsDeclared := declared.CalicoNetwork != nil && declared.CalicoNetwork.IPPools != nil
+	if poolsDeclared {
+		// Pool membership comes from the spec, since the computed config lags a write-back by a reconcile.
+		if computed.CalicoNetwork == nil {
+			computed.CalicoNetwork = &operatorv1.CalicoNetworkSpec{}
+		}
+		computed.CalicoNetwork.IPPools = declared.CalicoNetwork.DeepCopy().IPPools
+	}
+
 	if computed.CNI == nil || computed.CNI.Type == "" {
 		r.status.SetDegraded(operatorv1.ResourceNotReady, "Waiting for CNI type to be configured on Installation", nil, reqLogger)
 		return reconcile.Result{}, nil
@@ -242,6 +261,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		r.status.SetDegraded(operatorv1.InvalidConfigurationError, "error validating IP pool configuration", err, reqLogger)
 		return reconcile.Result{}, err
 	}
+
+	if !poolsDeclared && computed.CalicoNetwork != nil && computed.CalicoNetwork.IPPools != nil {
+		// Nobody declared pools, so the chosen list goes on the spec, where whoever edits it next can see it.
+		if err := r.writePoolMembership(ctx, installation, computed.CalicoNetwork.DeepCopy().IPPools); err != nil {
+			r.status.SetDegraded(operatorv1.ResourceUpdateError, "Failed to write IP pools to the Installation", err, reqLogger)
+			return reconcile.Result{}, err
+		}
+		if declared.CalicoNetwork == nil {
+			declared.CalicoNetwork = &operatorv1.CalicoNetworkSpec{}
+		}
+		declared.CalicoNetwork.IPPools = installation.Spec.CalicoNetwork.DeepCopy().IPPools
+	}
+
 	if err := r.recordDefaults(ctx, installation, declared, *computed); err != nil {
 		r.status.SetDegraded(operatorv1.ResourceUpdateError, "Failed to write defaults", err, reqLogger)
 		return reconcile.Result{}, err

--- a/pkg/controller/ippool/pool_controller.go
+++ b/pkg/controller/ippool/pool_controller.go
@@ -33,6 +33,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
@@ -133,6 +134,10 @@ const (
 	// with this label key/value pair is assumed to be solely managed and reconciled by this controller.
 	managedByLabel = "app.kubernetes.io/managed-by"
 	managedByValue = "tigera-operator"
+
+	// poolFieldManager owns the IP pool list this controller applies, leaving every other manager of the
+	// Installation the pools it declared.
+	poolFieldManager = "tigera-operator-ippools"
 )
 
 // hasOwnerLabel returns true if the given IP pool is owned by the tigera/operator, and false otheriwse.
@@ -143,14 +148,52 @@ func hasOwnerLabel(pool *v3.IPPool) bool {
 	return false
 }
 
-// writePoolMembership writes the pools this controller chose into the Installation spec, which is the
+// writePoolMembership applies the pools this controller chose to the Installation spec, which is the
 // one default this controller does not send to the status.
 func (r *Reconciler) writePoolMembership(ctx context.Context, installation *operatorv1.Installation, pools []operatorv1.IPPool) error {
+	content, err := poolListContent(pools)
+	if err != nil {
+		return err
+	}
+
+	// Apply just the pool list, so this field manager owns those pools and nothing else on the Installation.
+	desired := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": operatorv1.GroupVersion.String(),
+		"kind":       "Installation",
+		"metadata": map[string]any{
+			"name": installation.Name,
+		},
+		"spec": map[string]any{
+			"calicoNetwork": map[string]any{
+				"ipPools": content,
+			},
+		},
+	}}
+	if err := r.client.Apply(ctx, client.ApplyConfigurationFromUnstructured(desired), client.FieldOwner(poolFieldManager)); err != nil {
+		return err
+	}
+
+	// Carry the applied state forward, so the status write that follows doesn't conflict on resourceVersion.
+	installation.SetResourceVersion(desired.GetResourceVersion())
 	if installation.Spec.CalicoNetwork == nil {
 		installation.Spec.CalicoNetwork = &operatorv1.CalicoNetworkSpec{}
 	}
 	installation.Spec.CalicoNetwork.IPPools = pools
-	return r.client.Update(ctx, installation)
+	return nil
+}
+
+// poolListContent renders the IP pool list for an apply request, which must carry only the fields this
+// controller means to own.
+func poolListContent(pools []operatorv1.IPPool) ([]any, error) {
+	raw, err := json.Marshal(pools)
+	if err != nil {
+		return nil, fmt.Errorf("marshal IP pools: %w", err)
+	}
+	content := []any{}
+	if err := json.Unmarshal(raw, &content); err != nil {
+		return nil, fmt.Errorf("unmarshal IP pools: %w", err)
+	}
+	return content, nil
 }
 
 // recordDefaults adds per-pool field defaults to the Installation status, leaving the spec untouched.

--- a/pkg/controller/ippool/pool_controller_test.go
+++ b/pkg/controller/ippool/pool_controller_test.go
@@ -64,7 +64,7 @@ var _ = Describe("IP Pool controller tests", func() {
 		Expect(storagev1.SchemeBuilder.AddToScheme(scheme)).NotTo(HaveOccurred())
 
 		// Create a client that will have a crud interface of k8s objects.
-		c = ctrlrfake.DefaultFakeClientBuilder(scheme).Build()
+		c = ctrlrfake.DefaultFakeClientBuilder(scheme).WithReturnManagedFields().Build()
 		ctx, cancel = context.WithCancel(context.Background())
 
 		// Create an object we can use throughout the test to do the compliance reconcile loops.
@@ -156,6 +156,50 @@ var _ = Describe("IP Pool controller tests", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(ipPools.Items).To(HaveLen(1))
 		Expect(ipPools.Items[0].Spec.CIDR).To(Equal(pool.CIDR))
+	})
+
+	It("should apply its IP pool defaults under its own field manager", func() {
+		instance := &operator.Installation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "default",
+				Finalizers: []string{"tigera.io/operator-cleanup"},
+			},
+			Spec: operator.InstallationSpec{
+				Variant:  operator.Calico,
+				Registry: "some.registry.org/",
+				CNI: &operator.CNISpec{
+					Type: operator.PluginCalico,
+					IPAM: &operator.IPAMSpec{Type: operator.IPAMPluginCalico},
+				},
+			},
+		}
+		createInstallation(ctx, c, instance)
+
+		mockStatus.On("OnCRFound")
+		mockStatus.On("SetMetaData", mock.Anything)
+		mockStatus.On("IsAvailable").Return(true)
+		mockStatus.On("ReadyToMonitor")
+		mockStatus.On("ClearDegraded")
+
+		_, err := r.Reconcile(ctx, reconcile.Request{})
+		Expect(err).ShouldNot(HaveOccurred())
+		mockStatus.AssertExpectations(GinkgoT())
+
+		installation := &operator.Installation{}
+		Expect(c.Get(ctx, utils.DefaultInstanceKey, installation)).ShouldNot(HaveOccurred())
+
+		// The pools are owned by this controller's field manager, so another manager of the Installation
+		// keeps the pools it declared.
+		var applied *metav1.ManagedFieldsEntry
+		for i := range installation.ManagedFields {
+			if installation.ManagedFields[i].Manager == poolFieldManager {
+				applied = &installation.ManagedFields[i]
+			}
+		}
+		Expect(applied).NotTo(BeNil())
+		Expect(applied.Operation).To(Equal(metav1.ManagedFieldsOperationApply))
+		Expect(applied.FieldsV1).NotTo(BeNil())
+		Expect(applied.FieldsV1.GetRawString()).To(ContainSubstring("ipPools"))
 	})
 
 	It("should keep its own default pool when it reconciles again before the computed config is republished", func() {

--- a/pkg/controller/ippool/pool_controller_test.go
+++ b/pkg/controller/ippool/pool_controller_test.go
@@ -143,11 +143,12 @@ var _ = Describe("IP Pool controller tests", func() {
 		err = c.Get(ctx, utils.DefaultInstanceKey, installation)
 		Expect(err).ShouldNot(HaveOccurred())
 
-		// Verify an IP pool was defaulted onto the status, not the spec.
-		Expect(installation.Spec.CalicoNetwork).To(BeNil())
-		Expect(installation.Status.Defaults.CalicoNetwork.IPPools).To(HaveLen(1))
-		pool := installation.Status.Defaults.CalicoNetwork.IPPools[0]
+		// Verify the IP pool was defaulted onto the spec, and that nothing was recorded on the status.
+		Expect(installation.Spec.CalicoNetwork.IPPools).To(HaveLen(1))
+		pool := installation.Spec.CalicoNetwork.IPPools[0]
 		Expect(pool.CIDR).To(Equal("192.168.0.0/16"))
+		Expect(pool.Encapsulation).To(Equal(operator.EncapsulationIPIP))
+		Expect(installation.Status.Defaults).To(BeNil())
 
 		// Expect the IP pool to be created in the API server as well.
 		ipPools := v3.IPPoolList{}
@@ -174,6 +175,11 @@ var _ = Describe("IP Pool controller tests", func() {
 		}
 		createInstallation(ctx, c, instance)
 
+		// Use the projectcalico.org/v3 API path, so that a reconcile deciding to delete the pool
+		// carries the deletion out rather than just marking the controller as degraded.
+		r.clientv3 = c
+		r.opts.UseV3CRDs = true
+
 		// Set up expected mocks.
 		mockStatus.On("OnCRFound")
 		mockStatus.On("SetMetaData", mock.Anything)
@@ -181,27 +187,22 @@ var _ = Describe("IP Pool controller tests", func() {
 		mockStatus.On("ReadyToMonitor")
 		mockStatus.On("ClearDegraded")
 
-		// Allowed so that a reconcile deciding to delete the pool reaches the assertions below
-		// rather than panicking on an unexpected call.
-		mockStatus.On("SetDegraded", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
-
-		// The first reconcile defaults the pool and creates it.
-		_, err := r.Reconcile(ctx, reconcile.Request{})
-		Expect(err).ShouldNot(HaveOccurred())
-
-		// The pool it just created triggers another reconcile, and the core controller hasn't
-		// republished the computed config yet, so it still carries no pools.
-		_, err = r.Reconcile(ctx, reconcile.Request{})
-		Expect(err).ShouldNot(HaveOccurred())
+		// The first reconcile defaults the pool and creates it. The second stands in for the reconcile
+		// triggered by that create, before the core controller has republished the computed config.
+		for i := 0; i < 2; i++ {
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+		}
+		mockStatus.AssertExpectations(GinkgoT())
 
 		installation := &operator.Installation{}
-		err = c.Get(ctx, utils.DefaultInstanceKey, installation)
+		err := c.Get(ctx, utils.DefaultInstanceKey, installation)
 		Expect(err).ShouldNot(HaveOccurred())
 
-		// The recorded default still holds the pool, rather than the empty list that means
-		// pools are managed out-of-band.
-		Expect(installation.Status.Defaults.CalicoNetwork.IPPools).To(HaveLen(1))
-		Expect(installation.Status.Defaults.CalicoNetwork.IPPools[0].CIDR).To(Equal("192.168.0.0/16"))
+		// The spec still declares the pool, rather than the empty list that means pools are managed
+		// out-of-band.
+		Expect(installation.Spec.CalicoNetwork.IPPools).To(HaveLen(1))
+		Expect(installation.Spec.CalicoNetwork.IPPools[0].CIDR).To(Equal("192.168.0.0/16"))
 
 		// And the pool is still in the cluster.
 		ipPools := v3.IPPoolList{}
@@ -251,9 +252,9 @@ var _ = Describe("IP Pool controller tests", func() {
 		err = c.Get(ctx, utils.DefaultInstanceKey, installation)
 		Expect(err).ShouldNot(HaveOccurred())
 
-		// An explicitly empty pool list is the recorded default, meaning pools are managed out-of-band.
-		Expect(installation.Status.Defaults).NotTo(BeNil())
-		Expect(installation.Status.Defaults.CalicoNetwork.IPPools).To(Equal([]operator.IPPool{}))
+		// An explicitly empty pool list on the spec means pools are managed out-of-band.
+		Expect(installation.Spec.CalicoNetwork.IPPools).To(Equal([]operator.IPPool{}))
+		Expect(installation.Status.Defaults).To(BeNil())
 
 		// No new IP pools should exist.
 		ipPools := v3.IPPoolList{}

--- a/pkg/controller/ippool/pool_controller_test.go
+++ b/pkg/controller/ippool/pool_controller_test.go
@@ -913,14 +913,14 @@ var _ = Describe("fillDefaults()", func() {
 			Expect(fillDefaults(ctx, cli, &i.Spec, currentPools)).ToNot(HaveOccurred())
 
 			if i.Spec.CalicoNetwork != nil && i.Spec.CalicoNetwork.IPPools != nil && len(i.Spec.CalicoNetwork.IPPools) != 0 {
-				v4pool := render.GetIPv4Pool(i.Spec.CalicoNetwork.IPPools)
+				v4pool := poolOfFamily(i.Spec.CalicoNetwork.IPPools, render.IsIPv4Pool)
 				Expect(v4pool).ToNot(BeNil())
 				Expect(v4pool.CIDR).ToNot(BeEmpty(), "CIDR should be set on pool %v", v4pool)
 				Expect(v4pool.Encapsulation).To(BeElementOf(operator.EncapsulationTypes), "Encapsulation should be set on pool %q", v4pool)
 				Expect(v4pool.NATOutgoing).To(BeElementOf(operator.NATOutgoingTypes), "NATOutgoing should be set on pool %v", v4pool)
 				Expect(v4pool.NodeSelector).ToNot(BeEmpty(), "NodeSelector should be set on pool %v", v4pool)
 
-				v6pool := render.GetIPv6Pool(i.Spec.CalicoNetwork.IPPools)
+				v6pool := poolOfFamily(i.Spec.CalicoNetwork.IPPools, render.IsIPv6Pool)
 				Expect(v6pool).To(BeNil())
 			}
 
@@ -1006,10 +1006,10 @@ var _ = Describe("fillDefaults()", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(instance.Spec.CalicoNetwork.IPPools).To(HaveLen(1))
 
-		v4pool := render.GetIPv4Pool(instance.Spec.CalicoNetwork.IPPools)
+		v4pool := poolOfFamily(instance.Spec.CalicoNetwork.IPPools, render.IsIPv4Pool)
 		Expect(v4pool).To(BeNil())
 
-		v6pool := render.GetIPv6Pool(instance.Spec.CalicoNetwork.IPPools)
+		v6pool := poolOfFamily(instance.Spec.CalicoNetwork.IPPools, render.IsIPv6Pool)
 		Expect(v6pool).NotTo(BeNil())
 		Expect(v6pool.CIDR).To(Equal("fd00::0/64"))
 		Expect(v6pool.BlockSize).NotTo(BeNil())
@@ -1167,6 +1167,21 @@ func fillPrerequisiteDefaults(i *operator.Installation) {
 }
 
 // createInstallation creates the Installation with its effective config published on the status.
+// poolOfFamily returns the one pool matching the family predicate. These tests never declare two
+// pools of the same family, so a second match is a bug in the test rather than a choice to make.
+func poolOfFamily(pools []operator.IPPool, matches func(operator.IPPool) bool) *operator.IPPool {
+	var found *operator.IPPool
+	for i := range pools {
+		if !matches(pools[i]) {
+			continue
+		}
+
+		ExpectWithOffset(1, found).To(BeNil(), "more than one pool of the same family")
+		found = &pools[i]
+	}
+	return found
+}
+
 func createInstallation(ctx context.Context, c client.Client, instance *operator.Installation) {
 	instance.Status.Computed = instance.Spec.DeepCopy()
 	ExpectWithOffset(1, c.Create(ctx, instance)).ShouldNot(HaveOccurred())

--- a/pkg/controller/ippool/pool_controller_test.go
+++ b/pkg/controller/ippool/pool_controller_test.go
@@ -157,6 +157,60 @@ var _ = Describe("IP Pool controller tests", func() {
 		Expect(ipPools.Items[0].Spec.CIDR).To(Equal(pool.CIDR))
 	})
 
+	It("should keep its own default pool when it reconciles again before the computed config is republished", func() {
+		instance := &operator.Installation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "default",
+				Finalizers: []string{"tigera.io/operator-cleanup"},
+			},
+			Spec: operator.InstallationSpec{
+				Variant:  operator.Calico,
+				Registry: "some.registry.org/",
+				CNI: &operator.CNISpec{
+					Type: operator.PluginCalico,
+					IPAM: &operator.IPAMSpec{Type: operator.IPAMPluginCalico},
+				},
+			},
+		}
+		createInstallation(ctx, c, instance)
+
+		// Set up expected mocks.
+		mockStatus.On("OnCRFound")
+		mockStatus.On("SetMetaData", mock.Anything)
+		mockStatus.On("IsAvailable").Return(true)
+		mockStatus.On("ReadyToMonitor")
+		mockStatus.On("ClearDegraded")
+
+		// Allowed so that a reconcile deciding to delete the pool reaches the assertions below
+		// rather than panicking on an unexpected call.
+		mockStatus.On("SetDegraded", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+
+		// The first reconcile defaults the pool and creates it.
+		_, err := r.Reconcile(ctx, reconcile.Request{})
+		Expect(err).ShouldNot(HaveOccurred())
+
+		// The pool it just created triggers another reconcile, and the core controller hasn't
+		// republished the computed config yet, so it still carries no pools.
+		_, err = r.Reconcile(ctx, reconcile.Request{})
+		Expect(err).ShouldNot(HaveOccurred())
+
+		installation := &operator.Installation{}
+		err = c.Get(ctx, utils.DefaultInstanceKey, installation)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		// The recorded default still holds the pool, rather than the empty list that means
+		// pools are managed out-of-band.
+		Expect(installation.Status.Defaults.CalicoNetwork.IPPools).To(HaveLen(1))
+		Expect(installation.Status.Defaults.CalicoNetwork.IPPools[0].CIDR).To(Equal("192.168.0.0/16"))
+
+		// And the pool is still in the cluster.
+		ipPools := v3.IPPoolList{}
+		err = c.List(ctx, &ipPools)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(ipPools.Items).To(HaveLen(1))
+		Expect(ipPools.Items[0].Spec.CIDR).To(Equal("192.168.0.0/16"))
+	})
+
 	It("should not create a default IP pool if one already exists", func() {
 		instance := &operator.Installation{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/ippool/pool_controller_test.go
+++ b/pkg/controller/ippool/pool_controller_test.go
@@ -256,6 +256,103 @@ var _ = Describe("IP Pool controller tests", func() {
 		Expect(ipPools.Items[0].Spec.CIDR).To(Equal("192.168.0.0/16"))
 	})
 
+	It("should re-apply the pools it owns when the spec's pool list is cleared", func() {
+		instance := &operator.Installation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "default",
+				Finalizers: []string{"tigera.io/operator-cleanup"},
+			},
+			Spec: operator.InstallationSpec{
+				Variant:  operator.Calico,
+				Registry: "some.registry.org/",
+				CNI: &operator.CNISpec{
+					Type: operator.PluginCalico,
+					IPAM: &operator.IPAMSpec{Type: operator.IPAMPluginCalico},
+				},
+			},
+		}
+		createInstallation(ctx, c, instance)
+
+		// Use the projectcalico.org/v3 API path, so that a reconcile deciding to delete the pool
+		// carries the deletion out rather than just marking the controller as degraded.
+		r.clientv3 = c
+		r.opts.UseV3CRDs = true
+
+		mockStatus.On("OnCRFound")
+		mockStatus.On("SetMetaData", mock.Anything)
+		mockStatus.On("IsAvailable").Return(true)
+		mockStatus.On("ReadyToMonitor")
+		mockStatus.On("ClearDegraded")
+
+		_, err := r.Reconcile(ctx, reconcile.Request{})
+		Expect(err).ShouldNot(HaveOccurred())
+
+		// Clear the pool list. This is what a user reverting the field does, and also what an
+		// Installation cache that has not caught up with this controller's own write serves.
+		installation := &operator.Installation{}
+		Expect(c.Get(ctx, utils.DefaultInstanceKey, installation)).ShouldNot(HaveOccurred())
+		installation.Spec.CalicoNetwork.IPPools = nil
+		Expect(c.Update(ctx, installation)).ShouldNot(HaveOccurred())
+
+		_, err = r.Reconcile(ctx, reconcile.Request{})
+		Expect(err).ShouldNot(HaveOccurred())
+		mockStatus.AssertExpectations(GinkgoT())
+
+		// The cleared list reads as "keep what you own", not as a request to manage pools out-of-band,
+		// so the pool survives and goes back on the spec.
+		ipPools := v3.IPPoolList{}
+		Expect(c.List(ctx, &ipPools)).ShouldNot(HaveOccurred())
+		Expect(ipPools.Items).To(HaveLen(1))
+		Expect(ipPools.Items[0].Spec.CIDR).To(Equal("192.168.0.0/16"))
+
+		Expect(c.Get(ctx, utils.DefaultInstanceKey, installation)).ShouldNot(HaveOccurred())
+		Expect(installation.Spec.CalicoNetwork.IPPools).To(HaveLen(1))
+		Expect(installation.Spec.CalicoNetwork.IPPools[0].CIDR).To(Equal("192.168.0.0/16"))
+	})
+
+	It("should delete the pools it owns when the spec declares an empty list", func() {
+		instance := &operator.Installation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "default",
+				Finalizers: []string{"tigera.io/operator-cleanup"},
+			},
+			Spec: operator.InstallationSpec{
+				Variant:  operator.Calico,
+				Registry: "some.registry.org/",
+				CNI: &operator.CNISpec{
+					Type: operator.PluginCalico,
+					IPAM: &operator.IPAMSpec{Type: operator.IPAMPluginCalico},
+				},
+			},
+		}
+		createInstallation(ctx, c, instance)
+
+		r.clientv3 = c
+		r.opts.UseV3CRDs = true
+
+		mockStatus.On("OnCRFound")
+		mockStatus.On("SetMetaData", mock.Anything)
+		mockStatus.On("IsAvailable").Return(true)
+		mockStatus.On("ReadyToMonitor")
+		mockStatus.On("ClearDegraded")
+
+		_, err := r.Reconcile(ctx, reconcile.Request{})
+		Expect(err).ShouldNot(HaveOccurred())
+
+		installation := &operator.Installation{}
+		Expect(c.Get(ctx, utils.DefaultInstanceKey, installation)).ShouldNot(HaveOccurred())
+		installation.Spec.CalicoNetwork.IPPools = []operator.IPPool{}
+		updateInstallation(ctx, c, installation)
+
+		_, err = r.Reconcile(ctx, reconcile.Request{})
+		Expect(err).ShouldNot(HaveOccurred())
+		mockStatus.AssertExpectations(GinkgoT())
+
+		ipPools := v3.IPPoolList{}
+		Expect(c.List(ctx, &ipPools)).ShouldNot(HaveOccurred())
+		Expect(ipPools.Items).To(BeEmpty())
+	})
+
 	It("should not create a default IP pool if one already exists", func() {
 		instance := &operator.Installation{
 			ObjectMeta: metav1.ObjectMeta{
@@ -944,6 +1041,39 @@ var _ = Describe("fillDefaults()", func() {
 			Expect(instance.Spec.CalicoNetwork.IPPools[0].CIDR).To(Equal("172.16.0.0/16"))
 			Expect(ValidatePools(&instance.Spec)).NotTo(HaveOccurred())
 		})
+	})
+})
+
+var _ = Describe("ownedPoolMembership()", func() {
+	ownedPool := func(cidr string) v3.IPPool {
+		return v3.IPPool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "owned",
+				Labels: map[string]string{managedByLabel: managedByValue},
+			},
+			Spec: v3.IPPoolSpec{CIDR: cidr},
+		}
+	}
+
+	It("should return nil when the cluster has no pools", func() {
+		Expect(ownedPoolMembership(nil)).To(BeNil())
+		Expect(ownedPoolMembership(&v3.IPPoolList{})).To(BeNil())
+	})
+
+	It("should return the pools the operator owns", func() {
+		pools := &v3.IPPoolList{Items: []v3.IPPool{ownedPool("192.168.0.0/16")}}
+		membership := ownedPoolMembership(pools)
+		Expect(membership).To(HaveLen(1))
+		Expect(membership[0].CIDR).To(Equal("192.168.0.0/16"))
+	})
+
+	It("should return an empty list when any pool is unowned", func() {
+		unowned := v3.IPPool{
+			ObjectMeta: metav1.ObjectMeta{Name: "theirs"},
+			Spec:       v3.IPPoolSpec{CIDR: "10.0.0.0/16"},
+		}
+		pools := &v3.IPPoolList{Items: []v3.IPPool{ownedPool("192.168.0.0/16"), unowned}}
+		Expect(ownedPoolMembership(pools)).To(Equal([]operator.IPPool{}))
 	})
 })
 

--- a/pkg/controller/migration/convert/ippools.go
+++ b/pkg/controller/migration/convert/ippools.go
@@ -60,7 +60,7 @@ func handleIPPools(c *components, install *operatorv1.Installation) error {
 		}
 
 		// Convert any found CRD pools into Operator pools and add them.
-		if render.GetIPv4Pool(install.Spec.CalicoNetwork.IPPools) == nil && v4pool != nil {
+		if !render.HasIPv4Pool(install.Spec.CalicoNetwork.IPPools) && v4pool != nil {
 			pool, err := convertPool(*v4pool)
 			if err != nil {
 				return ErrIncompatibleCluster{
@@ -71,7 +71,7 @@ func handleIPPools(c *components, install *operatorv1.Installation) error {
 			install.Spec.CalicoNetwork.IPPools = append(install.Spec.CalicoNetwork.IPPools, pool)
 		}
 
-		if render.GetIPv6Pool(install.Spec.CalicoNetwork.IPPools) == nil && v6pool != nil {
+		if !render.HasIPv6Pool(install.Spec.CalicoNetwork.IPPools) && v6pool != nil {
 			operatorV6Pool, err = convertPool(*v6pool)
 			if err != nil {
 				return ErrIncompatibleCluster{

--- a/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_felixconfigurations.yaml
@@ -996,6 +996,8 @@ spec:
                   description: |-
                     LogActionRateLimit sets the rate of hitting a Log action. The value must be in the format "N/unit",
                     where N is a number and unit is one of: second, minute, hour, or day. For example: "10/second" or "100/hour".
+                    When LogConnectionTransitions is enabled, this also bounds the follow-up logs: a connection whose
+                    initial log was suppressed by this rate limit gets no follow-up log either.
                   pattern: ^[1-9]\d{0,3}/(?:second|minute|hour|day)$
                   type: string
                 logActionRateLimitBurst:
@@ -1005,6 +1007,33 @@ spec:
                   maximum: 9999
                   minimum: 0
                   type: integer
+                logConnectionTransitions:
+                  description: |-
+                    LogConnectionTransitions controls whether Felix emits an additional kernel log recording the
+                    first observed response for each connection that matched a policy rule with a Log action.
+                    When set to FirstResponseAfterLog, each connection whose initial log was emitted gets one
+                    follow-up log, prefixed with LogConnectionTransitionsPrefix plus a suffix identifying the
+                    transition: "-est" when the first reply packet is seen, "-rst" when the response is a TCP
+                    RST (connection refused), or "-icmp-err" when the response is a related ICMP error (e.g.
+                    port unreachable). The log body is the standard kernel packet log of the response packet,
+                    so the flow is identified by its 5-tuple and can be correlated with the original policy Log
+                    line (with source and destination swapped). A logged connection with no follow-up log never
+                    received a response. Connections whose initial log was suppressed by LogActionRateLimit get
+                    no follow-up log either, so every follow-up log pairs with an initial one. Enabling this
+                    consumes one bit from the Iptables/NftablesMarkMask space. Not supported in eBPF mode.
+                    [Default: Disabled]
+                  enum:
+                    - Disabled
+                    - FirstResponseAfterLog
+                  type: string
+                logConnectionTransitionsPrefix:
+                  description: |-
+                    LogConnectionTransitionsPrefix is the log prefix used for the logs emitted when
+                    LogConnectionTransitions is enabled; the transition suffix ("-est", "-rst" or "-icmp-err")
+                    is appended to it. Unlike LogPrefix, it does not support %-specifiers (such as %p): the
+                    rules that emit these logs are shared by all policies, so per-policy values cannot be
+                    substituted and any %-specifiers are rendered literally. [Default: calico-response]
+                  type: string
                 logDebugFilenameRegex:
                   description: |-
                     LogDebugFilenameRegex controls which source code files have their Debug log output included in the logs.

--- a/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_felixconfigurations.yaml
+++ b/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_felixconfigurations.yaml
@@ -995,6 +995,8 @@ spec:
                   description: |-
                     LogActionRateLimit sets the rate of hitting a Log action. The value must be in the format "N/unit",
                     where N is a number and unit is one of: second, minute, hour, or day. For example: "10/second" or "100/hour".
+                    When LogConnectionTransitions is enabled, this also bounds the follow-up logs: a connection whose
+                    initial log was suppressed by this rate limit gets no follow-up log either.
                   pattern: ^[1-9]\d{0,3}/(?:second|minute|hour|day)$
                   type: string
                 logActionRateLimitBurst:
@@ -1004,6 +1006,33 @@ spec:
                   maximum: 9999
                   minimum: 0
                   type: integer
+                logConnectionTransitions:
+                  description: |-
+                    LogConnectionTransitions controls whether Felix emits an additional kernel log recording the
+                    first observed response for each connection that matched a policy rule with a Log action.
+                    When set to FirstResponseAfterLog, each connection whose initial log was emitted gets one
+                    follow-up log, prefixed with LogConnectionTransitionsPrefix plus a suffix identifying the
+                    transition: "-est" when the first reply packet is seen, "-rst" when the response is a TCP
+                    RST (connection refused), or "-icmp-err" when the response is a related ICMP error (e.g.
+                    port unreachable). The log body is the standard kernel packet log of the response packet,
+                    so the flow is identified by its 5-tuple and can be correlated with the original policy Log
+                    line (with source and destination swapped). A logged connection with no follow-up log never
+                    received a response. Connections whose initial log was suppressed by LogActionRateLimit get
+                    no follow-up log either, so every follow-up log pairs with an initial one. Enabling this
+                    consumes one bit from the Iptables/NftablesMarkMask space. Not supported in eBPF mode.
+                    [Default: Disabled]
+                  enum:
+                    - Disabled
+                    - FirstResponseAfterLog
+                  type: string
+                logConnectionTransitionsPrefix:
+                  description: |-
+                    LogConnectionTransitionsPrefix is the log prefix used for the logs emitted when
+                    LogConnectionTransitions is enabled; the transition suffix ("-est", "-rst" or "-icmp-err")
+                    is appended to it. Unlike LogPrefix, it does not support %-specifiers (such as %p): the
+                    rules that emit these logs are shared by all policies, so per-policy values cannot be
+                    substituted and any %-specifiers are rendered literally. [Default: calico-response]
+                  type: string
                 logDebugFilenameRegex:
                   description: |-
                     LogDebugFilenameRegex controls which source code files have their Debug log output included in the logs.

--- a/pkg/imports/crds/enterprise/01-crd-eck-bundle.yaml
+++ b/pkg/imports/crds/enterprise/01-crd-eck-bundle.yaml
@@ -5309,6 +5309,34 @@ spec:
                             x-kubernetes-list-type: map
                           currentVolumeAttributesClassName:
                             type: string
+                          healthStatus:
+                            properties:
+                              healthConditions:
+                                items:
+                                  properties:
+                                    message:
+                                      type: string
+                                    reason:
+                                      type: string
+                                    status:
+                                      enum:
+                                        - DataLoss
+                                        - Degraded
+                                        - Inaccessible
+                                      type: string
+                                  required:
+                                    - reason
+                                    - status
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - status
+                                  - reason
+                                x-kubernetes-list-type: map
+                              lastTransitionTime:
+                                format: date-time
+                                type: string
+                            type: object
                           modifyVolumeStatus:
                             properties:
                               status:

--- a/pkg/imports/crds/operator/operator.tigera.io_installations.yaml
+++ b/pkg/imports/crds/operator/operator.tigera.io_installations.yaml
@@ -1467,6 +1467,9 @@ spec:
                         type: object
                       maxItems: 25
                       type: array
+                      x-kubernetes-list-map-keys:
+                        - cidr
+                      x-kubernetes-list-type: map
                     kubeProxyManagement:
                       description: |-
                         KubeProxyManagement controls whether the operator manages the kube-proxy DaemonSet.

--- a/pkg/imports/crds/operator/operator.tigera.io_installations.yaml
+++ b/pkg/imports/crds/operator/operator.tigera.io_installations.yaml
@@ -1389,9 +1389,10 @@ spec:
                       type: string
                     ipPools:
                       description: |-
-                        IPPools contains a list of IP pools to manage. If nil, the operator fills this field in: a single IPv4
-                        pool on a cluster with no IP pools, or an empty list on a cluster that already has them, which leaves
-                        those pools to whoever created them.
+                        IPPools contains a list of IP pools to manage. If left unset, the operator fills it in with the pools
+                        it already owns, or with the platform's pod CIDRs or a built-in default on a cluster that has none. A
+                        cluster with pools the operator does not own gets an empty list. Provide an empty list to manage IP
+                        pools out-of-band; the operator then deletes the pools it owns and creates none.
                         IP pools in this list will be reconciled by the operator and should not be modified out-of-band.
                       items:
                         properties:

--- a/pkg/imports/crds/operator/operator.tigera.io_installations.yaml
+++ b/pkg/imports/crds/operator/operator.tigera.io_installations.yaml
@@ -1389,10 +1389,9 @@ spec:
                       type: string
                     ipPools:
                       description: |-
-                        IPPools contains a list of IP pools to manage. If nil, the operator chooses: on a cluster with no
-                        operator-managed pools it creates a single IPv4 pool, and on a cluster that already has them it keeps
-                        the pools in use. Provide an empty list to manage IP pools out-of-band; the operator then deletes the
-                        pools it owns and creates none.
+                        IPPools contains a list of IP pools to manage. If nil, the operator fills this field in: a single IPv4
+                        pool on a cluster with no IP pools, or an empty list on a cluster that already has them, which leaves
+                        those pools to whoever created them.
                         IP pools in this list will be reconciled by the operator and should not be modified out-of-band.
                       items:
                         properties:

--- a/pkg/imports/crds/operator/operator.tigera.io_installations.yaml
+++ b/pkg/imports/crds/operator/operator.tigera.io_installations.yaml
@@ -1417,10 +1417,16 @@ spec:
                             format: int32
                             type: integer
                           cidr:
-                            description:
-                              CIDR contains the address range for the IP
-                              Pool in classless inter-domain routing format.
+                            description: |-
+                              CIDR contains the address range for the IP Pool in classless inter-domain routing format.
+                              MaxLength keeps the rule below inside the CEL cost budget.
+                            maxLength: 43
                             type: string
+                            x-kubernetes-validations:
+                              - message:
+                                  cidr must be in canonical form, for example 192.168.0.0/16
+                                  or fd00:10:244::/64
+                                rule: isCIDR(self) && string(cidr(self).masked()) == self
                           disableBGPExport:
                             default: false
                             description: |-

--- a/pkg/imports/crds/operator/operator.tigera.io_installations.yaml
+++ b/pkg/imports/crds/operator/operator.tigera.io_installations.yaml
@@ -1389,10 +1389,9 @@ spec:
                       type: string
                     ipPools:
                       description: |-
-                        IPPools contains a list of IP pools to manage. If left unset, the operator fills it in with the pools
-                        it already owns, or with the platform's pod CIDRs or a built-in default on a cluster that has none. A
-                        cluster with pools the operator does not own gets an empty list. Provide an empty list to manage IP
-                        pools out-of-band; the operator then deletes the pools it owns and creates none.
+                        IPPools contains a list of IP pools to manage. If unset, the operator fills it in with defaults based
+                        on cluster state. Provide an empty list to manage IP pools out-of-band; the operator then deletes the
+                        pools it owns and creates none.
                         IP pools in this list will be reconciled by the operator and should not be modified out-of-band.
                       items:
                         properties:
@@ -1417,9 +1416,9 @@ spec:
                             format: int32
                             type: integer
                           cidr:
-                            description: |-
-                              CIDR contains the address range for the IP Pool in classless inter-domain routing format.
-                              MaxLength keeps the rule below inside the CEL cost budget.
+                            description:
+                              CIDR contains the address range for the IP
+                              Pool in classless inter-domain routing format.
                             maxLength: 43
                             type: string
                             x-kubernetes-validations:

--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -823,12 +823,12 @@ func (c *nodeComponent) getCalicoIPAM() map[string]any {
 	// Determine what address families to enable.
 	var assign_ipv4 string
 	var assign_ipv6 string
-	if v4pool := GetIPv4Pool(c.cfg.IPPools); v4pool != nil {
+	if HasIPv4Pool(c.cfg.IPPools) {
 		assign_ipv4 = "true"
 	} else {
 		assign_ipv4 = "false"
 	}
-	if v6pool := GetIPv6Pool(c.cfg.IPPools); v6pool != nil {
+	if HasIPv6Pool(c.cfg.IPPools) {
 		assign_ipv6 = "true"
 	} else {
 		assign_ipv6 = "false"
@@ -841,8 +841,8 @@ func (c *nodeComponent) getCalicoIPAM() map[string]any {
 }
 
 func buildHostLocalIPAM(pools []operatorv1.IPPool) map[string]any {
-	v6 := GetIPv6Pool(pools) != nil
-	v4 := GetIPv4Pool(pools) != nil
+	v6 := HasIPv6Pool(pools)
+	v4 := HasIPv4Pool(pools)
 
 	if v4 && v6 {
 		// Dual-stack
@@ -1782,32 +1782,36 @@ func getAutodetectionMethod(ad *operatorv1.NodeAddressAutodetection) string {
 	return ""
 }
 
-// GetIPv4Pool returns the IPv4 IPPool in an installation, or nil if one can't be found.
-func GetIPv4Pool(pools []operatorv1.IPPool) *operatorv1.IPPool {
-	for ii, pool := range pools {
-		addr, _, err := net.ParseCIDR(pool.CIDR)
-		if err == nil {
-			if addr.To4() != nil {
-				return &pools[ii]
-			}
-		}
-	}
-
-	return nil
+// IsIPv4Pool reports whether the pool is IPv4. A CIDR that doesn't parse belongs to neither family.
+func IsIPv4Pool(pool operatorv1.IPPool) bool {
+	addr, _, err := net.ParseCIDR(pool.CIDR)
+	return err == nil && addr.To4() != nil
 }
 
-// GetIPv6Pool returns the IPv6 IPPool in an installation, or nil if one can't be found.
-func GetIPv6Pool(pools []operatorv1.IPPool) *operatorv1.IPPool {
-	for ii, pool := range pools {
-		addr, _, err := net.ParseCIDR(pool.CIDR)
-		if err == nil {
-			if addr.To4() == nil {
-				return &pools[ii]
-			}
+// IsIPv6Pool reports whether the pool is IPv6. A CIDR that doesn't parse belongs to neither family.
+func IsIPv6Pool(pool operatorv1.IPPool) bool {
+	addr, _, err := net.ParseCIDR(pool.CIDR)
+	return err == nil && addr.To4() == nil
+}
+
+// HasIPv4Pool reports whether any of the pools is IPv4.
+func HasIPv4Pool(pools []operatorv1.IPPool) bool {
+	for _, pool := range pools {
+		if IsIPv4Pool(pool) {
+			return true
 		}
 	}
+	return false
+}
 
-	return nil
+// HasIPv6Pool reports whether any of the pools is IPv6.
+func HasIPv6Pool(pools []operatorv1.IPPool) bool {
+	for _, pool := range pools {
+		if IsIPv6Pool(pool) {
+			return true
+		}
+	}
+	return false
 }
 
 // bgpEnabled returns true if the given Installation enables BGP, false otherwise.

--- a/test/pool_test.go
+++ b/test/pool_test.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/ptr"
@@ -414,4 +415,126 @@ var _ = Describe("IPPool FV tests", func() {
 		Expect(v3Pools.Items[0].Spec.IPIPMode).To(Equal(v3.IPIPMode(v3.IPIPModeAlways)))
 		Expect(v3Pools.Items[0].Spec.VXLANMode).To(Equal(v3.VXLANMode(v3.VXLANModeNever)))
 	})
+
+	// The operator applies its IP pool list under its own field manager, so these tests cover what
+	// happens when a second manager writes to the same field against a real API server.
+	It("should share the IP pool list with another field manager", func() {
+		operatorDone = createInstallation(c, mgr, shutdownContext, nil)
+		verifyCalicoHasDeployed(c)
+
+		instance := &operator.Installation{}
+		Eventually(func() error {
+			return installationHasPools(c, instance, 2)
+		}, 30*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+		Expect(managerOwningPools(instance)).To(Equal(poolFieldManager))
+
+		By("Applying an extra IP pool as a different field manager")
+		extra := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "operator.tigera.io/v1",
+			"kind":       "Installation",
+			"metadata":   map[string]any{"name": "default"},
+			"spec": map[string]any{
+				"calicoNetwork": map[string]any{
+					"ipPools": []any{
+						map[string]any{"cidr": "172.31.0.0/16", "encapsulation": "VXLAN"},
+					},
+				},
+			},
+		}}
+		Expect(c.Apply(context.Background(), client.ApplyConfigurationFromUnstructured(extra), client.FieldOwner("fv-writer"))).To(Succeed())
+
+		By("Verifying the two managers' pools are merged rather than replacing each other")
+		Eventually(func() error {
+			return installationHasPools(c, instance, 3)
+		}, 30*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+
+		cidrs := []string{}
+		for _, pool := range instance.Spec.CalicoNetwork.IPPools {
+			cidrs = append(cidrs, pool.CIDR)
+		}
+		Expect(cidrs).To(ConsistOf("192.168.0.0/16", "fd00:10:244::/64", "172.31.0.0/16"))
+
+		By("Verifying the operator creates the pool the other manager declared")
+		ipPools := &v3.IPPoolList{}
+		Eventually(func() error {
+			if err := c.List(context.Background(), ipPools); err != nil {
+				return err
+			}
+			if len(ipPools.Items) != 3 {
+				return fmt.Errorf("Expected 3 IP pools, but got: %+v", ipPools.Items)
+			}
+			return nil
+		}, 60*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+	})
+
+	It("should restore the pools it owns when the list is removed from the spec", func() {
+		operatorDone = createInstallation(c, mgr, shutdownContext, nil)
+		verifyCalicoHasDeployed(c)
+
+		instance := &operator.Installation{}
+		Eventually(func() error {
+			return installationHasPools(c, instance, 2)
+		}, 30*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+
+		By("Clearing the pool list the way a kubectl edit would")
+		Eventually(func() error {
+			if err := c.Get(context.Background(), types.NamespacedName{Name: "default"}, instance); err != nil {
+				return err
+			}
+
+			instance.Spec.CalicoNetwork.IPPools = nil
+			return c.Update(context.Background(), instance)
+		}, 30*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+
+		By("Verifying the operator puts its pools back rather than reading the clear as a deletion")
+		Eventually(func() error {
+			return installationHasPools(c, instance, 2)
+		}, 60*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+		Expect(managerOwningPools(instance)).To(Equal(poolFieldManager))
+
+		ipPools := &v3.IPPoolList{}
+		Consistently(func() error {
+			if err := c.List(context.Background(), ipPools); err != nil {
+				return err
+			}
+			if len(ipPools.Items) != 2 {
+				return fmt.Errorf("Expected 2 IP pools, but got: %+v", ipPools.Items)
+			}
+			return nil
+		}, 10*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+	})
 })
+
+// poolFieldManager matches the unexported field manager the IP pool controller applies under.
+const poolFieldManager = "tigera-operator-ippools"
+
+// installationHasPools reads the Installation into instance and reports whether its spec declares
+// the expected number of IP pools.
+func installationHasPools(c client.Client, instance *operator.Installation, expected int) error {
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "default"}, instance); err != nil {
+		return err
+	}
+	if instance.Spec.CalicoNetwork == nil {
+		return fmt.Errorf("Installation has no calicoNetwork yet")
+	}
+
+	pools := instance.Spec.CalicoNetwork.IPPools
+	if len(pools) != expected {
+		return fmt.Errorf("Expected %d IP pools on the spec, but got: %+v", expected, pools)
+	}
+	return nil
+}
+
+// managerOwningPools returns the name of the applying field manager that owns the IP pool list.
+func managerOwningPools(instance *operator.Installation) string {
+	for _, entry := range instance.ManagedFields {
+		if entry.Operation != metav1.ManagedFieldsOperationApply || entry.FieldsV1 == nil {
+			continue
+		}
+
+		if strings.Contains(entry.FieldsV1.GetRawString(), "ipPools") {
+			return entry.Manager
+		}
+	}
+	return ""
+}

--- a/test/pool_test.go
+++ b/test/pool_test.go
@@ -454,17 +454,8 @@ var _ = Describe("IPPool FV tests", func() {
 		}
 		Expect(cidrs).To(ConsistOf("192.168.0.0/16", "fd00:10:244::/64", "172.31.0.0/16"))
 
-		By("Verifying the operator creates the pool the other manager declared")
-		ipPools := &v3.IPPoolList{}
-		Eventually(func() error {
-			if err := c.List(context.Background(), ipPools); err != nil {
-				return err
-			}
-			if len(ipPools.Items) != 3 {
-				return fmt.Errorf("Expected 3 IP pools, but got: %+v", ipPools.Items)
-			}
-			return nil
-		}, 60*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
+		// The pool the other manager declared stays uncreated here. Past bootstrap this controller
+		// only writes pools through the Calico API server, which this suite doesn't run.
 	})
 
 	It("should restore the pools it owns when the list is removed from the spec", func() {


### PR DESCRIPTION
## Description

A fresh install that leaves the IP pool list unset could end up with no IP pool at all, leaving Calico degraded on "waiting for enabled IP pools to be created" and every pod unable to get a sandbox. The IP pool controller creates its default pool, reconciles again on that create before the effective config has been republished, and reads the pool it just made as a sign that pools are managed out-of-band, so it records an empty list over its own default and deletes the pool.

- Pool membership moves to the Installation spec. When nobody declared pools, the operator writes the ones it chose there and reads them back from there, so nothing re-derives the list from cluster state, and an edit that appends a pool can see the pools already in use.
- A declared list is left alone, and per-pool field defaults still go to the status and layer by CIDR.
- Second commit: that write is a server-side apply under its own field manager, and the pool list is a map keyed on CIDR, so each manager owns the pools it declared rather than fighting over the whole list.

Diagnosis by Jiawei Huang, who hit it on gcp-kubeadm clusters running the master hashrelease.

```release-note
Fixes a fresh install creating no IP pool when the Installation leaves the pool list unset; the operator now fills the IP pool list in on the Installation when it is not specified.
The Installation IP pool list is a map keyed on CIDR, so server-side apply clients keep ownership of the pools they declare.
```
