### PR TITLE
[release-v1.44] fix(apiserver): allow queryserver egress to Linseed via guardian on managed clusters

### DIFF
--- a/pkg/enterprise/apiserver/extension.go
+++ b/pkg/enterprise/apiserver/extension.go
@@ -724,9 +724,9 @@ func (c *apiServer) sidecarMutatingWebhookConfig() *admregv1.MutatingWebhookConf
 }
 
 // modifyAPIServerPolicy adds the enterprise additions to the API server network policy:
-// the OIDC egress rule (when an OIDC key validator is configured) and the L7 admission
-// controller ingress port (when sidecar injection is enabled). The base policy carries
-// neither.
+// the OIDC egress rule (when an OIDC key validator is configured), the query server's
+// egress to Linseed via Guardian (on a managed cluster) and the L7 admission controller
+// ingress port (when sidecar injection is enabled). The base policy carries none of these.
 func modifyAPIServerPolicy(ri render.Inputs, cfg *render.APIServerConfiguration, create, del []client.Object) ([]client.Object, []client.Object) {
 	c := &apiServer{cfg: cfg, data: apiServerData(ri)}
 
@@ -735,17 +735,20 @@ func modifyAPIServerPolicy(ri render.Inputs, cfg *render.APIServerConfiguration,
 		return create, del
 	}
 
-	// Insert the OIDC egress rule before the trailing Pass rule so it is evaluated.
 	if c.data.keyValidatorConfig != nil {
 		if parsedURL, err := url.Parse(c.data.keyValidatorConfig.Issuer()); err == nil {
-			oidc := networkpolicy.GetOIDCEgressRule(parsedURL)
-			egress := policy.Spec.Egress
-			if n := len(egress); n > 0 && egress[n-1].Action == v3.Pass {
-				policy.Spec.Egress = append(egress[:n-1:n-1], oidc, egress[n-1])
-			} else {
-				policy.Spec.Egress = append(egress, oidc)
-			}
+			insertEgressBeforePass(policy, networkpolicy.GetOIDCEgressRule(parsedURL))
 		}
+	}
+
+	// A managed cluster has no local Linseed; the query server reaches it through Guardian,
+	// matching the LINSEED_URL that LinseedEndpoint returns.
+	if c.data.managementClusterConnection != nil {
+		insertEgressBeforePass(policy, v3.Rule{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: render.GuardianEntityRule,
+		})
 	}
 
 	// Allow the kube-apiserver to reach the L7 admission controller.
@@ -758,6 +761,17 @@ func modifyAPIServerPolicy(ri render.Inputs, cfg *render.APIServerConfiguration,
 	}
 
 	return create, del
+}
+
+// insertEgressBeforePass inserts rule ahead of the policy's trailing Pass rule, so that it is
+// evaluated before the tier hands the traffic to subsequent tiers.
+func insertEgressBeforePass(policy *v3.NetworkPolicy, rule v3.Rule) {
+	egress := policy.Spec.Egress
+	if n := len(egress); n > 0 && egress[n-1].Action == v3.Pass {
+		policy.Spec.Egress = append(egress[:n-1:n-1], rule, egress[n-1])
+		return
+	}
+	policy.Spec.Egress = append(egress, rule)
 }
 
 // auditVolumes are the host-path audit log and audit policy volumes used by the

--- a/pkg/enterprise/apiserver/extension_test.go
+++ b/pkg/enterprise/apiserver/extension_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/tigera/operator/pkg/extensions"
 	"github.com/tigera/operator/pkg/extensions/extensionstest"
 	"github.com/tigera/operator/pkg/render"
+	"github.com/tigera/operator/pkg/render/common/networkpolicy"
 	"github.com/tigera/operator/pkg/render/common/rbacmanagement"
 	"github.com/tigera/operator/pkg/render/monitor"
 	"github.com/tigera/operator/pkg/render/webhooks"
@@ -835,6 +836,35 @@ var _ = Describe("API server enterprise policy modifier", func() {
 		n := len(policy.Spec.Egress)
 		Expect(n).To(BeNumerically(">", 0))
 		Expect(policy.Spec.Egress[n-1].Action).To(Equal(v3.Pass))
+	})
+
+	It("allows egress to Guardian on a managed cluster", func() {
+		ci := apiServerControllerInputs(operatorv1.CalicoEnterprise, nil,
+			&operatorv1.ManagementClusterConnection{ObjectMeta: metav1.ObjectMeta{Name: utils.DefaultEnterpriseInstanceKey.Name}})
+		eci, _, err := ext.APIServer().ExtendInputs(ctx, ci)
+		ri := eci.RenderInputs
+		Expect(err).NotTo(HaveOccurred())
+
+		policy := applyPolicy(ci, ri)
+		guardian := v3.Rule{
+			Action:      v3.Allow,
+			Protocol:    &networkpolicy.TCPProtocol,
+			Destination: render.GuardianEntityRule,
+		}
+		// The rule is only reached if it precedes the trailing Pass.
+		n := len(policy.Spec.Egress)
+		Expect(policy.Spec.Egress[n-1].Action).To(Equal(v3.Pass))
+		Expect(policy.Spec.Egress[n-2]).To(Equal(guardian))
+	})
+
+	It("omits the Guardian egress rule when the cluster is not managed", func() {
+		ci := apiServerControllerInputs(operatorv1.CalicoEnterprise, nil)
+		eci, _, err := ext.APIServer().ExtendInputs(ctx, ci)
+		ri := eci.RenderInputs
+		Expect(err).NotTo(HaveOccurred())
+
+		policy := applyPolicy(ci, ri)
+		Expect(policy.Spec.Egress).NotTo(ContainElement(HaveField("Destination", render.GuardianEntityRule)))
 	})
 
 	It("adds the L7 admission controller ingress port when sidecar injection is enabled", func() {

--- a/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_felixconfigurations.yaml
@@ -62,12 +62,18 @@ spec:
                 bpfAttachType:
                   description: |-
                     BPFAttachType controls how are the BPF programs at the network interfaces attached.
-                    By default `TCX` is used where available to enable easier coexistence with 3rd party programs.
-                    `TC` can force the legacy method of attaching via a qdisc. `TCX` falls back to `TC` if `TCX` is not available.
-                    [Default: TCX]
+                    By default `Netkit` is used, which attaches via the netkit API on workload interfaces that are
+                    netkit devices and via `TCX` on every other interface. `TCX` is used where available to enable
+                    easier coexistence with 3rd party programs. `TC` can force the legacy method of attaching via a
+                    qdisc. `TCX` falls back to `TC` if `TCX` is not available.
+                    Setting this to `TCX` or `TC` also makes Felix drive existing netkit devices with that mechanism
+                    instead of the netkit API, which is required before downgrading to a release without netkit
+                    support.
+                    [Default: Netkit]
                   enum:
                     - TC
                     - TCX
+                    - Netkit
                   type: string
                 bpfCTLBLogFilter:
                   description: |-
@@ -990,6 +996,8 @@ spec:
                   description: |-
                     LogActionRateLimit sets the rate of hitting a Log action. The value must be in the format "N/unit",
                     where N is a number and unit is one of: second, minute, hour, or day. For example: "10/second" or "100/hour".
+                    When LogConnectionTransitions is enabled, this also bounds the follow-up logs: a connection whose
+                    initial log was suppressed by this rate limit gets no follow-up log either.
                   pattern: ^[1-9]\d{0,3}/(?:second|minute|hour|day)$
                   type: string
                 logActionRateLimitBurst:
@@ -999,6 +1007,33 @@ spec:
                   maximum: 9999
                   minimum: 0
                   type: integer
+                logConnectionTransitions:
+                  description: |-
+                    LogConnectionTransitions controls whether Felix emits an additional kernel log recording the
+                    first observed response for each connection that matched a policy rule with a Log action.
+                    When set to FirstResponseAfterLog, each connection whose initial log was emitted gets one
+                    follow-up log, prefixed with LogConnectionTransitionsPrefix plus a suffix identifying the
+                    transition: "-est" when the first reply packet is seen, "-rst" when the response is a TCP
+                    RST (connection refused), or "-icmp-err" when the response is a related ICMP error (e.g.
+                    port unreachable). The log body is the standard kernel packet log of the response packet,
+                    so the flow is identified by its 5-tuple and can be correlated with the original policy Log
+                    line (with source and destination swapped). A logged connection with no follow-up log never
+                    received a response. Connections whose initial log was suppressed by LogActionRateLimit get
+                    no follow-up log either, so every follow-up log pairs with an initial one. Enabling this
+                    consumes one bit from the Iptables/NftablesMarkMask space. Not supported in eBPF mode.
+                    [Default: Disabled]
+                  enum:
+                    - Disabled
+                    - FirstResponseAfterLog
+                  type: string
+                logConnectionTransitionsPrefix:
+                  description: |-
+                    LogConnectionTransitionsPrefix is the log prefix used for the logs emitted when
+                    LogConnectionTransitions is enabled; the transition suffix ("-est", "-rst" or "-icmp-err")
+                    is appended to it. Unlike LogPrefix, it does not support %-specifiers (such as %p): the
+                    rules that emit these logs are shared by all policies, so per-policy values cannot be
+                    substituted and any %-specifiers are rendered literally. [Default: calico-response]
+                  type: string
                 logDebugFilenameRegex:
                   description: |-
                     LogDebugFilenameRegex controls which source code files have their Debug log output included in the logs.

--- a/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_ippools.yaml
+++ b/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_ippools.yaml
@@ -68,8 +68,8 @@ spec:
                 blockSize:
                   description: |-
                     The block size to use for IP address assignments from this pool. Defaults to 26 for IPv4 and 122 for IPv6.
-                    The block size must be between 0 and 32 for IPv4 and between 0 and 128 for IPv6. It must also be smaller than
-                    or equal to the size of the pool CIDR.
+                    The block size must be between 20 and 32 for IPv4 and between 116 and 128 for IPv6. It must also be smaller
+                    than or equal to the size of the pool CIDR.
                   maximum: 128
                   minimum: 0
                   type: integer
@@ -187,6 +187,33 @@ spec:
                 - message: global() selector is not valid for IPPool namespaceSelector
                   reason: FieldValueInvalid
                   rule: "!has(self.namespaceSelector) || !self.namespaceSelector.contains('global(')"
+                - message: IPPool CIDR must be strictly masked
+                  reason: FieldValueInvalid
+                  rule: cidr(self.cidr) == cidr(self.cidr).masked()
+                - message: IPPool CIDR overlaps with IPv4 link local range 169.254.0.0/16
+                  reason: FieldValueInvalid
+                  rule:
+                    "!cidr('169.254.0.0/16').containsIP(cidr(self.cidr).ip()) &&
+                    !cidr(self.cidr).containsIP('169.254.0.0')"
+                - message: IPPool CIDR overlaps with IPv6 link local range fe80::/10
+                  reason: FieldValueInvalid
+                  rule: "!cidr('fe80::/10').containsIP(cidr(self.cidr).ip()) && !cidr(self.cidr).containsIP('fe80::')"
+                - message:
+                    blockSize must be between 20 and 32 for IPv4 pools, and between
+                    116 and 128 for IPv6 pools
+                  reason: FieldValueInvalid
+                  rule:
+                    "!has(self.blockSize) || self.blockSize == 0 || (cidr(self.cidr).ip().family()
+                    == 4 ? self.blockSize >= 20 && self.blockSize <= 32 : self.blockSize
+                    >= 116 && self.blockSize <= 128)"
+                - message:
+                    IP pool size is too small for use with Calico IPAM. It must
+                    be equal to or greater than the block size.
+                  reason: FieldValueInvalid
+                  rule:
+                    "(has(self.disabled) && self.disabled) || cidr(self.cidr).prefixLength()
+                    <= (has(self.blockSize) && self.blockSize != 0 ? self.blockSize :
+                    (cidr(self.cidr).ip().family() == 4 ? 26 : 122))"
             status:
               properties:
                 conditions:

--- a/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_felixconfigurations.yaml
+++ b/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_felixconfigurations.yaml
@@ -61,12 +61,18 @@ spec:
                 bpfAttachType:
                   description: |-
                     BPFAttachType controls how are the BPF programs at the network interfaces attached.
-                    By default `TCX` is used where available to enable easier coexistence with 3rd party programs.
-                    `TC` can force the legacy method of attaching via a qdisc. `TCX` falls back to `TC` if `TCX` is not available.
-                    [Default: TCX]
+                    By default `Netkit` is used, which attaches via the netkit API on workload interfaces that are
+                    netkit devices and via `TCX` on every other interface. `TCX` is used where available to enable
+                    easier coexistence with 3rd party programs. `TC` can force the legacy method of attaching via a
+                    qdisc. `TCX` falls back to `TC` if `TCX` is not available.
+                    Setting this to `TCX` or `TC` also makes Felix drive existing netkit devices with that mechanism
+                    instead of the netkit API, which is required before downgrading to a release without netkit
+                    support.
+                    [Default: Netkit]
                   enum:
                     - TC
                     - TCX
+                    - Netkit
                   type: string
                 bpfCTLBLogFilter:
                   description: |-
@@ -989,6 +995,8 @@ spec:
                   description: |-
                     LogActionRateLimit sets the rate of hitting a Log action. The value must be in the format "N/unit",
                     where N is a number and unit is one of: second, minute, hour, or day. For example: "10/second" or "100/hour".
+                    When LogConnectionTransitions is enabled, this also bounds the follow-up logs: a connection whose
+                    initial log was suppressed by this rate limit gets no follow-up log either.
                   pattern: ^[1-9]\d{0,3}/(?:second|minute|hour|day)$
                   type: string
                 logActionRateLimitBurst:
@@ -998,6 +1006,33 @@ spec:
                   maximum: 9999
                   minimum: 0
                   type: integer
+                logConnectionTransitions:
+                  description: |-
+                    LogConnectionTransitions controls whether Felix emits an additional kernel log recording the
+                    first observed response for each connection that matched a policy rule with a Log action.
+                    When set to FirstResponseAfterLog, each connection whose initial log was emitted gets one
+                    follow-up log, prefixed with LogConnectionTransitionsPrefix plus a suffix identifying the
+                    transition: "-est" when the first reply packet is seen, "-rst" when the response is a TCP
+                    RST (connection refused), or "-icmp-err" when the response is a related ICMP error (e.g.
+                    port unreachable). The log body is the standard kernel packet log of the response packet,
+                    so the flow is identified by its 5-tuple and can be correlated with the original policy Log
+                    line (with source and destination swapped). A logged connection with no follow-up log never
+                    received a response. Connections whose initial log was suppressed by LogActionRateLimit get
+                    no follow-up log either, so every follow-up log pairs with an initial one. Enabling this
+                    consumes one bit from the Iptables/NftablesMarkMask space. Not supported in eBPF mode.
+                    [Default: Disabled]
+                  enum:
+                    - Disabled
+                    - FirstResponseAfterLog
+                  type: string
+                logConnectionTransitionsPrefix:
+                  description: |-
+                    LogConnectionTransitionsPrefix is the log prefix used for the logs emitted when
+                    LogConnectionTransitions is enabled; the transition suffix ("-est", "-rst" or "-icmp-err")
+                    is appended to it. Unlike LogPrefix, it does not support %-specifiers (such as %p): the
+                    rules that emit these logs are shared by all policies, so per-policy values cannot be
+                    substituted and any %-specifiers are rendered literally. [Default: calico-response]
+                  type: string
                 logDebugFilenameRegex:
                   description: |-
                     LogDebugFilenameRegex controls which source code files have their Debug log output included in the logs.

--- a/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_ippools.yaml
+++ b/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_ippools.yaml
@@ -93,8 +93,8 @@ spec:
                 blockSize:
                   description: |-
                     The block size to use for IP address assignments from this pool. Defaults to 26 for IPv4 and 122 for IPv6.
-                    The block size must be between 0 and 32 for IPv4 and between 0 and 128 for IPv6. It must also be smaller than
-                    or equal to the size of the pool CIDR.
+                    The block size must be between 20 and 32 for IPv4 and between 116 and 128 for IPv6. It must also be smaller
+                    than or equal to the size of the pool CIDR.
                   maximum: 128
                   minimum: 0
                   type: integer
@@ -212,6 +212,33 @@ spec:
                 - message: global() selector is not valid for IPPool namespaceSelector
                   reason: FieldValueInvalid
                   rule: "!has(self.namespaceSelector) || !self.namespaceSelector.contains('global(')"
+                - message: IPPool CIDR must be strictly masked
+                  reason: FieldValueInvalid
+                  rule: cidr(self.cidr) == cidr(self.cidr).masked()
+                - message: IPPool CIDR overlaps with IPv4 link local range 169.254.0.0/16
+                  reason: FieldValueInvalid
+                  rule:
+                    "!cidr('169.254.0.0/16').containsIP(cidr(self.cidr).ip()) &&
+                    !cidr(self.cidr).containsIP('169.254.0.0')"
+                - message: IPPool CIDR overlaps with IPv6 link local range fe80::/10
+                  reason: FieldValueInvalid
+                  rule: "!cidr('fe80::/10').containsIP(cidr(self.cidr).ip()) && !cidr(self.cidr).containsIP('fe80::')"
+                - message:
+                    blockSize must be between 20 and 32 for IPv4 pools, and between
+                    116 and 128 for IPv6 pools
+                  reason: FieldValueInvalid
+                  rule:
+                    "!has(self.blockSize) || self.blockSize == 0 || (cidr(self.cidr).ip().family()
+                    == 4 ? self.blockSize >= 20 && self.blockSize <= 32 : self.blockSize
+                    >= 116 && self.blockSize <= 128)"
+                - message:
+                    IP pool size is too small for use with Calico IPAM. It must
+                    be equal to or greater than the block size.
+                  reason: FieldValueInvalid
+                  rule:
+                    "(has(self.disabled) && self.disabled) || cidr(self.cidr).prefixLength()
+                    <= (has(self.blockSize) && self.blockSize != 0 ? self.blockSize :
+                    (cidr(self.cidr).ip().family() == 4 ? 26 : 122))"
             status:
               properties:
                 conditions:

--- a/pkg/imports/crds/enterprise/v1.crd.projectcalico.org/crd.projectcalico.org_bgpconfigurations.yaml
+++ b/pkg/imports/crds/enterprise/v1.crd.projectcalico.org/crd.projectcalico.org_bgpconfigurations.yaml
@@ -211,13 +211,33 @@ spec:
                   x-kubernetes-list-type: atomic
                 programClusterRoutes:
                   description: |-
-                    ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
-                    when that workload's IP comes from an IP Pool with vxlanMode: Never. When ProgramClusterRoutes is Enabled,
-                    confd and BIRD program that route. When ProgramClusterRoutes is Disabled, it is expected that Felix will program that route.
-                    Felix always programs such routes for IP Pools with vxlanMode: Always or vxlanMode: CrossSubnet. [Default: Enabled]
+                    ProgramClusterRoutes controls which "cluster routes" are programmed by Calico's BGP
+                    stack, i.e. the routes that a node needs in order to reach workloads on other nodes.  It
+                    only applies to IP Pools with vxlanMode: Never; the cluster routes for IP Pools with
+                    vxlanMode: Always or vxlanMode: CrossSubnet are always programmed by Felix.  The routes
+                    that BIRD does not program here are expected to be programmed by Felix instead.  Below,
+                    an IPIP IP Pool is one with ipipMode: Always or CrossSubnet, and an unencapsulated one
+                    has ipipMode and vxlanMode both Never.
+
+                    - Disabled: BIRD programs no cluster routes.
+                    - EnabledNoEncapOnly: BIRD programs them for unencapsulated IP Pools.
+                    - EnabledIPIPOnly: BIRD programs them for IPIP IP Pools.
+                    - Enabled: BIRD programs them for both.
+
+                    This field must be kept consistent with FelixConfiguration.ProgramClusterRoutes, which
+                    makes the same choice from Felix's side.  If both Felix and BIRD are enabled for the same
+                    kind of IP Pool they will fight over the routes; if neither is, there will be no cluster
+                    routes at all.
+
+                    Note: asking BIRD to program IPIP cluster routes, which the Enabled and EnabledIPIPOnly
+                    values do, is deprecated as of v3.33 and will be removed in v3.35.
+
+                    [Default: EnabledNoEncapOnly]
                   enum:
                     - Enabled
                     - Disabled
+                    - EnabledIPIPOnly
+                    - EnabledNoEncapOnly
                   type: string
                 serviceClusterIPs:
                   description: |-

--- a/pkg/imports/crds/enterprise/v1.crd.projectcalico.org/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/imports/crds/enterprise/v1.crd.projectcalico.org/crd.projectcalico.org_felixconfigurations.yaml
@@ -84,12 +84,18 @@ spec:
                 bpfAttachType:
                   description: |-
                     BPFAttachType controls how are the BPF programs at the network interfaces attached.
-                    By default `TCX` is used where available to enable easier coexistence with 3rd party programs.
-                    `TC` can force the legacy method of attaching via a qdisc. `TCX` falls back to `TC` if `TCX` is not available.
-                    [Default: TCX]
+                    By default `Netkit` is used, which attaches via the netkit API on workload interfaces that are
+                    netkit devices and via `TCX` on every other interface. `TCX` is used where available to enable
+                    easier coexistence with 3rd party programs. `TC` can force the legacy method of attaching via a
+                    qdisc. `TCX` falls back to `TC` if `TCX` is not available.
+                    Setting this to `TCX` or `TC` also makes Felix drive existing netkit devices with that mechanism
+                    instead of the netkit API, which is required before downgrading to a release without netkit
+                    support.
+                    [Default: Netkit]
                   enum:
                     - TC
                     - TCX
+                    - Netkit
                   type: string
                 bpfCTLBLogFilter:
                   description: |-
@@ -1854,13 +1860,33 @@ spec:
                   type: string
                 programClusterRoutes:
                   description: |-
-                    ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
-                    when that workload's IP comes from an IP Pool with vxlanMode: Never. When ProgramClusterRoutes is Disabled,
-                    it is expected that confd and BIRD will program that route. When ProgramClusterRoutes is Enabled, Felix program that route.
-                    Felix always programs such routes for IP Pools with vxlanMode: Always or vxlanMode: CrossSubnet. [Default: Disabled]
+                    ProgramClusterRoutes controls which "cluster routes" Felix programs, i.e. the routes that
+                    a node needs in order to reach workloads on other nodes.  It only applies to IP Pools
+                    with vxlanMode: Never; Felix always programs the cluster routes for IP Pools with
+                    vxlanMode: Always or vxlanMode: CrossSubnet.  The routes that Felix does not program here
+                    are expected to be programmed by Calico's BGP stack instead.  Below, an IPIP IP Pool is
+                    one with ipipMode: Always or CrossSubnet, and an unencapsulated one has ipipMode and
+                    vxlanMode both Never.
+
+                    - Disabled: Felix programs no cluster routes.
+                    - EnabledIPIPOnly: Felix programs them for IPIP IP Pools.
+                    - EnabledNoEncapOnly: Felix programs them for unencapsulated IP Pools.
+                    - Enabled: Felix programs them for both.
+
+                    This field must be kept consistent with BGPConfiguration.ProgramClusterRoutes, which
+                    makes the same choice from BIRD's side.  If both Felix and BIRD are enabled for the same
+                    kind of IP Pool they will fight over the routes; if neither is, there will be no cluster
+                    routes at all.
+
+                    Note: leaving the IPIP cluster routes to BGP, which the Disabled and EnabledNoEncapOnly
+                    values do, is deprecated as of v3.33 and will be removed in v3.35.
+
+                    [Default: EnabledIPIPOnly]
                   enum:
                     - Enabled
                     - Disabled
+                    - EnabledIPIPOnly
+                    - EnabledNoEncapOnly
                   type: string
                 prometheusGoMetricsEnabled:
                   description: |-

--- a/pkg/imports/crds/enterprise/v3.projectcalico.org/projectcalico.org_bgpconfigurations.yaml
+++ b/pkg/imports/crds/enterprise/v3.projectcalico.org/projectcalico.org_bgpconfigurations.yaml
@@ -213,13 +213,33 @@ spec:
                   x-kubernetes-list-type: atomic
                 programClusterRoutes:
                   description: |-
-                    ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
-                    when that workload's IP comes from an IP Pool with vxlanMode: Never. When ProgramClusterRoutes is Enabled,
-                    confd and BIRD program that route. When ProgramClusterRoutes is Disabled, it is expected that Felix will program that route.
-                    Felix always programs such routes for IP Pools with vxlanMode: Always or vxlanMode: CrossSubnet. [Default: Enabled]
+                    ProgramClusterRoutes controls which "cluster routes" are programmed by Calico's BGP
+                    stack, i.e. the routes that a node needs in order to reach workloads on other nodes.  It
+                    only applies to IP Pools with vxlanMode: Never; the cluster routes for IP Pools with
+                    vxlanMode: Always or vxlanMode: CrossSubnet are always programmed by Felix.  The routes
+                    that BIRD does not program here are expected to be programmed by Felix instead.  Below,
+                    an IPIP IP Pool is one with ipipMode: Always or CrossSubnet, and an unencapsulated one
+                    has ipipMode and vxlanMode both Never.
+
+                    - Disabled: BIRD programs no cluster routes.
+                    - EnabledNoEncapOnly: BIRD programs them for unencapsulated IP Pools.
+                    - EnabledIPIPOnly: BIRD programs them for IPIP IP Pools.
+                    - Enabled: BIRD programs them for both.
+
+                    This field must be kept consistent with FelixConfiguration.ProgramClusterRoutes, which
+                    makes the same choice from Felix's side.  If both Felix and BIRD are enabled for the same
+                    kind of IP Pool they will fight over the routes; if neither is, there will be no cluster
+                    routes at all.
+
+                    Note: asking BIRD to program IPIP cluster routes, which the Enabled and EnabledIPIPOnly
+                    values do, is deprecated as of v3.33 and will be removed in v3.35.
+
+                    [Default: EnabledNoEncapOnly]
                   enum:
                     - Enabled
                     - Disabled
+                    - EnabledIPIPOnly
+                    - EnabledNoEncapOnly
                   type: string
                 serviceClusterIPs:
                   description: |-

--- a/pkg/imports/crds/enterprise/v3.projectcalico.org/projectcalico.org_felixconfigurations.yaml
+++ b/pkg/imports/crds/enterprise/v3.projectcalico.org/projectcalico.org_felixconfigurations.yaml
@@ -83,12 +83,18 @@ spec:
                 bpfAttachType:
                   description: |-
                     BPFAttachType controls how are the BPF programs at the network interfaces attached.
-                    By default `TCX` is used where available to enable easier coexistence with 3rd party programs.
-                    `TC` can force the legacy method of attaching via a qdisc. `TCX` falls back to `TC` if `TCX` is not available.
-                    [Default: TCX]
+                    By default `Netkit` is used, which attaches via the netkit API on workload interfaces that are
+                    netkit devices and via `TCX` on every other interface. `TCX` is used where available to enable
+                    easier coexistence with 3rd party programs. `TC` can force the legacy method of attaching via a
+                    qdisc. `TCX` falls back to `TC` if `TCX` is not available.
+                    Setting this to `TCX` or `TC` also makes Felix drive existing netkit devices with that mechanism
+                    instead of the netkit API, which is required before downgrading to a release without netkit
+                    support.
+                    [Default: Netkit]
                   enum:
                     - TC
                     - TCX
+                    - Netkit
                   type: string
                 bpfCTLBLogFilter:
                   description: |-
@@ -1853,13 +1859,33 @@ spec:
                   type: string
                 programClusterRoutes:
                   description: |-
-                    ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
-                    when that workload's IP comes from an IP Pool with vxlanMode: Never. When ProgramClusterRoutes is Disabled,
-                    it is expected that confd and BIRD will program that route. When ProgramClusterRoutes is Enabled, Felix program that route.
-                    Felix always programs such routes for IP Pools with vxlanMode: Always or vxlanMode: CrossSubnet. [Default: Disabled]
+                    ProgramClusterRoutes controls which "cluster routes" Felix programs, i.e. the routes that
+                    a node needs in order to reach workloads on other nodes.  It only applies to IP Pools
+                    with vxlanMode: Never; Felix always programs the cluster routes for IP Pools with
+                    vxlanMode: Always or vxlanMode: CrossSubnet.  The routes that Felix does not program here
+                    are expected to be programmed by Calico's BGP stack instead.  Below, an IPIP IP Pool is
+                    one with ipipMode: Always or CrossSubnet, and an unencapsulated one has ipipMode and
+                    vxlanMode both Never.
+
+                    - Disabled: Felix programs no cluster routes.
+                    - EnabledIPIPOnly: Felix programs them for IPIP IP Pools.
+                    - EnabledNoEncapOnly: Felix programs them for unencapsulated IP Pools.
+                    - Enabled: Felix programs them for both.
+
+                    This field must be kept consistent with BGPConfiguration.ProgramClusterRoutes, which
+                    makes the same choice from BIRD's side.  If both Felix and BIRD are enabled for the same
+                    kind of IP Pool they will fight over the routes; if neither is, there will be no cluster
+                    routes at all.
+
+                    Note: leaving the IPIP cluster routes to BGP, which the Disabled and EnabledNoEncapOnly
+                    values do, is deprecated as of v3.33 and will be removed in v3.35.
+
+                    [Default: EnabledIPIPOnly]
                   enum:
                     - Enabled
                     - Disabled
+                    - EnabledIPIPOnly
+                    - EnabledNoEncapOnly
                   type: string
                 prometheusGoMetricsEnabled:
                   description: |-


### PR DESCRIPTION
## Description

Clean cherry-pick of #5240, no adaptation needed — this branch carries the
`pkg/enterprise/apiserver` extension mechanism (#4871), so the commit applies as-is.

A managed cluster runs no local Linseed, so the query server reaches it through guardian —
the URL `LinseedEndpoint` returns as `LINSEED_URL`. The `calico-system.apiserver-access`
policy permitted only the local Linseed pods, whose selector matches nothing on a managed
cluster, so the connection fell through to the policy's trailing `Pass`. The `calico-system`
tier's default-deny excludes `calico-apiserver` by design, so the traffic is then evaluated
against the customer's tiers, where any default-deny drops it. The Manager policy board
renders empty and policy activity requests return 500.

The rule is branched in `modifyAPIServerPolicy` on `managementClusterConnection`, which is the
same condition the `LINSEED_URL` env var already uses in that file.

Addresses CI-2048.

### Testing

Verified on a live managed cluster on the master change (#5240): with the customer's
default-deny in a tier after `calico-system`, the original operator returned the reported 500
on `GET /policies` after a 19.5s guardian timeout, and the fixed operator returned 200 in
0.58s with the `calico-system` tier present. The deny stayed applied across both runs and only
the operator image changed.

On this branch: `pkg/enterprise/apiserver` suite green, including the specs covering the rule
being rendered ahead of the trailing `Pass` on a managed cluster and absent otherwise.

## Release Note

```release-note
Fixed the Manager policy board rendering empty on managed clusters, where the query server was not permitted egress to Linseed through guardian.
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---




---

**Second commit — CRD regeneration.** `make gen-versions` produces changes against the
committed CRDs on this branch, so `dirty-check` fails. A separate `chore(crds)` commit carries
the regenerated output; it is isolated so it can be reviewed or dropped on its own.

**FV is red on this branch regardless of this change** — #5211 and #5229 both fail FV with no
CRD change at all. Note that the regenerated IPPool CRD is rejected by the API server on CEL
cost (`x-kubernetes-validations[9].rule: estimated rule cost exceeds budget by factor of more
than 100x`), so FV now fails at `deploy-crds` rather than on individual specs. That rule needs
bounding with `maxItems`/`maxLength` where the CRD is generated upstream; fixing it there is
what turns FV green for this branch and for #5211 and #5229.