### PR TITLE
Resolve the CSR init image without branching on the variant

### DIFF
--- a/pkg/controller/certificatemanager/certificatemanager.go
+++ b/pkg/controller/certificatemanager/certificatemanager.go
@@ -34,6 +34,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/components"
 	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/controller/utils/imageset"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
@@ -174,7 +175,8 @@ func Create(cli client.Client, installation *operatorv1.InstallationSpec, cluste
 			return nil, err
 		}
 		// We instantiate csrImage regardless of whether certificate management is enabled; it may still be used.
-		csrImage, err = certificatemanagement.ResolveCSRInitImage(installation, imageSet)
+		// The init container runs out of the combined image as a key-cert-provisioner subcommand.
+		csrImage, err = components.GetReference(components.CombinedCalicoImage(installation), installation.Registry, installation.ImagePath, installation.ImagePrefix, imageSet)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/render/dex.go
+++ b/pkg/render/dex.go
@@ -111,7 +111,7 @@ func (c *dexComponent) ResolveImages(is *operatorv1.ImageSet) error {
 	}
 
 	if c.cfg.Installation.CertificateManagement != nil {
-		c.csrInitImage, err = certificatemanagement.ResolveCSRInitImage(c.cfg.Installation, is)
+		c.csrInitImage, err = components.GetReference(components.ComponentTigeraCalico, reg, path, prefix, is)
 		if err != nil {
 			errMsgs = append(errMsgs, err.Error())
 		}

--- a/pkg/render/logstorage.go
+++ b/pkg/render/logstorage.go
@@ -193,7 +193,7 @@ func (es *elasticsearchComponent) ResolveImages(is *operatorv1.ImageSet) error {
 	}
 
 	if es.cfg.Installation.CertificateManagement != nil {
-		es.csrImage, err = certificatemanagement.ResolveCSRInitImage(es.cfg.Installation, is)
+		es.csrImage, err = components.GetReference(components.ComponentTigeraCalico, reg, path, prefix, is)
 		if err != nil {
 			errMsgs = append(errMsgs, err.Error())
 		}

--- a/pkg/render/logstorage/dashboards/dashboards.go
+++ b/pkg/render/logstorage/dashboards/dashboards.go
@@ -111,7 +111,7 @@ func (d *dashboards) ResolveImages(is *operatorv1.ImageSet) error {
 	}
 
 	if d.cfg.Installation.CertificateManagement != nil {
-		d.csrImage, err = certificatemanagement.ResolveCSRInitImage(d.cfg.Installation, is)
+		d.csrImage, err = components.GetReference(components.ComponentTigeraCalico, reg, path, prefix, is)
 		if err != nil {
 			errMsgs = append(errMsgs, err.Error())
 		}

--- a/pkg/render/logstorage/esgateway/esgateway.go
+++ b/pkg/render/logstorage/esgateway/esgateway.go
@@ -116,7 +116,7 @@ func (e *esGateway) ResolveImages(is *operatorv1.ImageSet) error {
 		errMsgs = append(errMsgs, err.Error())
 	}
 	if e.cfg.Installation.CertificateManagement != nil {
-		e.csrImage, err = certificatemanagement.ResolveCSRInitImage(e.cfg.Installation, is)
+		e.csrImage, err = components.GetReference(components.ComponentTigeraCalico, reg, path, prefix, is)
 		if err != nil {
 			errMsgs = append(errMsgs, err.Error())
 		}

--- a/pkg/render/logstorage/kibana/kibana.go
+++ b/pkg/render/logstorage/kibana/kibana.go
@@ -116,7 +116,7 @@ func (k *kibana) ResolveImages(is *operatorv1.ImageSet) error {
 	}
 
 	if k.cfg.Installation.CertificateManagement != nil {
-		k.csrImage, err = certificatemanagement.ResolveCSRInitImage(k.cfg.Installation, is)
+		k.csrImage, err = components.GetReference(components.ComponentTigeraCalico, reg, path, prefix, is)
 		if err != nil {
 			errMsgs = append(errMsgs, err.Error())
 		}

--- a/pkg/render/logstorage/linseed/linseed.go
+++ b/pkg/render/logstorage/linseed/linseed.go
@@ -152,7 +152,7 @@ func (l *linseed) ResolveImages(is *operatorv1.ImageSet) error {
 	}
 
 	if l.cfg.Installation.CertificateManagement != nil {
-		l.csrImage, err = certificatemanagement.ResolveCSRInitImage(l.cfg.Installation, is)
+		l.csrImage, err = components.GetReference(components.ComponentTigeraCalico, reg, path, prefix, is)
 		if err != nil {
 			errMsgs = append(errMsgs, err.Error())
 		}

--- a/pkg/tls/certificatemanagement/csr.go
+++ b/pkg/tls/certificatemanagement/csr.go
@@ -93,13 +93,6 @@ func CreateCSRInitContainer(
 	}
 }
 
-// ResolveCSRInitImage resolves the image needed for the CSR init container, taking into account the
-// specified ImageSet. The init container reuses the combined calico/calico image and dispatches into
-// the key-cert-provisioner Cobra subcommand.
-func ResolveCSRInitImage(inst *operatorv1.InstallationSpec, is *operatorv1.ImageSet) (string, error) {
-	return components.GetReference(components.CombinedCalicoImage(inst), inst.Registry, inst.ImagePath, inst.ImagePrefix, is)
-}
-
 // CSRClusterRole returns a role with the necessary permissions to create certificate signing requests.
 func CSRClusterRole() client.Object {
 	return &rbacv1.ClusterRole{


### PR DESCRIPTION
Image selection for the CSR init container went through a shared helper that asked which variant is installed. Six of its seven callers are Enterprise-only renders (dex, elasticsearch, kibana, linseed, dashboards, esgateway), so they name the Enterprise image directly and the helper collapses into the certificate manager, the only caller left that picks at runtime. Those six were already getting the Enterprise image out of the helper, so no test expectations move.

Related: [CORE-13398](https://tigera.atlassian.net/browse/CORE-13398)

```release-note
None
```


[CORE-13398]: https://tigera.atlassian.net/browse/CORE-13398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ