### PR TITLE
[release-v1.43-2] fix(apiserver): allow queryserver egress to Linseed via guardian on managed clusters

### DIFF
--- a/pkg/imports/crds/enterprise/01-crd-eck-bundle.yaml
+++ b/pkg/imports/crds/enterprise/01-crd-eck-bundle.yaml
@@ -4,12 +4,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.1'
+    app.kubernetes.io/version: '3.5.0'
   name: agents.agent.k8s.elastic.co
 spec:
   group: agent.k8s.elastic.co
@@ -114,6 +114,8 @@ spec:
                 elasticsearchRefs:
                   items:
                     properties:
+                      clientCertificateSecretName:
+                        type: string
                       name:
                         type: string
                       namespace:
@@ -130,6 +132,8 @@ spec:
                   type: boolean
                 fleetServerRef:
                   properties:
+                    clientCertificateSecretName:
+                      type: string
                     name:
                       type: string
                     namespace:
@@ -263,6 +267,11 @@ spec:
                             secretName:
                               type: string
                           type: object
+                        client:
+                          properties:
+                            authentication:
+                              type: boolean
+                          type: object
                         selfSignedCertificate:
                           properties:
                             disabled:
@@ -299,6 +308,39 @@ spec:
                   type: string
                 policyID:
                   type: string
+                resources:
+                  properties:
+                    limits:
+                      properties:
+                        cpu:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        memory:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    requests:
+                      properties:
+                        cpu:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        memory:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                  type: object
                 revisionHistoryLimit:
                   format: int32
                   type: integer
@@ -323,6 +365,9 @@ spec:
                     type: object
                   type: array
                 serviceAccountName:
+                  type: string
+                spaceID:
+                  pattern: ^[a-z0-9_-]+$
                   type: string
                 statefulSet:
                   properties:
@@ -467,6 +512,23 @@ spec:
                 availableNodes:
                   format: int32
                   type: integer
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
                 elasticsearchAssociationsStatus:
                   additionalProperties:
                     type: string
@@ -497,12 +559,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.1'
+    app.kubernetes.io/version: '3.5.0'
   name: apmservers.apm.k8s.elastic.co
 spec:
   group: apm.k8s.elastic.co
@@ -550,6 +612,8 @@ spec:
                   type: integer
                 elasticsearchRef:
                   properties:
+                    clientCertificateSecretName:
+                      type: string
                     name:
                       type: string
                     namespace:
@@ -715,6 +779,39 @@ spec:
                 podTemplate:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
+                resources:
+                  properties:
+                    limits:
+                      properties:
+                        cpu:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        memory:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    requests:
+                      properties:
+                        cpu:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        memory:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                  type: object
                 revisionHistoryLimit:
                   format: int32
                   type: integer
@@ -750,6 +847,23 @@ spec:
                 availableNodes:
                   format: int32
                   type: integer
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
                 count:
                   format: int32
                   type: integer
@@ -1019,12 +1133,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.1'
+    app.kubernetes.io/version: '3.5.0'
   name: autoopsagentpolicies.autoops.k8s.elastic.co
 spec:
   group: autoops.k8s.elastic.co
@@ -1062,6 +1176,14 @@ spec:
             spec:
               properties:
                 autoOpsRef:
+                  properties:
+                    secretName:
+                      type: string
+                  type: object
+                config:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                configRef:
                   properties:
                     secretName:
                       type: string
@@ -1123,6 +1245,39 @@ spec:
                       type: object
                   type: object
                   x-kubernetes-map-type: atomic
+                resources:
+                  properties:
+                    limits:
+                      properties:
+                        cpu:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        memory:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    requests:
+                      properties:
+                        cpu:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        memory:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                  type: object
                 revisionHistoryLimit:
                   format: int32
                   type: integer
@@ -1135,6 +1290,23 @@ spec:
               type: object
             status:
               properties:
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
                 details:
                   additionalProperties:
                     properties:
@@ -1179,12 +1351,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.1'
+    app.kubernetes.io/version: '3.5.0'
   name: beats.beat.k8s.elastic.co
 spec:
   group: beat.k8s.elastic.co
@@ -1291,6 +1463,8 @@ spec:
                   type: object
                 elasticsearchRef:
                   properties:
+                    clientCertificateSecretName:
+                      type: string
                     name:
                       type: string
                     namespace:
@@ -1348,6 +1522,39 @@ spec:
                           type: array
                       type: object
                   type: object
+                resources:
+                  properties:
+                    limits:
+                      properties:
+                        cpu:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        memory:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    requests:
+                      properties:
+                        cpu:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        memory:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                  type: object
                 revisionHistoryLimit:
                   format: int32
                   type: integer
@@ -1388,6 +1595,23 @@ spec:
                 availableNodes:
                   format: int32
                   type: integer
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
                 elasticsearchAssociationStatus:
                   type: string
                 expectedNodes:
@@ -1418,12 +1642,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.1'
+    app.kubernetes.io/version: '3.5.0'
   name: elasticmapsservers.maps.k8s.elastic.co
 spec:
   group: maps.k8s.elastic.co
@@ -1476,6 +1700,8 @@ spec:
                   type: integer
                 elasticsearchRef:
                   properties:
+                    clientCertificateSecretName:
+                      type: string
                     name:
                       type: string
                     namespace:
@@ -1630,6 +1856,39 @@ spec:
                 podTemplate:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
+                resources:
+                  properties:
+                    limits:
+                      properties:
+                        cpu:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        memory:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    requests:
+                      properties:
+                        cpu:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        memory:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                  type: object
                 revisionHistoryLimit:
                   format: int32
                   type: integer
@@ -1647,6 +1906,23 @@ spec:
                 availableNodes:
                   format: int32
                   type: integer
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
                 count:
                   format: int32
                   type: integer
@@ -1675,12 +1951,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.1'
+    app.kubernetes.io/version: '3.5.0'
   name: elasticsearchautoscalers.autoscaling.k8s.elastic.co
 spec:
   group: autoscaling.k8s.elastic.co
@@ -1932,12 +2208,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.1'
+    app.kubernetes.io/version: '3.5.0'
   name: elasticsearches.elasticsearch.k8s.elastic.co
 spec:
   group: elasticsearch.k8s.elastic.co
@@ -2197,6 +2473,39 @@ spec:
                       podTemplate:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
+                      resources:
+                        properties:
+                          limits:
+                            properties:
+                              cpu:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            properties:
+                              cpu:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
                       volumeClaimTemplates:
                         items:
                           properties:
@@ -3317,12 +3626,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.1'
+    app.kubernetes.io/version: '3.5.0'
   name: enterprisesearches.enterprisesearch.k8s.elastic.co
 spec:
   group: enterprisesearch.k8s.elastic.co
@@ -3375,6 +3684,8 @@ spec:
                   type: integer
                 elasticsearchRef:
                   properties:
+                    clientCertificateSecretName:
+                      type: string
                     name:
                       type: string
                     namespace:
@@ -3529,6 +3840,39 @@ spec:
                 podTemplate:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
+                resources:
+                  properties:
+                    limits:
+                      properties:
+                        cpu:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        memory:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    requests:
+                      properties:
+                        cpu:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        memory:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                  type: object
                 revisionHistoryLimit:
                   format: int32
                   type: integer
@@ -3544,6 +3888,23 @@ spec:
                 availableNodes:
                   format: int32
                   type: integer
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
                 count:
                   format: int32
                   type: integer
@@ -3772,6 +4133,23 @@ spec:
                 availableNodes:
                   format: int32
                   type: integer
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
                 count:
                   format: int32
                   type: integer
@@ -3795,12 +4173,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.1'
+    app.kubernetes.io/version: '3.5.0'
   name: kibanas.kibana.k8s.elastic.co
 spec:
   group: kibana.k8s.elastic.co
@@ -4059,6 +4437,39 @@ spec:
                 podTemplate:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
+                resources:
+                  properties:
+                    limits:
+                      properties:
+                        cpu:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        memory:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    requests:
+                      properties:
+                        cpu:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        memory:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                  type: object
                 revisionHistoryLimit:
                   format: int32
                   type: integer
@@ -4096,6 +4507,23 @@ spec:
                 availableNodes:
                   format: int32
                   type: integer
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
                 count:
                   format: int32
                   type: integer
@@ -4363,12 +4791,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.1'
+    app.kubernetes.io/version: '3.5.0'
   name: logstashes.logstash.k8s.elastic.co
 spec:
   group: logstash.k8s.elastic.co
@@ -4425,6 +4853,8 @@ spec:
                 elasticsearchRefs:
                   items:
                     properties:
+                      clientCertificateSecretName:
+                        type: string
                       clusterName:
                         minLength: 1
                         type: string
@@ -4490,6 +4920,39 @@ spec:
                 podTemplate:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
+                resources:
+                  properties:
+                    limits:
+                      properties:
+                        cpu:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        memory:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    requests:
+                      properties:
+                        cpu:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        memory:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                  type: object
                 revisionHistoryLimit:
                   format: int32
                   type: integer
@@ -4868,6 +5331,23 @@ spec:
                 availableNodes:
                   format: int32
                   type: integer
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
                 elasticsearchAssociationsStatus:
                   additionalProperties:
                     type: string
@@ -4906,12 +5386,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.1'
+    app.kubernetes.io/version: '3.5.0'
   name: packageregistries.packageregistry.k8s.elastic.co
 spec:
   group: packageregistry.k8s.elastic.co
@@ -5107,6 +5587,39 @@ spec:
                 podTemplate:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
+                resources:
+                  properties:
+                    limits:
+                      properties:
+                        cpu:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        memory:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    requests:
+                      properties:
+                        cpu:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        memory:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                  type: object
                 revisionHistoryLimit:
                   format: int32
                   type: integer
@@ -5120,6 +5633,23 @@ spec:
                 availableNodes:
                   format: int32
                   type: integer
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
                 count:
                   format: int32
                   type: integer
@@ -5148,12 +5678,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: 'elastic-operator'
     app.kubernetes.io/name: 'eck-operator-crds'
-    app.kubernetes.io/version: '3.4.1'
+    app.kubernetes.io/version: '3.5.0'
   name: stackconfigpolicies.stackconfigpolicy.k8s.elastic.co
 spec:
   group: stackconfigpolicy.k8s.elastic.co
@@ -5251,6 +5781,9 @@ spec:
                     securityRoleMappings:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
+                    securityRoles:
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
                     snapshotLifecyclePolicies:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
@@ -5329,6 +5862,26 @@ spec:
                         type: string
                     required:
                       - secretName
+                    type: object
+                  type: array
+                variablesFrom:
+                  items:
+                    properties:
+                      kind:
+                        enum:
+                          - ConfigMap
+                          - Secret
+                        type: string
+                      name:
+                        minLength: 1
+                        type: string
+                      namespace:
+                        type: string
+                      optional:
+                        type: boolean
+                    required:
+                      - kind
+                      - name
                     type: object
                   type: array
                 weight:

--- a/pkg/imports/crds/enterprise/v1.crd.projectcalico.org/crd.projectcalico.org_ippools.yaml
+++ b/pkg/imports/crds/enterprise/v1.crd.projectcalico.org/crd.projectcalico.org_ippools.yaml
@@ -41,20 +41,23 @@ spec:
                 allowedUses:
                   description: |-
                     AllowedUses controls what the IP pool will be used for. If not specified or empty, defaults to
-                    ["Tunnel", "Workload"] for back-compatibility. Valid values: "Tunnel", "Workload", "LoadBalancer".
+                    ["Tunnel", "Workload"] for back-compatibility. Valid values: "Tunnel", "Workload", "LoadBalancer",
+                    "HostSecondaryInterface", "L2Workload".
                   items:
                     description: |-
                       IPPoolAllowedUse defines the allowed uses for an IP pool.
-                      It can be one of "Workload", "Tunnel", "LoadBalancer" or "HostSecondaryInterface".
+                      It can be one of "Workload", "Tunnel", "LoadBalancer", "HostSecondaryInterface" or "L2Workload".
                       - "Workload" means the pool is used for workload IP addresses.
                       - "Tunnel" means the pool is used for tunnel IP addresses.
                       - "LoadBalancer" means the pool is used for load balancer IP addresses.
                       - "HostSecondaryInterface" means the pool is used for host secondary interface IP addresses.
+                      - "L2Workload" means the pool is used for workloads attached to an L2 bridge Network.
                     enum:
                       - Workload
                       - Tunnel
                       - LoadBalancer
                       - HostSecondaryInterface
+                      - L2Workload
                     type: string
                   maxItems: 10
                   type: array
@@ -193,6 +196,24 @@ spec:
                     "!has(self.allowedUses) || !self.allowedUses.exists(u, u == 'Tunnel')
                     || !has(self.namespaceSelector) || size(self.namespaceSelector) ==
                     0"
+                - message: L2Workload cannot be combined with other allowed uses
+                  reason: FieldValueForbidden
+                  rule:
+                    "!has(self.allowedUses) || !self.allowedUses.exists(u, u == 'L2Workload')
+                    || !self.allowedUses.exists(u, u == 'Workload' || u == 'Tunnel'
+                    || u == 'LoadBalancer' || u == 'HostSecondaryInterface')"
+                - message: L2Workload IP pool cannot have IPIP or VXLAN enabled
+                  reason: FieldValueForbidden
+                  rule:
+                    "!has(self.allowedUses) || !self.allowedUses.exists(u, u == 'L2Workload')
+                    || (!has(self.ipipMode) || size(self.ipipMode) == 0 || self.ipipMode
+                    == 'Never') && (!has(self.vxlanMode) || size(self.vxlanMode) ==
+                    0 || self.vxlanMode == 'Never')"
+                - message: L2Workload IP pools must disable BGP export
+                  reason: FieldValueForbidden
+                  rule:
+                    "!has(self.allowedUses) || !self.allowedUses.exists(u, u == 'L2Workload')
+                    || (has(self.disableBGPExport) && self.disableBGPExport)"
                 - message: global() selector is not valid for IPPool nodeSelector
                   reason: FieldValueInvalid
                   rule: "!has(self.nodeSelector) || !self.nodeSelector.contains('global(')"

--- a/pkg/imports/crds/enterprise/v1.crd.projectcalico.org/crd.projectcalico.org_networks.yaml
+++ b/pkg/imports/crds/enterprise/v1.crd.projectcalico.org/crd.projectcalico.org_networks.yaml
@@ -38,10 +38,301 @@ spec:
             spec:
               description: |-
                 NetworkSpec contains the specification for a Network resource.  Exactly one of the
-                network-type fields (vrf, ...) must be set.
+                network-type fields (vrf, l2Bridge, ...) must be set.  The network type is immutable
+                after creation: a Network cannot be switched between types (e.g. vrf to l2Bridge).
               maxProperties: 1
               minProperties: 1
               properties:
+                l2Bridge:
+                  description: |-
+                    L2Bridge configures a Layer 2 bridged network.  A Linux bridge on each
+                    participating node connects workload interfaces to VLAN segments
+                    carried by physical trunk interfaces.  See L2BridgeSpec.
+                  properties:
+                    hostConfig:
+                      description: |-
+                        HostConfig defines per-node-group configuration for this network.
+                        When multiple entries are present, the first entry whose
+                        nodeSelector matches a given node is used; all other entries are
+                        ignored for that node.  Entries with no nodeSelector match all
+                        nodes.
+                      items:
+                        description: |-
+                          L2HostConfig provides node-specific L2 bridge settings.  Different nodes
+                          may have different bridge types or trunk interface names; each entry
+                          applies to the nodes matched by its NodeSelector (first-match wins).
+                        properties:
+                          bridge:
+                            description: |-
+                              Bridge selects the bridge device for these nodes: either a
+                              Calico-managed bridge or a pre-existing (BYO) bridge.
+                            maxProperties: 1
+                            minProperties: 1
+                            properties:
+                              existingBridge:
+                                description: |-
+                                  ExistingBridge instructs Calico to attach to a pre-existing bridge
+                                  created and managed externally (e.g. via netplan).  Calico does
+                                  not create, reconfigure, or delete the bridge; it does not add or
+                                  remove IP addresses on it; and it does not remove interfaces it
+                                  did not create.  Calico still attaches workload veths, configures
+                                  their VLAN membership, and connects trunk interfaces (if
+                                  hostConnections is specified) unless the trunk is already
+                                  connected.
+                                properties:
+                                  name:
+                                    description:
+                                      Name is the Linux bridge device name
+                                      (e.g. "br0").
+                                    maxLength: 15
+                                    minLength: 1
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                                x-kubernetes-validations:
+                                  - message:
+                                      "name must not start with calb- or calq-:
+                                      those prefixes are reserved for devices Calico creates
+                                      and deletes"
+                                    rule: "!self.name.startsWith('calb-') && !self.name.startsWith('calq-')"
+                              managedBridge:
+                                description: |-
+                                  ManagedBridge instructs Calico to create and fully manage the
+                                  bridge device.  The bridge name is derived automatically from the
+                                  Network name so it does not clash with other Networks or with
+                                  Calico workload veth names.
+                                properties:
+                                  stp:
+                                    default: Disabled
+                                    description: |-
+                                      STP controls whether Spanning Tree Protocol is active on the
+                                      bridge.  "Disabled" (default) is appropriate for datacenter
+                                      topologies where loop prevention is handled by the upstream
+                                      switch; "Enabled" causes the bridge to exchange BPDU frames on
+                                      trunk ports.  Workload veth ports always operate in edge/portfast
+                                      mode regardless of this setting — they never participate in STP.
+                                    enum:
+                                      - Enabled
+                                      - Disabled
+                                    type: string
+                                type: object
+                            type: object
+                          hostConnections:
+                            description: |-
+                              HostConnections defines how the bridge connects to the physical
+                              network on these nodes.  Each entry is a typed connection
+                              (currently only trunkPort).  If omitted, no trunk is attached by
+                              Calico — the user is responsible for providing external
+                              connectivity (e.g. on a BYO bridge with a pre-configured trunk).
+                            items:
+                              description: |-
+                                L2HostConnection defines a single host-side connection to the bridge.
+                                Exactly one connection type must be set.
+                              maxProperties: 1
+                              minProperties: 1
+                              properties:
+                                trunkPort:
+                                  description: |-
+                                    TrunkPort enslaves a host interface to the bridge as an 802.1Q
+                                    trunk.
+                                  properties:
+                                    interface:
+                                      description: |-
+                                        Interface identifies the trunk interface on this node group.
+                                        Heterogeneous clusters use separate HostConfig entries with
+                                        different NodeSelectors rather than per-rule selectors.
+                                      maxProperties: 1
+                                      minProperties: 1
+                                      properties:
+                                        name:
+                                          description: |-
+                                            Name matches a network interface by its exact device name
+                                            (e.g. "bond0", "eth1", "ens192").
+                                          maxLength: 15
+                                          minLength: 1
+                                          type: string
+                                      type: object
+                                    nativeVLAN:
+                                      description: |-
+                                        NativeVLAN, when set, designates one VLAN ID as the trunk's native
+                                        VLAN: frames in that VLAN are sent untagged on the wire and
+                                        untagged frames received on the trunk are tagged with this VLAN.
+                                        This should be one of the VLAN IDs the trunk carries (i.e. present
+                                        in spec.vlans); if it names a VLAN the trunk does not carry it is
+                                        ignored and the trunk stays strictly tagged for every VLAN.  When
+                                        unset (default) the trunk is strictly tagged: only 802.1Q-tagged
+                                        frames are accepted and transmitted.
+                                      maximum: 4094
+                                      minimum: 1
+                                      type: integer
+                                  required:
+                                    - interface
+                                  type: object
+                                  x-kubernetes-validations:
+                                    - message: nativeVLAN must be between 1 and 4094
+                                      rule:
+                                        "!has(self.nativeVLAN) || self.nativeVLAN
+                                        >= 1 && self.nativeVLAN <= 4094"
+                              type: object
+                            maxItems: 1
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          nodeSelector:
+                            default: ""
+                            description: |-
+                              NodeSelector is a Calico selector expression that determines which
+                              nodes this configuration applies to.  If omitted, the entry
+                              applies to all nodes.  When multiple HostConfig entries are
+                              present, the first entry whose selector matches a given node wins;
+                              subsequent entries are ignored for that node.
+                            type: string
+                        required:
+                          - bridge
+                        type: object
+                      maxItems: 100
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - nodeSelector
+                      x-kubernetes-list-type: map
+                    vlans:
+                      description: |-
+                        VLANs is the authoritative list of 802.1Q VLAN segments carried by
+                        this network.  Each entry defines a single VLAN ID or a contiguous
+                        range of VLAN IDs, plus the subnets associated with that segment.
+
+                        The set of VLAN IDs the network may carry is the union of all IDs and
+                        ranges in this list.  Entries are not required to be disjoint: if the
+                        same VLAN ID appears in more than one entry the network still simply
+                        carries that VLAN, so overlap is permitted and not validated here.
+
+                        Workload attachments select a single entry via the CNI config
+                        "vlan" field; if spec.vlans has exactly one entry that resolves to
+                        a single VLAN ID, the CNI config "vlan" field may be omitted.
+                      items:
+                        description:
+                          L2VLANSpec defines a VLAN segment and its optional
+                          IP configuration.
+                        properties:
+                          subnets:
+                            description: |-
+                              Subnets are the IP subnets for this VLAN segment.  They filter which
+                              IPPools the IPAM plugin considers for this VLAN (only pools that fall
+                              within one of these subnets are eligible) and supply the prefix
+                              length programmed on the pod interface.  Multiple entries support
+                              dual-stack or multi-subnet VLANs.
+
+                              IPAM allocates the address from the eligible pools without preferring
+                              any particular subnet; the allocated address then falls within
+                              exactly one of these subnets, and that subnet's CIDR prefix length is
+                              the one programmed on the pod interface.  For a dual-stack VLAN this
+                              resolves independently per family (one IPv4 and one IPv6 subnet).
+                            items:
+                              description:
+                                L2Subnet defines an IP subnet associated
+                                with a VLAN segment.
+                              properties:
+                                cidr:
+                                  description: |-
+                                    CIDR is the subnet in CIDR notation (e.g. "10.100.0.0/24",
+                                    "fd00::/64").
+                                  type: string
+                                routes:
+                                  description: |-
+                                    Routes are programmed inside the pod's per-interface routing table
+                                    for workloads attached to this subnet, in addition to the connected
+                                    route for CIDR itself.  Each next hop must be an L2 neighbor on this
+                                    subnet, reachable via the bridge; routes are installed onlink.  The
+                                    common "default gateway" case is a single entry with destination
+                                    "0.0.0.0/0" (or "::/0") whose nextHop is the upstream router.
+                                  items:
+                                    description: |-
+                                      L2Route defines a route programmed in a pod's per-interface routing table
+                                      for an L2 bridge subnet.  Parallel to VRFStaticRoute, but with its own
+                                      action type so L2 and VRF route semantics can evolve independently.
+                                    properties:
+                                      action:
+                                        description: |-
+                                          Action determines how traffic matching this route is handled.
+                                          Exactly one action field must be set.
+                                        maxProperties: 1
+                                        minProperties: 1
+                                        properties:
+                                          nextHop:
+                                            description: |-
+                                              NextHop forwards matching traffic to the specified gateway IP.  The
+                                              address must be an L2 neighbor on this subnet, reachable via the
+                                              bridge; the route is installed onlink.
+                                            type: string
+                                        type: object
+                                      destination:
+                                        description: |-
+                                          Destination is the CIDR prefix for this route.  Use "0.0.0.0/0" or
+                                          "::/0" for a default route.
+                                        type: string
+                                    required:
+                                      - action
+                                      - destination
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - destination
+                                  x-kubernetes-list-type: map
+                              required:
+                                - cidr
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          vlan:
+                            description: |-
+                              VLAN identifies this segment: a single VLAN ID or a contiguous
+                              range of VLAN IDs.
+                            maxProperties: 1
+                            minProperties: 1
+                            properties:
+                              id:
+                                description: ID selects a single 802.1Q VLAN (1-4094).
+                                maximum: 4094
+                                minimum: 1
+                                type: integer
+                              range:
+                                description:
+                                  Range selects a contiguous range of VLAN
+                                  IDs (inclusive).
+                                properties:
+                                  end:
+                                    description:
+                                      End is the last VLAN ID in the range
+                                      (1-4094, must be ≥ Start).
+                                    maximum: 4094
+                                    minimum: 1
+                                    type: integer
+                                  start:
+                                    description:
+                                      Start is the first VLAN ID in the range
+                                      (1-4094).
+                                    maximum: 4094
+                                    minimum: 1
+                                    type: integer
+                                required:
+                                  - end
+                                  - start
+                                type: object
+                                x-kubernetes-validations:
+                                  - message: start must be <= end
+                                    rule: self.start <= self.end
+                            type: object
+                        required:
+                          - vlan
+                        type: object
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  required:
+                    - hostConfig
+                    - vlans
+                  type: object
                 vrf:
                   description: |-
                     VRF network configuration.
@@ -169,6 +460,13 @@ spec:
                     - hostConfig
                   type: object
               type: object
+              x-kubernetes-validations:
+                - message: Cannot change the network type (vrf is immutable after creation)
+                  rule: has(self.vrf) == has(oldSelf.vrf)
+                - message:
+                    Cannot change the network type (l2Bridge is immutable after
+                    creation)
+                  rule: has(self.l2Bridge) == has(oldSelf.l2Bridge)
             status:
               description: NetworkStatus reports the observed state of the Network resource.
               properties:

--- a/pkg/imports/crds/enterprise/v3.projectcalico.org/projectcalico.org_ippools.yaml
+++ b/pkg/imports/crds/enterprise/v3.projectcalico.org/projectcalico.org_ippools.yaml
@@ -66,20 +66,23 @@ spec:
                 allowedUses:
                   description: |-
                     AllowedUses controls what the IP pool will be used for. If not specified or empty, defaults to
-                    ["Tunnel", "Workload"] for back-compatibility. Valid values: "Tunnel", "Workload", "LoadBalancer".
+                    ["Tunnel", "Workload"] for back-compatibility. Valid values: "Tunnel", "Workload", "LoadBalancer",
+                    "HostSecondaryInterface", "L2Workload".
                   items:
                     description: |-
                       IPPoolAllowedUse defines the allowed uses for an IP pool.
-                      It can be one of "Workload", "Tunnel", "LoadBalancer" or "HostSecondaryInterface".
+                      It can be one of "Workload", "Tunnel", "LoadBalancer", "HostSecondaryInterface" or "L2Workload".
                       - "Workload" means the pool is used for workload IP addresses.
                       - "Tunnel" means the pool is used for tunnel IP addresses.
                       - "LoadBalancer" means the pool is used for load balancer IP addresses.
                       - "HostSecondaryInterface" means the pool is used for host secondary interface IP addresses.
+                      - "L2Workload" means the pool is used for workloads attached to an L2 bridge Network.
                     enum:
                       - Workload
                       - Tunnel
                       - LoadBalancer
                       - HostSecondaryInterface
+                      - L2Workload
                     type: string
                   maxItems: 10
                   type: array
@@ -218,6 +221,24 @@ spec:
                     "!has(self.allowedUses) || !self.allowedUses.exists(u, u == 'Tunnel')
                     || !has(self.namespaceSelector) || size(self.namespaceSelector) ==
                     0"
+                - message: L2Workload cannot be combined with other allowed uses
+                  reason: FieldValueForbidden
+                  rule:
+                    "!has(self.allowedUses) || !self.allowedUses.exists(u, u == 'L2Workload')
+                    || !self.allowedUses.exists(u, u == 'Workload' || u == 'Tunnel'
+                    || u == 'LoadBalancer' || u == 'HostSecondaryInterface')"
+                - message: L2Workload IP pool cannot have IPIP or VXLAN enabled
+                  reason: FieldValueForbidden
+                  rule:
+                    "!has(self.allowedUses) || !self.allowedUses.exists(u, u == 'L2Workload')
+                    || (!has(self.ipipMode) || size(self.ipipMode) == 0 || self.ipipMode
+                    == 'Never') && (!has(self.vxlanMode) || size(self.vxlanMode) ==
+                    0 || self.vxlanMode == 'Never')"
+                - message: L2Workload IP pools must disable BGP export
+                  reason: FieldValueForbidden
+                  rule:
+                    "!has(self.allowedUses) || !self.allowedUses.exists(u, u == 'L2Workload')
+                    || (has(self.disableBGPExport) && self.disableBGPExport)"
                 - message: global() selector is not valid for IPPool nodeSelector
                   reason: FieldValueInvalid
                   rule: "!has(self.nodeSelector) || !self.nodeSelector.contains('global(')"

--- a/pkg/imports/crds/enterprise/v3.projectcalico.org/projectcalico.org_networks.yaml
+++ b/pkg/imports/crds/enterprise/v3.projectcalico.org/projectcalico.org_networks.yaml
@@ -42,10 +42,301 @@ spec:
             spec:
               description: |-
                 NetworkSpec contains the specification for a Network resource.  Exactly one of the
-                network-type fields (vrf, ...) must be set.
+                network-type fields (vrf, l2Bridge, ...) must be set.  The network type is immutable
+                after creation: a Network cannot be switched between types (e.g. vrf to l2Bridge).
               maxProperties: 1
               minProperties: 1
               properties:
+                l2Bridge:
+                  description: |-
+                    L2Bridge configures a Layer 2 bridged network.  A Linux bridge on each
+                    participating node connects workload interfaces to VLAN segments
+                    carried by physical trunk interfaces.  See L2BridgeSpec.
+                  properties:
+                    hostConfig:
+                      description: |-
+                        HostConfig defines per-node-group configuration for this network.
+                        When multiple entries are present, the first entry whose
+                        nodeSelector matches a given node is used; all other entries are
+                        ignored for that node.  Entries with no nodeSelector match all
+                        nodes.
+                      items:
+                        description: |-
+                          L2HostConfig provides node-specific L2 bridge settings.  Different nodes
+                          may have different bridge types or trunk interface names; each entry
+                          applies to the nodes matched by its NodeSelector (first-match wins).
+                        properties:
+                          bridge:
+                            description: |-
+                              Bridge selects the bridge device for these nodes: either a
+                              Calico-managed bridge or a pre-existing (BYO) bridge.
+                            maxProperties: 1
+                            minProperties: 1
+                            properties:
+                              existingBridge:
+                                description: |-
+                                  ExistingBridge instructs Calico to attach to a pre-existing bridge
+                                  created and managed externally (e.g. via netplan).  Calico does
+                                  not create, reconfigure, or delete the bridge; it does not add or
+                                  remove IP addresses on it; and it does not remove interfaces it
+                                  did not create.  Calico still attaches workload veths, configures
+                                  their VLAN membership, and connects trunk interfaces (if
+                                  hostConnections is specified) unless the trunk is already
+                                  connected.
+                                properties:
+                                  name:
+                                    description:
+                                      Name is the Linux bridge device name
+                                      (e.g. "br0").
+                                    maxLength: 15
+                                    minLength: 1
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                                x-kubernetes-validations:
+                                  - message:
+                                      "name must not start with calb- or calq-:
+                                      those prefixes are reserved for devices Calico creates
+                                      and deletes"
+                                    rule: "!self.name.startsWith('calb-') && !self.name.startsWith('calq-')"
+                              managedBridge:
+                                description: |-
+                                  ManagedBridge instructs Calico to create and fully manage the
+                                  bridge device.  The bridge name is derived automatically from the
+                                  Network name so it does not clash with other Networks or with
+                                  Calico workload veth names.
+                                properties:
+                                  stp:
+                                    default: Disabled
+                                    description: |-
+                                      STP controls whether Spanning Tree Protocol is active on the
+                                      bridge.  "Disabled" (default) is appropriate for datacenter
+                                      topologies where loop prevention is handled by the upstream
+                                      switch; "Enabled" causes the bridge to exchange BPDU frames on
+                                      trunk ports.  Workload veth ports always operate in edge/portfast
+                                      mode regardless of this setting — they never participate in STP.
+                                    enum:
+                                      - Enabled
+                                      - Disabled
+                                    type: string
+                                type: object
+                            type: object
+                          hostConnections:
+                            description: |-
+                              HostConnections defines how the bridge connects to the physical
+                              network on these nodes.  Each entry is a typed connection
+                              (currently only trunkPort).  If omitted, no trunk is attached by
+                              Calico — the user is responsible for providing external
+                              connectivity (e.g. on a BYO bridge with a pre-configured trunk).
+                            items:
+                              description: |-
+                                L2HostConnection defines a single host-side connection to the bridge.
+                                Exactly one connection type must be set.
+                              maxProperties: 1
+                              minProperties: 1
+                              properties:
+                                trunkPort:
+                                  description: |-
+                                    TrunkPort enslaves a host interface to the bridge as an 802.1Q
+                                    trunk.
+                                  properties:
+                                    interface:
+                                      description: |-
+                                        Interface identifies the trunk interface on this node group.
+                                        Heterogeneous clusters use separate HostConfig entries with
+                                        different NodeSelectors rather than per-rule selectors.
+                                      maxProperties: 1
+                                      minProperties: 1
+                                      properties:
+                                        name:
+                                          description: |-
+                                            Name matches a network interface by its exact device name
+                                            (e.g. "bond0", "eth1", "ens192").
+                                          maxLength: 15
+                                          minLength: 1
+                                          type: string
+                                      type: object
+                                    nativeVLAN:
+                                      description: |-
+                                        NativeVLAN, when set, designates one VLAN ID as the trunk's native
+                                        VLAN: frames in that VLAN are sent untagged on the wire and
+                                        untagged frames received on the trunk are tagged with this VLAN.
+                                        This should be one of the VLAN IDs the trunk carries (i.e. present
+                                        in spec.vlans); if it names a VLAN the trunk does not carry it is
+                                        ignored and the trunk stays strictly tagged for every VLAN.  When
+                                        unset (default) the trunk is strictly tagged: only 802.1Q-tagged
+                                        frames are accepted and transmitted.
+                                      maximum: 4094
+                                      minimum: 1
+                                      type: integer
+                                  required:
+                                    - interface
+                                  type: object
+                                  x-kubernetes-validations:
+                                    - message: nativeVLAN must be between 1 and 4094
+                                      rule:
+                                        "!has(self.nativeVLAN) || self.nativeVLAN
+                                        >= 1 && self.nativeVLAN <= 4094"
+                              type: object
+                            maxItems: 1
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          nodeSelector:
+                            default: ""
+                            description: |-
+                              NodeSelector is a Calico selector expression that determines which
+                              nodes this configuration applies to.  If omitted, the entry
+                              applies to all nodes.  When multiple HostConfig entries are
+                              present, the first entry whose selector matches a given node wins;
+                              subsequent entries are ignored for that node.
+                            type: string
+                        required:
+                          - bridge
+                        type: object
+                      maxItems: 100
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - nodeSelector
+                      x-kubernetes-list-type: map
+                    vlans:
+                      description: |-
+                        VLANs is the authoritative list of 802.1Q VLAN segments carried by
+                        this network.  Each entry defines a single VLAN ID or a contiguous
+                        range of VLAN IDs, plus the subnets associated with that segment.
+
+                        The set of VLAN IDs the network may carry is the union of all IDs and
+                        ranges in this list.  Entries are not required to be disjoint: if the
+                        same VLAN ID appears in more than one entry the network still simply
+                        carries that VLAN, so overlap is permitted and not validated here.
+
+                        Workload attachments select a single entry via the CNI config
+                        "vlan" field; if spec.vlans has exactly one entry that resolves to
+                        a single VLAN ID, the CNI config "vlan" field may be omitted.
+                      items:
+                        description:
+                          L2VLANSpec defines a VLAN segment and its optional
+                          IP configuration.
+                        properties:
+                          subnets:
+                            description: |-
+                              Subnets are the IP subnets for this VLAN segment.  They filter which
+                              IPPools the IPAM plugin considers for this VLAN (only pools that fall
+                              within one of these subnets are eligible) and supply the prefix
+                              length programmed on the pod interface.  Multiple entries support
+                              dual-stack or multi-subnet VLANs.
+
+                              IPAM allocates the address from the eligible pools without preferring
+                              any particular subnet; the allocated address then falls within
+                              exactly one of these subnets, and that subnet's CIDR prefix length is
+                              the one programmed on the pod interface.  For a dual-stack VLAN this
+                              resolves independently per family (one IPv4 and one IPv6 subnet).
+                            items:
+                              description:
+                                L2Subnet defines an IP subnet associated
+                                with a VLAN segment.
+                              properties:
+                                cidr:
+                                  description: |-
+                                    CIDR is the subnet in CIDR notation (e.g. "10.100.0.0/24",
+                                    "fd00::/64").
+                                  type: string
+                                routes:
+                                  description: |-
+                                    Routes are programmed inside the pod's per-interface routing table
+                                    for workloads attached to this subnet, in addition to the connected
+                                    route for CIDR itself.  Each next hop must be an L2 neighbor on this
+                                    subnet, reachable via the bridge; routes are installed onlink.  The
+                                    common "default gateway" case is a single entry with destination
+                                    "0.0.0.0/0" (or "::/0") whose nextHop is the upstream router.
+                                  items:
+                                    description: |-
+                                      L2Route defines a route programmed in a pod's per-interface routing table
+                                      for an L2 bridge subnet.  Parallel to VRFStaticRoute, but with its own
+                                      action type so L2 and VRF route semantics can evolve independently.
+                                    properties:
+                                      action:
+                                        description: |-
+                                          Action determines how traffic matching this route is handled.
+                                          Exactly one action field must be set.
+                                        maxProperties: 1
+                                        minProperties: 1
+                                        properties:
+                                          nextHop:
+                                            description: |-
+                                              NextHop forwards matching traffic to the specified gateway IP.  The
+                                              address must be an L2 neighbor on this subnet, reachable via the
+                                              bridge; the route is installed onlink.
+                                            type: string
+                                        type: object
+                                      destination:
+                                        description: |-
+                                          Destination is the CIDR prefix for this route.  Use "0.0.0.0/0" or
+                                          "::/0" for a default route.
+                                        type: string
+                                    required:
+                                      - action
+                                      - destination
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - destination
+                                  x-kubernetes-list-type: map
+                              required:
+                                - cidr
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          vlan:
+                            description: |-
+                              VLAN identifies this segment: a single VLAN ID or a contiguous
+                              range of VLAN IDs.
+                            maxProperties: 1
+                            minProperties: 1
+                            properties:
+                              id:
+                                description: ID selects a single 802.1Q VLAN (1-4094).
+                                maximum: 4094
+                                minimum: 1
+                                type: integer
+                              range:
+                                description:
+                                  Range selects a contiguous range of VLAN
+                                  IDs (inclusive).
+                                properties:
+                                  end:
+                                    description:
+                                      End is the last VLAN ID in the range
+                                      (1-4094, must be ≥ Start).
+                                    maximum: 4094
+                                    minimum: 1
+                                    type: integer
+                                  start:
+                                    description:
+                                      Start is the first VLAN ID in the range
+                                      (1-4094).
+                                    maximum: 4094
+                                    minimum: 1
+                                    type: integer
+                                required:
+                                  - end
+                                  - start
+                                type: object
+                                x-kubernetes-validations:
+                                  - message: start must be <= end
+                                    rule: self.start <= self.end
+                            type: object
+                        required:
+                          - vlan
+                        type: object
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  required:
+                    - hostConfig
+                    - vlans
+                  type: object
                 vrf:
                   description: |-
                     VRF network configuration.
@@ -173,6 +464,13 @@ spec:
                     - hostConfig
                   type: object
               type: object
+              x-kubernetes-validations:
+                - message: Cannot change the network type (vrf is immutable after creation)
+                  rule: has(self.vrf) == has(oldSelf.vrf)
+                - message:
+                    Cannot change the network type (l2Bridge is immutable after
+                    creation)
+                  rule: has(self.l2Bridge) == has(oldSelf.l2Bridge)
             status:
               description: NetworkStatus reports the observed state of the Network resource.
               properties:

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -565,6 +565,16 @@ func calicoSystemAPIServerPolicy(cfg *APIServerConfiguration) *v3.NetworkPolicy 
 		},
 	}...)
 
+	// A managed cluster has no local Linseed; the query server reaches it through Guardian,
+	// matching the LINSEED_URL that LinseedEndpoint returns.
+	if cfg.ManagementClusterConnection != nil {
+		egressRules = append(egressRules, v3.Rule{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: GuardianEntityRule,
+		})
+	}
+
 	if cfg.KeyValidatorConfig != nil {
 		if parsedURL, err := url.Parse(cfg.KeyValidatorConfig.Issuer()); err == nil {
 			oidcEgressRule := networkpolicy.GetOIDCEgressRule(parsedURL)

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -63,6 +63,8 @@ import (
 var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 	apiServerPolicy := testutils.GetExpectedPolicyFromFile("./testutils/expected_policies/apiserver.json")
 	apiServerPolicyForOCP := testutils.GetExpectedPolicyFromFile("./testutils/expected_policies/apiserver_ocp.json")
+	apiServerPolicyForManaged := testutils.GetExpectedPolicyFromFile("./testutils/expected_policies/apiserver_managed.json")
+	apiServerPolicyForManagedOCP := testutils.GetExpectedPolicyFromFile("./testutils/expected_policies/apiserver_managed_ocp.json")
 	var (
 		instance           *operatorv1.InstallationSpec
 		apiserver          *operatorv1.APIServerSpec
@@ -830,6 +832,33 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 		}))
 	})
 
+	It("should allow egress to Guardian on a managed cluster", func() {
+		cfg.ManagementClusterConnection = &operatorv1.ManagementClusterConnection{}
+
+		component := render.APIServerPolicy(cfg)
+		resources, _ := component.Objects()
+		policyName := types.NamespacedName{Name: "calico-system.apiserver-access", Namespace: "calico-system"}
+		policy := testutils.GetCalicoSystemPolicyFromResources(policyName, resources)
+		Expect(policy).ToNot(BeNil())
+		Expect(policy.Spec.Egress).To(ContainElement(calicov3.Rule{
+			Action:      calicov3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: render.GuardianEntityRule,
+		}))
+		// The rule is only reached if it precedes the trailing Pass.
+		n := len(policy.Spec.Egress)
+		Expect(policy.Spec.Egress[n-1].Action).To(Equal(calicov3.Pass))
+	})
+
+	It("should omit the Guardian egress rule when the cluster is not managed", func() {
+		component := render.APIServerPolicy(cfg)
+		resources, _ := component.Objects()
+		policyName := types.NamespacedName{Name: "calico-system.apiserver-access", Namespace: "calico-system"}
+		policy := testutils.GetCalicoSystemPolicyFromResources(policyName, resources)
+		Expect(policy).ToNot(BeNil())
+		Expect(policy.Spec.Egress).NotTo(ContainElement(HaveField("Destination", render.GuardianEntityRule)))
+	})
+
 	It("should add egress policy with Enterprise variant and K8SServiceEndpoint as IP defined", func() {
 		cfg.K8SServiceEndpoint.Host = "169.169.169.169"
 		cfg.K8SServiceEndpoint.Port = "4321"
@@ -1182,7 +1211,15 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 				resources, _ := component.Objects()
 
 				policy := testutils.GetCalicoSystemPolicyFromResources(policyName, resources)
-				expectedPolicy := testutils.SelectPolicyByProvider(scenario, apiServerPolicy, apiServerPolicyForOCP)
+				expectedPolicy := testutils.SelectPolicyByClusterTypeAndProvider(
+					scenario,
+					map[string]*calicov3.NetworkPolicy{
+						"unmanaged":           apiServerPolicy,
+						"unmanaged-openshift": apiServerPolicyForOCP,
+						"managed":             apiServerPolicyForManaged,
+						"managed-openshift":   apiServerPolicyForManagedOCP,
+					},
+				)
 				Expect(policy).To(Equal(expectedPolicy))
 			},
 			Entry("for management/standalone, kube-dns", testutils.CalicoSystemScenario{ManagedCluster: false, OpenShift: false}),

--- a/pkg/render/testutils/expected_policies/apiserver_managed.json
+++ b/pkg/render/testutils/expected_policies/apiserver_managed.json
@@ -1,0 +1,123 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "calico-system.apiserver-access",
+    "namespace": "calico-system"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "calico-system",
+    "selector": "k8s-app == 'calico-apiserver'",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "nets": [
+            "0.0.0.0/0"
+          ]
+        },
+        "destination": {
+          "ports": [
+            443,
+            5443,
+            8080,
+            10443
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "nets": [
+            "::/0"
+          ]
+        },
+        "destination": {
+          "ports": [
+            443,
+            5443,
+            8080,
+            10443
+          ]
+        }
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'kube-system'",
+          "selector": "k8s-app in { 'kube-dns', 'coredns' }",
+          "ports": [
+            53
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "services": {
+            "name": "kubernetes",
+            "namespace": "default"
+          }
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-prometheus'",
+          "selector": "k8s-app == 'tigera-prometheus'",
+          "ports": [
+            9095
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "selector": "k8s-app == 'tigera-dex'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-dex'",
+          "ports": [
+            5556
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "selector": "k8s-app == 'tigera-linseed'",
+          "ports": [
+            8444
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'calico-system'",
+          "selector": "k8s-app == 'guardian'",
+          "ports": [
+            8080
+          ]
+        }
+      },
+      {
+        "action": "Pass"
+      }
+    ]
+  }
+}

--- a/pkg/render/testutils/expected_policies/apiserver_managed_ocp.json
+++ b/pkg/render/testutils/expected_policies/apiserver_managed_ocp.json
@@ -1,0 +1,134 @@
+{
+  "apiVersion": "projectcalico.org/v3",
+  "kind": "NetworkPolicy",
+  "metadata": {
+    "name": "calico-system.apiserver-access",
+    "namespace": "calico-system"
+  },
+  "spec": {
+    "order": 1,
+    "tier": "calico-system",
+    "selector": "k8s-app == 'calico-apiserver'",
+    "types": [
+      "Ingress",
+      "Egress"
+    ],
+    "ingress": [
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "nets": [
+            "0.0.0.0/0"
+          ]
+        },
+        "destination": {
+          "ports": [
+            443,
+            5443,
+            8080,
+            10443
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "source": {
+          "nets": [
+            "::/0"
+          ]
+        },
+        "destination": {
+          "ports": [
+            443,
+            5443,
+            8080,
+            10443
+          ]
+        }
+      }
+    ],
+    "egress": [
+      {
+        "action": "Allow",
+        "protocol": "UDP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'openshift-dns'",
+          "selector": "dns.operator.openshift.io/daemonset-dns == 'default'",
+          "ports": [
+            5353
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "services": {
+            "name": "kubernetes",
+            "namespace": "default"
+          }
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-prometheus'",
+          "selector": "k8s-app == 'tigera-prometheus'",
+          "ports": [
+            9095
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "selector": "k8s-app == 'tigera-dex'",
+          "namespaceSelector": "projectcalico.org/name == 'tigera-dex'",
+          "ports": [
+            5556
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'tigera-elasticsearch'",
+          "selector": "k8s-app == 'tigera-linseed'",
+          "ports": [
+            8444
+          ]
+        }
+      },
+      {
+        "action": "Allow",
+        "protocol": "TCP",
+        "destination": {
+          "namespaceSelector": "projectcalico.org/name == 'calico-system'",
+          "selector": "k8s-app == 'guardian'",
+          "ports": [
+            8080
+          ]
+        }
+      },
+      {
+        "action": "Pass"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Description

Cherry-pick of #5240.

A managed cluster runs no local Linseed, so the query server reaches it through guardian —
the URL `LinseedEndpoint` returns as `LINSEED_URL`. The `calico-system.apiserver-access`
policy permitted only the local Linseed pods, whose selector matches nothing on a managed
cluster, so the connection fell through to the policy's trailing `Pass`. The `calico-system`
tier's default-deny excludes `calico-apiserver` by design, so the traffic is then evaluated
against the customer's tiers, where any default-deny drops it. The Manager policy board
renders empty and policy activity requests return 500.

This branch predates the `pkg/enterprise/apiserver` extension mechanism (#4871), so the rule
is branched directly in `calicoSystemAPIServerPolicy` on `cfg.ManagementClusterConnection` —
the same condition `LINSEED_URL` already uses a few hundred lines away in the same file.

The `calico-system` policy table already had `for managed` entries, but
`SelectPolicyByProvider` only switches on the provider, so both managed cases were asserting
the unmanaged fixture and could not have caught this. The table now uses
`SelectPolicyByClusterTypeAndProvider` against new `apiserver_managed.json` and
`apiserver_managed_ocp.json` fixtures.

The inert local-Linseed rule is left in place. It selects no pods on a managed cluster, so it
is harmless, and removing it would churn the base fixtures across every backport branch.

`release-v1.41` (CE v3.23.0-1.0) carries neither the egress rule nor `LINSEED_URL`, so the
affected range starts here.

Addresses CI-2048.

### Testing

Verified on a live managed cluster on the master change (#5240): with the customer's
default-deny in a tier after `calico-system`, the original operator returned the reported 500
on `GET /policies` after a 19.5s guardian timeout, and the fixed operator returned 200 in
0.58s with the `calico-system` tier present. The deny stayed applied across both runs and only
the operator image changed.

On this branch: full `pkg/render` suite green, `make static-checks` reports 0 issues, and new
specs cover the rule being rendered ahead of the trailing `Pass` on a managed cluster and
absent otherwise.

## Release Note

```release-note
Fixed the Manager policy board rendering empty on managed clusters, where the query server was not permitted egress to Linseed through guardian.
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

**Second commit — CRD regeneration.** This branch fails `validate-gen-versions` for *every*
PR opened against it, because `make gen-versions` produces changes against the committed CRDs.
It is unrelated to the policy fix and predates it. A separate `chore(crds)` commit carries the
regenerated output so this PR can go green; it is isolated so it can be reviewed or dropped on
its own. The drift is upstream CRD movement only. `make test-crds` and the
`pkg/imports/crds` suite pass.