### PR TITLE
Render a write-only tiered policy passthrough in v3 CRD mode

### DIFF
--- a/pkg/enterprise/apiserver/extension.go
+++ b/pkg/enterprise/apiserver/extension.go
@@ -396,7 +396,7 @@ func modifyAPIServer(ri render.Inputs, cfg *render.APIServerConfiguration, creat
 	c.layerDeployment(extensions.MustFindObject[*appsv1.Deployment](create, render.APIServerName))
 	c.addServicePorts(extensions.MustFindObject[*corev1.Service](create, render.APIServerServiceName))
 	// Staged policies are tiered too, so they need the same passthrough as their non-staged
-	// counterparts. They are Enterprise-only, so the base role does not list them.
+	// counterparts.
 	passthru := extensions.MustFindObject[*rbacv1.ClusterRole](create, render.TieredPolicyPassthruClusterRoleName)
 	for i := range passthru.Rules {
 		if slices.Contains(passthru.Rules[i].Resources, "networkpolicies") {

--- a/pkg/enterprise/apiserver/extension.go
+++ b/pkg/enterprise/apiserver/extension.go
@@ -395,13 +395,12 @@ func modifyAPIServer(ri render.Inputs, cfg *render.APIServerConfiguration, creat
 
 	c.layerDeployment(extensions.MustFindObject[*appsv1.Deployment](create, render.APIServerName))
 	c.addServicePorts(extensions.MustFindObject[*corev1.Service](create, render.APIServerServiceName))
-	// Enterprise serves staged policies through the tiered-policy passthrough role, which
-	// the base only creates when running an aggregation API server.
-	if role, ok := extensions.FindObject[*rbacv1.ClusterRole](create, render.TieredPolicyPassthruClusterRoleName); ok {
-		for i := range role.Rules {
-			if slices.Contains(role.Rules[i].Resources, "networkpolicies") {
-				role.Rules[i].Resources = append(role.Rules[i].Resources, "stagednetworkpolicies", "stagedglobalnetworkpolicies")
-			}
+	// Staged policies are tiered too, so they need the same passthrough as their non-staged
+	// counterparts. They are Enterprise-only, so the base role does not list them.
+	passthru := extensions.MustFindObject[*rbacv1.ClusterRole](create, render.TieredPolicyPassthruClusterRoleName)
+	for i := range passthru.Rules {
+		if slices.Contains(passthru.Rules[i].Resources, "networkpolicies") {
+			passthru.Rules[i].Resources = append(passthru.Rules[i].Resources, "stagednetworkpolicies", "stagedglobalnetworkpolicies")
 		}
 	}
 

--- a/pkg/enterprise/apiserver/extension.go
+++ b/pkg/enterprise/apiserver/extension.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
-	"slices"
 	"strings"
 
 	admregv1 "k8s.io/api/admissionregistration/v1"
@@ -395,15 +394,6 @@ func modifyAPIServer(ri render.Inputs, cfg *render.APIServerConfiguration, creat
 
 	c.layerDeployment(extensions.MustFindObject[*appsv1.Deployment](create, render.APIServerName))
 	c.addServicePorts(extensions.MustFindObject[*corev1.Service](create, render.APIServerServiceName))
-	// Staged policies are tiered too, so they need the same passthrough as their non-staged
-	// counterparts.
-	passthru := extensions.MustFindObject[*rbacv1.ClusterRole](create, render.TieredPolicyPassthruClusterRoleName)
-	for i := range passthru.Rules {
-		if slices.Contains(passthru.Rules[i].Resources, "networkpolicies") {
-			passthru.Rules[i].Resources = append(passthru.Rules[i].Resources, "stagednetworkpolicies", "stagedglobalnetworkpolicies")
-		}
-	}
-
 	// The L7 sidecar mutating webhook is driven by ApplicationLayer. The base always
 	// queues it for deletion; when sidecar injection is on, render it and pull it back
 	// out of the delete list.

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -106,6 +106,16 @@ var (
 		"delete",
 		"deletecollection",
 	}
+
+	// writeVerbs is the subset of allVerbs that the tiered policy admission webhook
+	// intercepts, used for tiered policy passthrough in v3-CRD mode.
+	writeVerbs = []string{
+		"create",
+		"update",
+		"patch",
+		"delete",
+		"deletecollection",
+	}
 )
 
 func APIServer(cfg *APIServerConfiguration) (Component, error) {
@@ -203,6 +213,8 @@ func (c *apiServerComponent) Objects() ([]client.Object, []client.Object) {
 		c.delegateAuthClusterRoleBinding(),
 		c.webhookReaderClusterRole(),
 		c.webhookReaderClusterRoleBinding(),
+		c.calicoPolicyPassthruClusterRole(),
+		c.calicoPolicyPassthruClusterRolebinding(),
 	}
 
 	objsToDelete := []client.Object{}
@@ -225,8 +237,6 @@ func (c *apiServerComponent) Objects() ([]client.Object, []client.Object) {
 	// These are objects that only need to exist when we are running an aggregation API server to
 	// serve projectcalico.org/v3 APIs. If using CRDs for this API group, we can remove these objects.
 	aggregationAPIServerObjects := []client.Object{
-		c.calicoPolicyPassthruClusterRole(),
-		c.calicoPolicyPassthruClusterRolebinding(),
 		c.authClusterRole(),
 		c.authClusterRoleBinding(),
 		c.authReaderRoleBinding(),
@@ -1116,6 +1126,14 @@ func (c *apiServerComponent) kubeControllerMgrTierGetterClusterRoleBinding() *rb
 func (c *apiServerComponent) calicoPolicyPassthruClusterRole() *rbacv1.ClusterRole {
 	resources := []string{"networkpolicies", "globalnetworkpolicies"}
 
+	// The aggregation API server authorizes reads against the tier.xxx resource type, so it can
+	// pass every verb through. In v3-CRD mode only writes reach the admission webhook, so reads
+	// stay subject to ordinary RBAC and roles must grant them explicitly.
+	verbs := allVerbs
+	if !c.cfg.RequiresAggregationServer {
+		verbs = writeVerbs
+	}
+
 	return &rbacv1.ClusterRole{
 		TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -1128,7 +1146,7 @@ func (c *apiServerComponent) calicoPolicyPassthruClusterRole() *rbacv1.ClusterRo
 			{
 				APIGroups: []string{"projectcalico.org"},
 				Resources: resources,
-				Verbs:     allVerbs,
+				Verbs:     verbs,
 			},
 		},
 	}

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -1124,7 +1124,7 @@ func (c *apiServerComponent) kubeControllerMgrTierGetterClusterRoleBinding() *rb
 // calicoPolicyPassthruClusterRole creates a clusterrole that is used to control the RBAC
 // mechanism for Calico tiered policy.
 func (c *apiServerComponent) calicoPolicyPassthruClusterRole() *rbacv1.ClusterRole {
-	resources := []string{"networkpolicies", "globalnetworkpolicies"}
+	resources := []string{"networkpolicies", "globalnetworkpolicies", "stagednetworkpolicies", "stagedglobalnetworkpolicies"}
 
 	// The aggregation API server authorizes reads against the tier.xxx resource type, so it can
 	// pass every verb through. In v3-CRD mode only writes reach the admission webhook, so reads

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -220,8 +220,11 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 		for _, rule := range cr.Rules {
 			tieredPolicyRules = append(tieredPolicyRules, rule.Resources...)
 		}
-		Expect(tieredPolicyRules).To(ContainElements("networkpolicies", "globalnetworkpolicies"))
-		Expect(tieredPolicyRules).ToNot(ContainElements("stagednetworkpolicies", "stagedglobalnetworkpolicies"))
+		// Staged policies are tiered in both variants, so they get the same passthrough.
+		Expect(tieredPolicyRules).To(ContainElements("networkpolicies", "globalnetworkpolicies",
+			"stagednetworkpolicies", "stagedglobalnetworkpolicies"))
+		// StagedKubernetesNetworkPolicy has no tier and is handled by ordinary RBAC.
+		Expect(tieredPolicyRules).ToNot(ContainElement("stagedkubernetesnetworkpolicies"))
 
 		// The aggregation API server authorizes reads itself, so the passthrough covers them too.
 		Expect(cr.Rules[0].Verbs).To(ContainElements("get", "list", "watch"))
@@ -265,7 +268,8 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 
 		cr := rtest.GetResource(resources, "calico-tiered-policy-passthrough", "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
 		Expect(cr.Rules).To(HaveLen(1))
-		Expect(cr.Rules[0].Resources).To(ConsistOf("networkpolicies", "globalnetworkpolicies"))
+		Expect(cr.Rules[0].Resources).To(ConsistOf("networkpolicies", "globalnetworkpolicies",
+			"stagednetworkpolicies", "stagedglobalnetworkpolicies"))
 
 		// Writes pass through to the admission webhook, which enforces the tier. Reads have no
 		// such hook, so they stay subject to ordinary RBAC.

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -222,6 +222,9 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 		}
 		Expect(tieredPolicyRules).To(ContainElements("networkpolicies", "globalnetworkpolicies"))
 		Expect(tieredPolicyRules).ToNot(ContainElements("stagednetworkpolicies", "stagedglobalnetworkpolicies"))
+
+		// The aggregation API server authorizes reads itself, so the passthrough covers them too.
+		Expect(cr.Rules[0].Verbs).To(ContainElements("get", "list", "watch"))
 	},
 		Entry("default cluster domain", dns.DefaultClusterDomain),
 		Entry("custom cluster domain", "custom-domain.internal"),
@@ -250,6 +253,26 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 		rtest.ExpectResourceInList(deleteResources, "calico-apiserver", "calico-system", "apps", "v1", "Deployment")
 		rtest.ExpectResourceInList(deleteResources, "calico-api", "calico-system", "", "v1", "Service")
 		rtest.ExpectResourceInList(deleteResources, "calico-apiserver", "calico-system", "policy", "v1", "PodDisruptionBudget")
+	})
+
+	It("should render a write-only tiered policy passthrough in v3 CRD mode", func() {
+		cfg.RequiresAggregationServer = false
+
+		component, err := render.APIServer(cfg)
+		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
+		Expect(component.ResolveImages(nil)).To(BeNil())
+		resources, _ := apiServerObjects(component)
+
+		cr := rtest.GetResource(resources, "calico-tiered-policy-passthrough", "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
+		Expect(cr.Rules).To(HaveLen(1))
+		Expect(cr.Rules[0].Resources).To(ConsistOf("networkpolicies", "globalnetworkpolicies"))
+
+		// Writes pass through to the admission webhook, which enforces the tier. Reads have no
+		// such hook, so they stay subject to ordinary RBAC.
+		Expect(cr.Rules[0].Verbs).To(ConsistOf("create", "update", "patch", "delete", "deletecollection"))
+		Expect(cr.Rules[0].Verbs).NotTo(ContainElements("get", "list", "watch"))
+
+		rtest.ExpectResourceInList(resources, "calico-tiered-policy-passthrough", "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding")
 	})
 
 	It("should not register the aggregation APIService when not requiring the aggregation server", func() {


### PR DESCRIPTION
The tiered policy passthrough is only rendered when running the aggregation API server, so on clusters serving the Calico v3 API through CRDs nothing grants the policy resources themselves and every tier-scoped role is denied on all verbs. This renders it in both modes: all verbs under the aggregation API server as before, writes only in v3 CRD mode, where writes reach the tiered policy admission webhook and reads stay subject to ordinary RBAC.

The second commit moves staged policies into the base role. They are tiered in Calico as well as Enterprise and the admission webhook gates them in both, but the passthrough listed them for Enterprise only, which dates back to the two roles being merged in #4017.

```release-note
Fixes tier-scoped policy roles being denied all access on clusters serving the Calico v3 API through CRDs.
```

```release-note
Fixes staged network policy writes being denied for tier-scoped roles in Calico.
```
