### PR TITLE
[release-v1.42] fix(apiserver): allow queryserver egress to Linseed via guardian on managed clusters

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -598,6 +598,16 @@ func calicoSystemAPIServerPolicy(cfg *APIServerConfiguration) *v3.NetworkPolicy 
 		},
 	}...)
 
+	// A managed cluster has no local Linseed; the query server reaches it through Guardian,
+	// matching the LINSEED_URL that LinseedEndpoint returns.
+	if cfg.ManagementClusterConnection != nil {
+		egressRules = append(egressRules, v3.Rule{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: GuardianEntityRule,
+		})
+	}
+
 	if cfg.KeyValidatorConfig != nil {
 		if parsedURL, err := url.Parse(cfg.KeyValidatorConfig.Issuer()); err == nil {
 			oidcEgressRule := networkpolicy.GetOIDCEgressRule(parsedURL)

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -63,6 +63,8 @@ import (
 var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 	apiServerPolicy := testutils.GetExpectedPolicyFromFile("./testutils/expected_policies/apiserver.json")
 	apiServerPolicyForOCP := testutils.GetExpectedPolicyFromFile("./testutils/expected_policies/apiserver_ocp.json")
+	apiServerPolicyForManaged := testutils.GetExpectedPolicyFromFile("./testutils/expected_policies/apiserver_managed.json")
+	apiServerPolicyForManagedOCP := testutils.GetExpectedPolicyFromFile("./testutils/expected_policies/apiserver_managed_ocp.json")
 	var (
 		instance           *operatorv1.InstallationSpec
 		apiserver          *operatorv1.APIServerSpec
@@ -852,6 +854,33 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 		}))
 	})
 
+	It("should allow egress to Guardian on a managed cluster", func() {
+		cfg.ManagementClusterConnection = &operatorv1.ManagementClusterConnection{}
+
+		component := render.APIServerPolicy(cfg)
+		resources, _ := component.Objects()
+		policyName := types.NamespacedName{Name: "calico-system.apiserver-access", Namespace: "calico-system"}
+		policy := testutils.GetCalicoSystemPolicyFromResources(policyName, resources)
+		Expect(policy).ToNot(BeNil())
+		Expect(policy.Spec.Egress).To(ContainElement(calicov3.Rule{
+			Action:      calicov3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: render.GuardianEntityRule,
+		}))
+		// The rule is only reached if it precedes the trailing Pass.
+		n := len(policy.Spec.Egress)
+		Expect(policy.Spec.Egress[n-1].Action).To(Equal(calicov3.Pass))
+	})
+
+	It("should omit the Guardian egress rule when the cluster is not managed", func() {
+		component := render.APIServerPolicy(cfg)
+		resources, _ := component.Objects()
+		policyName := types.NamespacedName{Name: "calico-system.apiserver-access", Namespace: "calico-system"}
+		policy := testutils.GetCalicoSystemPolicyFromResources(policyName, resources)
+		Expect(policy).ToNot(BeNil())
+		Expect(policy.Spec.Egress).NotTo(ContainElement(HaveField("Destination", render.GuardianEntityRule)))
+	})
+
 	It("should add egress policy with Enterprise variant and K8SServiceEndpoint as IP defined", func() {
 		cfg.K8SServiceEndpoint.Host = "169.169.169.169"
 		cfg.K8SServiceEndpoint.Port = "4321"
@@ -1204,7 +1233,15 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 				resources, _ := component.Objects()
 
 				policy := testutils.GetCalicoSystemPolicyFromResources(policyName, resources)
-				expectedPolicy := testutils.SelectPolicyByProvider(scenario, apiServerPolicy, apiServerPolicyForOCP)
+				expectedPolicy := testutils.SelectPolicyByClusterTypeAndProvider(
+					scenario,
+					map[string]*calicov3.NetworkPolicy{
+						"unmanaged":           apiServerPolicy,
+						"unmanaged-openshift": apiServerPolicyForOCP,
+						"managed":             apiServerPolicyForManaged,
+						"managed-openshift":   apiServerPolicyForManagedOCP,
+					},
+				)
 				Expect(policy).To(Equal(expectedPolicy))
 			},
 			Entry("for management/standalone, kube-dns", testutils.CalicoSystemScenario{ManagedCluster: false, OpenShift: false}),

--- a/pkg/render/testutils/expected_policies/apiserver_managed.json
+++ b/pkg/render/testutils/expected_policies/apiserver_managed.json
@@ -1,0 +1,123 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "calico-system.apiserver-access",
+    "namespace": "calico-system"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "calico-system",
+    "selector": "k8s-app == 'calico-apiserver'",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "nets": [
+            "0.0.0.0/0"
+          ]
+        },
+        "destination": {
+          "ports": [
+            443,
+            5443,
+            8080,
+            10443
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "nets": [
+            "::/0"
+          ]
+        },
+        "destination": {
+          "ports": [
+            443,
+            5443,
+            8080,
+            10443
+          ]
+        }
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "selector": "k8s-app in { 'kube-dns', 'coredns' }",
+          "ports": [
+            53
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "services": {
+            "name": "kubernetes",
+            "namespace": "default"
+          }
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-prometheus'",
+          "selector": "k8s-app == 'tigera-prometheus'",
+          "ports": [
+            9095
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "selector": "k8s-app == 'tigera-dex'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-dex'",
+          "ports": [
+            5556
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "selector": "k8s-app == 'tigera-linseed'",
+          "ports": [
+            8444
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'calico-system'",
+          "selector": "k8s-app == 'guardian'",
+          "ports": [
+            8080
+          ]
+        }
+      },
+      {
+        "action": "Pass"
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/apiserver_managed_ocp.json
+++ b/pkg/render/testutils/expected_policies/apiserver_managed_ocp.json
@@ -1,0 +1,134 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "calico-system.apiserver-access",
+    "namespace": "calico-system"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "calico-system",
+    "selector": "k8s-app == 'calico-apiserver'",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "nets": [
+            "0.0.0.0/0"
+          ]
+        },
+        "destination": {
+          "ports": [
+            443,
+            5443,
+            8080,
+            10443
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "nets": [
+            "::/0"
+          ]
+        },
+        "destination": {
+          "ports": [
+            443,
+            5443,
+            8080,
+            10443
+          ]
+        }
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "services": {
+            "name": "kubernetes",
+            "namespace": "default"
+          }
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-prometheus'",
+          "selector": "k8s-app == 'tigera-prometheus'",
+          "ports": [
+            9095
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "selector": "k8s-app == 'tigera-dex'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-dex'",
+          "ports": [
+            5556
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "selector": "k8s-app == 'tigera-linseed'",
+          "ports": [
+            8444
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'calico-system'",
+          "selector": "k8s-app == 'guardian'",
+          "ports": [
+            8080
+          ]
+        }
+      },
+      {
+        "action": "Pass"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Description

Cherry-pick of #5240.

A managed cluster runs no local Linseed, so the query server reaches it through guardian —
the URL `LinseedEndpoint` returns as `LINSEED_URL`. The `calico-system.apiserver-access`
policy permitted only the local Linseed pods, whose selector matches nothing on a managed
cluster, so the connection fell through to the policy's trailing `Pass`. The `calico-system`
tier's default-deny excludes `calico-apiserver` by design, so the traffic is then evaluated
against the customer's tiers, where any default-deny drops it. The Manager policy board
renders empty and policy activity requests return 500.

This branch predates the `pkg/enterprise/apiserver` extension mechanism (#4871), so the rule
is branched directly in `calicoSystemAPIServerPolicy` on `cfg.ManagementClusterConnection` —
the same condition `LINSEED_URL` already uses a few hundred lines away in the same file.

The `calico-system` policy table already had `for managed` entries, but
`SelectPolicyByProvider` only switches on the provider, so both managed cases were asserting
the unmanaged fixture and could not have caught this. The table now uses
`SelectPolicyByClusterTypeAndProvider` against new `apiserver_managed.json` and
`apiserver_managed_ocp.json` fixtures.

The inert local-Linseed rule is left in place. It selects no pods on a managed cluster, so it
is harmless, and removing it would churn the base fixtures across every backport branch.

`release-v1.41` (CE v3.23.0-1.0) carries neither the egress rule nor `LINSEED_URL`, so the
affected range starts here.

Addresses CI-2048.

### Testing

Verified on a live managed cluster on the master change (#5240): with the customer's
default-deny in a tier after `calico-system`, the original operator returned the reported 500
on `GET /policies` after a 19.5s guardian timeout, and the fixed operator returned 200 in
0.58s with the `calico-system` tier present. The deny stayed applied across both runs and only
the operator image changed.

On this branch: full `pkg/render` suite green, `make static-checks` reports 0 issues, and new
specs cover the rule being rendered ahead of the trailing `Pass` on a managed cluster and
absent otherwise.

## Release Note

```release-note
Fixed the Manager policy board rendering empty on managed clusters, where the query server was not permitted egress to Linseed through guardian.
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
