### PR TITLE
[release-v1.44] Render a write-only tiered policy passthrough in v3 CRD mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -380,7 +380,7 @@ run-fvs: $(ENVOY_GATEWAY_CHART) $(ISTIO_CHART_FILES)
 ## Create a local kind dual stack cluster.
 KIND_CLUSTER_NAME?=tigera-operator-kind
 KIND_KUBECONFIG?=./kubeconfig.yaml
-KINDEST_NODE_VERSION?=v1.31.12
+KINDEST_NODE_VERSION?=v1.32.11
 cluster-create: $(BINDIR)/kubectl $(BINDIR)/kind
 	# First make sure any previous cluster is deleted
 	make cluster-destroy

--- a/pkg/enterprise/apiserver/extension.go
+++ b/pkg/enterprise/apiserver/extension.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
-	"slices"
 	"strings"
 
 	admregv1 "k8s.io/api/admissionregistration/v1"
@@ -383,15 +382,6 @@ func modifyAPIServer(ri render.Inputs, cfg *render.APIServerConfiguration, creat
 	if svc, ok := extensions.FindObject[*corev1.Service](create, render.APIServerServiceName); ok {
 		c.addServicePorts(svc)
 	}
-	// Enterprise serves staged policies through the tiered-policy passthrough role.
-	if role, ok := extensions.FindObject[*rbacv1.ClusterRole](create, render.TieredPolicyPassthruClusterRoleName); ok {
-		for i := range role.Rules {
-			if slices.Contains(role.Rules[i].Resources, "networkpolicies") {
-				role.Rules[i].Resources = append(role.Rules[i].Resources, "stagednetworkpolicies", "stagedglobalnetworkpolicies")
-			}
-		}
-	}
-
 	// The L7 sidecar mutating webhook is driven by ApplicationLayer. The base always
 	// queues it for deletion; when sidecar injection is on, render it and pull it back
 	// out of the delete list.

--- a/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_felixconfigurations.yaml
@@ -62,12 +62,18 @@ spec:
                 bpfAttachType:
                   description: |-
                     BPFAttachType controls how are the BPF programs at the network interfaces attached.
-                    By default `TCX` is used where available to enable easier coexistence with 3rd party programs.
-                    `TC` can force the legacy method of attaching via a qdisc. `TCX` falls back to `TC` if `TCX` is not available.
-                    [Default: TCX]
+                    By default `Netkit` is used, which attaches via the netkit API on workload interfaces that are
+                    netkit devices and via `TCX` on every other interface. `TCX` is used where available to enable
+                    easier coexistence with 3rd party programs. `TC` can force the legacy method of attaching via a
+                    qdisc. `TCX` falls back to `TC` if `TCX` is not available.
+                    Setting this to `TCX` or `TC` also makes Felix drive existing netkit devices with that mechanism
+                    instead of the netkit API, which is required before downgrading to a release without netkit
+                    support.
+                    [Default: Netkit]
                   enum:
                     - TC
                     - TCX
+                    - Netkit
                   type: string
                 bpfCTLBLogFilter:
                   description: |-
@@ -990,6 +996,8 @@ spec:
                   description: |-
                     LogActionRateLimit sets the rate of hitting a Log action. The value must be in the format "N/unit",
                     where N is a number and unit is one of: second, minute, hour, or day. For example: "10/second" or "100/hour".
+                    When LogConnectionTransitions is enabled, this also bounds the follow-up logs: a connection whose
+                    initial log was suppressed by this rate limit gets no follow-up log either.
                   pattern: ^[1-9]\d{0,3}/(?:second|minute|hour|day)$
                   type: string
                 logActionRateLimitBurst:
@@ -999,6 +1007,33 @@ spec:
                   maximum: 9999
                   minimum: 0
                   type: integer
+                logConnectionTransitions:
+                  description: |-
+                    LogConnectionTransitions controls whether Felix emits an additional kernel log recording the
+                    first observed response for each connection that matched a policy rule with a Log action.
+                    When set to FirstResponseAfterLog, each connection whose initial log was emitted gets one
+                    follow-up log, prefixed with LogConnectionTransitionsPrefix plus a suffix identifying the
+                    transition: "-est" when the first reply packet is seen, "-rst" when the response is a TCP
+                    RST (connection refused), or "-icmp-err" when the response is a related ICMP error (e.g.
+                    port unreachable). The log body is the standard kernel packet log of the response packet,
+                    so the flow is identified by its 5-tuple and can be correlated with the original policy Log
+                    line (with source and destination swapped). A logged connection with no follow-up log never
+                    received a response. Connections whose initial log was suppressed by LogActionRateLimit get
+                    no follow-up log either, so every follow-up log pairs with an initial one. Enabling this
+                    consumes one bit from the Iptables/NftablesMarkMask space. Not supported in eBPF mode.
+                    [Default: Disabled]
+                  enum:
+                    - Disabled
+                    - FirstResponseAfterLog
+                  type: string
+                logConnectionTransitionsPrefix:
+                  description: |-
+                    LogConnectionTransitionsPrefix is the log prefix used for the logs emitted when
+                    LogConnectionTransitions is enabled; the transition suffix ("-est", "-rst" or "-icmp-err")
+                    is appended to it. Unlike LogPrefix, it does not support %-specifiers (such as %p): the
+                    rules that emit these logs are shared by all policies, so per-policy values cannot be
+                    substituted and any %-specifiers are rendered literally. [Default: calico-response]
+                  type: string
                 logDebugFilenameRegex:
                   description: |-
                     LogDebugFilenameRegex controls which source code files have their Debug log output included in the logs.

--- a/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_ippools.yaml
+++ b/pkg/imports/crds/calico/v1.crd.projectcalico.org/crd.projectcalico.org_ippools.yaml
@@ -68,8 +68,8 @@ spec:
                 blockSize:
                   description: |-
                     The block size to use for IP address assignments from this pool. Defaults to 26 for IPv4 and 122 for IPv6.
-                    The block size must be between 0 and 32 for IPv4 and between 0 and 128 for IPv6. It must also be smaller than
-                    or equal to the size of the pool CIDR.
+                    The block size must be between 20 and 32 for IPv4 and between 116 and 128 for IPv6. It must also be smaller
+                    than or equal to the size of the pool CIDR.
                   maximum: 128
                   minimum: 0
                   type: integer
@@ -187,6 +187,33 @@ spec:
                 - message: global() selector is not valid for IPPool namespaceSelector
                   reason: FieldValueInvalid
                   rule: "!has(self.namespaceSelector) || !self.namespaceSelector.contains('global(')"
+                - message: IPPool CIDR must be strictly masked
+                  reason: FieldValueInvalid
+                  rule: cidr(self.cidr) == cidr(self.cidr).masked()
+                - message: IPPool CIDR overlaps with IPv4 link local range 169.254.0.0/16
+                  reason: FieldValueInvalid
+                  rule:
+                    "!cidr('169.254.0.0/16').containsIP(cidr(self.cidr).ip()) &&
+                    !cidr(self.cidr).containsIP('169.254.0.0')"
+                - message: IPPool CIDR overlaps with IPv6 link local range fe80::/10
+                  reason: FieldValueInvalid
+                  rule: "!cidr('fe80::/10').containsIP(cidr(self.cidr).ip()) && !cidr(self.cidr).containsIP('fe80::')"
+                - message:
+                    blockSize must be between 20 and 32 for IPv4 pools, and between
+                    116 and 128 for IPv6 pools
+                  reason: FieldValueInvalid
+                  rule:
+                    "!has(self.blockSize) || self.blockSize == 0 || (cidr(self.cidr).ip().family()
+                    == 4 ? self.blockSize >= 20 && self.blockSize <= 32 : self.blockSize
+                    >= 116 && self.blockSize <= 128)"
+                - message:
+                    IP pool size is too small for use with Calico IPAM. It must
+                    be equal to or greater than the block size.
+                  reason: FieldValueInvalid
+                  rule:
+                    "(has(self.disabled) && self.disabled) || cidr(self.cidr).prefixLength()
+                    <= (has(self.blockSize) && self.blockSize != 0 ? self.blockSize :
+                    (cidr(self.cidr).ip().family() == 4 ? 26 : 122))"
             status:
               properties:
                 conditions:

--- a/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_felixconfigurations.yaml
+++ b/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_felixconfigurations.yaml
@@ -61,12 +61,18 @@ spec:
                 bpfAttachType:
                   description: |-
                     BPFAttachType controls how are the BPF programs at the network interfaces attached.
-                    By default `TCX` is used where available to enable easier coexistence with 3rd party programs.
-                    `TC` can force the legacy method of attaching via a qdisc. `TCX` falls back to `TC` if `TCX` is not available.
-                    [Default: TCX]
+                    By default `Netkit` is used, which attaches via the netkit API on workload interfaces that are
+                    netkit devices and via `TCX` on every other interface. `TCX` is used where available to enable
+                    easier coexistence with 3rd party programs. `TC` can force the legacy method of attaching via a
+                    qdisc. `TCX` falls back to `TC` if `TCX` is not available.
+                    Setting this to `TCX` or `TC` also makes Felix drive existing netkit devices with that mechanism
+                    instead of the netkit API, which is required before downgrading to a release without netkit
+                    support.
+                    [Default: Netkit]
                   enum:
                     - TC
                     - TCX
+                    - Netkit
                   type: string
                 bpfCTLBLogFilter:
                   description: |-
@@ -989,6 +995,8 @@ spec:
                   description: |-
                     LogActionRateLimit sets the rate of hitting a Log action. The value must be in the format "N/unit",
                     where N is a number and unit is one of: second, minute, hour, or day. For example: "10/second" or "100/hour".
+                    When LogConnectionTransitions is enabled, this also bounds the follow-up logs: a connection whose
+                    initial log was suppressed by this rate limit gets no follow-up log either.
                   pattern: ^[1-9]\d{0,3}/(?:second|minute|hour|day)$
                   type: string
                 logActionRateLimitBurst:
@@ -998,6 +1006,33 @@ spec:
                   maximum: 9999
                   minimum: 0
                   type: integer
+                logConnectionTransitions:
+                  description: |-
+                    LogConnectionTransitions controls whether Felix emits an additional kernel log recording the
+                    first observed response for each connection that matched a policy rule with a Log action.
+                    When set to FirstResponseAfterLog, each connection whose initial log was emitted gets one
+                    follow-up log, prefixed with LogConnectionTransitionsPrefix plus a suffix identifying the
+                    transition: "-est" when the first reply packet is seen, "-rst" when the response is a TCP
+                    RST (connection refused), or "-icmp-err" when the response is a related ICMP error (e.g.
+                    port unreachable). The log body is the standard kernel packet log of the response packet,
+                    so the flow is identified by its 5-tuple and can be correlated with the original policy Log
+                    line (with source and destination swapped). A logged connection with no follow-up log never
+                    received a response. Connections whose initial log was suppressed by LogActionRateLimit get
+                    no follow-up log either, so every follow-up log pairs with an initial one. Enabling this
+                    consumes one bit from the Iptables/NftablesMarkMask space. Not supported in eBPF mode.
+                    [Default: Disabled]
+                  enum:
+                    - Disabled
+                    - FirstResponseAfterLog
+                  type: string
+                logConnectionTransitionsPrefix:
+                  description: |-
+                    LogConnectionTransitionsPrefix is the log prefix used for the logs emitted when
+                    LogConnectionTransitions is enabled; the transition suffix ("-est", "-rst" or "-icmp-err")
+                    is appended to it. Unlike LogPrefix, it does not support %-specifiers (such as %p): the
+                    rules that emit these logs are shared by all policies, so per-policy values cannot be
+                    substituted and any %-specifiers are rendered literally. [Default: calico-response]
+                  type: string
                 logDebugFilenameRegex:
                   description: |-
                     LogDebugFilenameRegex controls which source code files have their Debug log output included in the logs.

--- a/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_ippools.yaml
+++ b/pkg/imports/crds/calico/v3.projectcalico.org/projectcalico.org_ippools.yaml
@@ -93,8 +93,8 @@ spec:
                 blockSize:
                   description: |-
                     The block size to use for IP address assignments from this pool. Defaults to 26 for IPv4 and 122 for IPv6.
-                    The block size must be between 0 and 32 for IPv4 and between 0 and 128 for IPv6. It must also be smaller than
-                    or equal to the size of the pool CIDR.
+                    The block size must be between 20 and 32 for IPv4 and between 116 and 128 for IPv6. It must also be smaller
+                    than or equal to the size of the pool CIDR.
                   maximum: 128
                   minimum: 0
                   type: integer
@@ -212,6 +212,33 @@ spec:
                 - message: global() selector is not valid for IPPool namespaceSelector
                   reason: FieldValueInvalid
                   rule: "!has(self.namespaceSelector) || !self.namespaceSelector.contains('global(')"
+                - message: IPPool CIDR must be strictly masked
+                  reason: FieldValueInvalid
+                  rule: cidr(self.cidr) == cidr(self.cidr).masked()
+                - message: IPPool CIDR overlaps with IPv4 link local range 169.254.0.0/16
+                  reason: FieldValueInvalid
+                  rule:
+                    "!cidr('169.254.0.0/16').containsIP(cidr(self.cidr).ip()) &&
+                    !cidr(self.cidr).containsIP('169.254.0.0')"
+                - message: IPPool CIDR overlaps with IPv6 link local range fe80::/10
+                  reason: FieldValueInvalid
+                  rule: "!cidr('fe80::/10').containsIP(cidr(self.cidr).ip()) && !cidr(self.cidr).containsIP('fe80::')"
+                - message:
+                    blockSize must be between 20 and 32 for IPv4 pools, and between
+                    116 and 128 for IPv6 pools
+                  reason: FieldValueInvalid
+                  rule:
+                    "!has(self.blockSize) || self.blockSize == 0 || (cidr(self.cidr).ip().family()
+                    == 4 ? self.blockSize >= 20 && self.blockSize <= 32 : self.blockSize
+                    >= 116 && self.blockSize <= 128)"
+                - message:
+                    IP pool size is too small for use with Calico IPAM. It must
+                    be equal to or greater than the block size.
+                  reason: FieldValueInvalid
+                  rule:
+                    "(has(self.disabled) && self.disabled) || cidr(self.cidr).prefixLength()
+                    <= (has(self.blockSize) && self.blockSize != 0 ? self.blockSize :
+                    (cidr(self.cidr).ip().family() == 4 ? 26 : 122))"
             status:
               properties:
                 conditions:

--- a/pkg/imports/crds/enterprise/v1.crd.projectcalico.org/crd.projectcalico.org_bgpconfigurations.yaml
+++ b/pkg/imports/crds/enterprise/v1.crd.projectcalico.org/crd.projectcalico.org_bgpconfigurations.yaml
@@ -211,13 +211,33 @@ spec:
                   x-kubernetes-list-type: atomic
                 programClusterRoutes:
                   description: |-
-                    ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
-                    when that workload's IP comes from an IP Pool with vxlanMode: Never. When ProgramClusterRoutes is Enabled,
-                    confd and BIRD program that route. When ProgramClusterRoutes is Disabled, it is expected that Felix will program that route.
-                    Felix always programs such routes for IP Pools with vxlanMode: Always or vxlanMode: CrossSubnet. [Default: Enabled]
+                    ProgramClusterRoutes controls which "cluster routes" are programmed by Calico's BGP
+                    stack, i.e. the routes that a node needs in order to reach workloads on other nodes.  It
+                    only applies to IP Pools with vxlanMode: Never; the cluster routes for IP Pools with
+                    vxlanMode: Always or vxlanMode: CrossSubnet are always programmed by Felix.  The routes
+                    that BIRD does not program here are expected to be programmed by Felix instead.  Below,
+                    an IPIP IP Pool is one with ipipMode: Always or CrossSubnet, and an unencapsulated one
+                    has ipipMode and vxlanMode both Never.
+
+                    - Disabled: BIRD programs no cluster routes.
+                    - EnabledNoEncapOnly: BIRD programs them for unencapsulated IP Pools.
+                    - EnabledIPIPOnly: BIRD programs them for IPIP IP Pools.
+                    - Enabled: BIRD programs them for both.
+
+                    This field must be kept consistent with FelixConfiguration.ProgramClusterRoutes, which
+                    makes the same choice from Felix's side.  If both Felix and BIRD are enabled for the same
+                    kind of IP Pool they will fight over the routes; if neither is, there will be no cluster
+                    routes at all.
+
+                    Note: asking BIRD to program IPIP cluster routes, which the Enabled and EnabledIPIPOnly
+                    values do, is deprecated as of v3.33 and will be removed in v3.35.
+
+                    [Default: EnabledNoEncapOnly]
                   enum:
                     - Enabled
                     - Disabled
+                    - EnabledIPIPOnly
+                    - EnabledNoEncapOnly
                   type: string
                 serviceClusterIPs:
                   description: |-

--- a/pkg/imports/crds/enterprise/v1.crd.projectcalico.org/crd.projectcalico.org_felixconfigurations.yaml
+++ b/pkg/imports/crds/enterprise/v1.crd.projectcalico.org/crd.projectcalico.org_felixconfigurations.yaml
@@ -84,12 +84,18 @@ spec:
                 bpfAttachType:
                   description: |-
                     BPFAttachType controls how are the BPF programs at the network interfaces attached.
-                    By default `TCX` is used where available to enable easier coexistence with 3rd party programs.
-                    `TC` can force the legacy method of attaching via a qdisc. `TCX` falls back to `TC` if `TCX` is not available.
-                    [Default: TCX]
+                    By default `Netkit` is used, which attaches via the netkit API on workload interfaces that are
+                    netkit devices and via `TCX` on every other interface. `TCX` is used where available to enable
+                    easier coexistence with 3rd party programs. `TC` can force the legacy method of attaching via a
+                    qdisc. `TCX` falls back to `TC` if `TCX` is not available.
+                    Setting this to `TCX` or `TC` also makes Felix drive existing netkit devices with that mechanism
+                    instead of the netkit API, which is required before downgrading to a release without netkit
+                    support.
+                    [Default: Netkit]
                   enum:
                     - TC
                     - TCX
+                    - Netkit
                   type: string
                 bpfCTLBLogFilter:
                   description: |-
@@ -1854,13 +1860,33 @@ spec:
                   type: string
                 programClusterRoutes:
                   description: |-
-                    ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
-                    when that workload's IP comes from an IP Pool with vxlanMode: Never. When ProgramClusterRoutes is Disabled,
-                    it is expected that confd and BIRD will program that route. When ProgramClusterRoutes is Enabled, Felix program that route.
-                    Felix always programs such routes for IP Pools with vxlanMode: Always or vxlanMode: CrossSubnet. [Default: Disabled]
+                    ProgramClusterRoutes controls which "cluster routes" Felix programs, i.e. the routes that
+                    a node needs in order to reach workloads on other nodes.  It only applies to IP Pools
+                    with vxlanMode: Never; Felix always programs the cluster routes for IP Pools with
+                    vxlanMode: Always or vxlanMode: CrossSubnet.  The routes that Felix does not program here
+                    are expected to be programmed by Calico's BGP stack instead.  Below, an IPIP IP Pool is
+                    one with ipipMode: Always or CrossSubnet, and an unencapsulated one has ipipMode and
+                    vxlanMode both Never.
+
+                    - Disabled: Felix programs no cluster routes.
+                    - EnabledIPIPOnly: Felix programs them for IPIP IP Pools.
+                    - EnabledNoEncapOnly: Felix programs them for unencapsulated IP Pools.
+                    - Enabled: Felix programs them for both.
+
+                    This field must be kept consistent with BGPConfiguration.ProgramClusterRoutes, which
+                    makes the same choice from BIRD's side.  If both Felix and BIRD are enabled for the same
+                    kind of IP Pool they will fight over the routes; if neither is, there will be no cluster
+                    routes at all.
+
+                    Note: leaving the IPIP cluster routes to BGP, which the Disabled and EnabledNoEncapOnly
+                    values do, is deprecated as of v3.33 and will be removed in v3.35.
+
+                    [Default: EnabledIPIPOnly]
                   enum:
                     - Enabled
                     - Disabled
+                    - EnabledIPIPOnly
+                    - EnabledNoEncapOnly
                   type: string
                 prometheusGoMetricsEnabled:
                   description: |-

--- a/pkg/imports/crds/enterprise/v3.projectcalico.org/projectcalico.org_bgpconfigurations.yaml
+++ b/pkg/imports/crds/enterprise/v3.projectcalico.org/projectcalico.org_bgpconfigurations.yaml
@@ -213,13 +213,33 @@ spec:
                   x-kubernetes-list-type: atomic
                 programClusterRoutes:
                   description: |-
-                    ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
-                    when that workload's IP comes from an IP Pool with vxlanMode: Never. When ProgramClusterRoutes is Enabled,
-                    confd and BIRD program that route. When ProgramClusterRoutes is Disabled, it is expected that Felix will program that route.
-                    Felix always programs such routes for IP Pools with vxlanMode: Always or vxlanMode: CrossSubnet. [Default: Enabled]
+                    ProgramClusterRoutes controls which "cluster routes" are programmed by Calico's BGP
+                    stack, i.e. the routes that a node needs in order to reach workloads on other nodes.  It
+                    only applies to IP Pools with vxlanMode: Never; the cluster routes for IP Pools with
+                    vxlanMode: Always or vxlanMode: CrossSubnet are always programmed by Felix.  The routes
+                    that BIRD does not program here are expected to be programmed by Felix instead.  Below,
+                    an IPIP IP Pool is one with ipipMode: Always or CrossSubnet, and an unencapsulated one
+                    has ipipMode and vxlanMode both Never.
+
+                    - Disabled: BIRD programs no cluster routes.
+                    - EnabledNoEncapOnly: BIRD programs them for unencapsulated IP Pools.
+                    - EnabledIPIPOnly: BIRD programs them for IPIP IP Pools.
+                    - Enabled: BIRD programs them for both.
+
+                    This field must be kept consistent with FelixConfiguration.ProgramClusterRoutes, which
+                    makes the same choice from Felix's side.  If both Felix and BIRD are enabled for the same
+                    kind of IP Pool they will fight over the routes; if neither is, there will be no cluster
+                    routes at all.
+
+                    Note: asking BIRD to program IPIP cluster routes, which the Enabled and EnabledIPIPOnly
+                    values do, is deprecated as of v3.33 and will be removed in v3.35.
+
+                    [Default: EnabledNoEncapOnly]
                   enum:
                     - Enabled
                     - Disabled
+                    - EnabledIPIPOnly
+                    - EnabledNoEncapOnly
                   type: string
                 serviceClusterIPs:
                   description: |-

--- a/pkg/imports/crds/enterprise/v3.projectcalico.org/projectcalico.org_felixconfigurations.yaml
+++ b/pkg/imports/crds/enterprise/v3.projectcalico.org/projectcalico.org_felixconfigurations.yaml
@@ -83,12 +83,18 @@ spec:
                 bpfAttachType:
                   description: |-
                     BPFAttachType controls how are the BPF programs at the network interfaces attached.
-                    By default `TCX` is used where available to enable easier coexistence with 3rd party programs.
-                    `TC` can force the legacy method of attaching via a qdisc. `TCX` falls back to `TC` if `TCX` is not available.
-                    [Default: TCX]
+                    By default `Netkit` is used, which attaches via the netkit API on workload interfaces that are
+                    netkit devices and via `TCX` on every other interface. `TCX` is used where available to enable
+                    easier coexistence with 3rd party programs. `TC` can force the legacy method of attaching via a
+                    qdisc. `TCX` falls back to `TC` if `TCX` is not available.
+                    Setting this to `TCX` or `TC` also makes Felix drive existing netkit devices with that mechanism
+                    instead of the netkit API, which is required before downgrading to a release without netkit
+                    support.
+                    [Default: Netkit]
                   enum:
                     - TC
                     - TCX
+                    - Netkit
                   type: string
                 bpfCTLBLogFilter:
                   description: |-
@@ -1853,13 +1859,33 @@ spec:
                   type: string
                 programClusterRoutes:
                   description: |-
-                    ProgramClusterRoutes controls how a cluster node gets a route to a workload on another node,
-                    when that workload's IP comes from an IP Pool with vxlanMode: Never. When ProgramClusterRoutes is Disabled,
-                    it is expected that confd and BIRD will program that route. When ProgramClusterRoutes is Enabled, Felix program that route.
-                    Felix always programs such routes for IP Pools with vxlanMode: Always or vxlanMode: CrossSubnet. [Default: Disabled]
+                    ProgramClusterRoutes controls which "cluster routes" Felix programs, i.e. the routes that
+                    a node needs in order to reach workloads on other nodes.  It only applies to IP Pools
+                    with vxlanMode: Never; Felix always programs the cluster routes for IP Pools with
+                    vxlanMode: Always or vxlanMode: CrossSubnet.  The routes that Felix does not program here
+                    are expected to be programmed by Calico's BGP stack instead.  Below, an IPIP IP Pool is
+                    one with ipipMode: Always or CrossSubnet, and an unencapsulated one has ipipMode and
+                    vxlanMode both Never.
+
+                    - Disabled: Felix programs no cluster routes.
+                    - EnabledIPIPOnly: Felix programs them for IPIP IP Pools.
+                    - EnabledNoEncapOnly: Felix programs them for unencapsulated IP Pools.
+                    - Enabled: Felix programs them for both.
+
+                    This field must be kept consistent with BGPConfiguration.ProgramClusterRoutes, which
+                    makes the same choice from BIRD's side.  If both Felix and BIRD are enabled for the same
+                    kind of IP Pool they will fight over the routes; if neither is, there will be no cluster
+                    routes at all.
+
+                    Note: leaving the IPIP cluster routes to BGP, which the Disabled and EnabledNoEncapOnly
+                    values do, is deprecated as of v3.33 and will be removed in v3.35.
+
+                    [Default: EnabledIPIPOnly]
                   enum:
                     - Enabled
                     - Disabled
+                    - EnabledIPIPOnly
+                    - EnabledNoEncapOnly
                   type: string
                 prometheusGoMetricsEnabled:
                   description: |-

--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -106,6 +106,16 @@ var (
 		"delete",
 		"deletecollection",
 	}
+
+	// writeVerbs is the subset of allVerbs that the tiered policy admission webhook
+	// intercepts, used for tiered policy passthrough in v3-CRD mode.
+	writeVerbs = []string{
+		"create",
+		"update",
+		"patch",
+		"delete",
+		"deletecollection",
+	}
 )
 
 func APIServer(cfg *APIServerConfiguration) (Component, error) {
@@ -203,6 +213,8 @@ func (c *apiServerComponent) Objects() ([]client.Object, []client.Object) {
 		c.delegateAuthClusterRoleBinding(),
 		c.webhookReaderClusterRole(),
 		c.webhookReaderClusterRoleBinding(),
+		c.calicoPolicyPassthruClusterRole(),
+		c.calicoPolicyPassthruClusterRolebinding(),
 	}
 
 	objsToDelete := []client.Object{}
@@ -225,8 +237,6 @@ func (c *apiServerComponent) Objects() ([]client.Object, []client.Object) {
 	// These are objects that only need to exist when we are running an aggregation API server to
 	// serve projectcalico.org/v3 APIs. If using CRDs for this API group, we can remove these objects.
 	aggregationAPIServerObjects := []client.Object{
-		c.calicoPolicyPassthruClusterRole(),
-		c.calicoPolicyPassthruClusterRolebinding(),
 		c.authClusterRole(),
 		c.authClusterRoleBinding(),
 		c.authReaderRoleBinding(),
@@ -1114,7 +1124,15 @@ func (c *apiServerComponent) kubeControllerMgrTierGetterClusterRoleBinding() *rb
 // calicoPolicyPassthruClusterRole creates a clusterrole that is used to control the RBAC
 // mechanism for Calico tiered policy.
 func (c *apiServerComponent) calicoPolicyPassthruClusterRole() *rbacv1.ClusterRole {
-	resources := []string{"networkpolicies", "globalnetworkpolicies"}
+	resources := []string{"networkpolicies", "globalnetworkpolicies", "stagednetworkpolicies", "stagedglobalnetworkpolicies"}
+
+	// The aggregation API server authorizes reads against the tier.xxx resource type, so it can
+	// pass every verb through. In v3-CRD mode only writes reach the admission webhook, so reads
+	// stay subject to ordinary RBAC and roles must grant them explicitly.
+	verbs := allVerbs
+	if !c.cfg.RequiresAggregationServer {
+		verbs = writeVerbs
+	}
 
 	return &rbacv1.ClusterRole{
 		TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
@@ -1128,7 +1146,7 @@ func (c *apiServerComponent) calicoPolicyPassthruClusterRole() *rbacv1.ClusterRo
 			{
 				APIGroups: []string{"projectcalico.org"},
 				Resources: resources,
-				Verbs:     allVerbs,
+				Verbs:     verbs,
 			},
 		},
 	}

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -220,8 +220,14 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 		for _, rule := range cr.Rules {
 			tieredPolicyRules = append(tieredPolicyRules, rule.Resources...)
 		}
-		Expect(tieredPolicyRules).To(ContainElements("networkpolicies", "globalnetworkpolicies"))
-		Expect(tieredPolicyRules).ToNot(ContainElements("stagednetworkpolicies", "stagedglobalnetworkpolicies"))
+		// Staged policies are tiered in both variants, so they get the same passthrough.
+		Expect(tieredPolicyRules).To(ContainElements("networkpolicies", "globalnetworkpolicies",
+			"stagednetworkpolicies", "stagedglobalnetworkpolicies"))
+		// StagedKubernetesNetworkPolicy has no tier and is handled by ordinary RBAC.
+		Expect(tieredPolicyRules).ToNot(ContainElement("stagedkubernetesnetworkpolicies"))
+
+		// The aggregation API server authorizes reads itself, so the passthrough covers them too.
+		Expect(cr.Rules[0].Verbs).To(ContainElements("get", "list", "watch"))
 	},
 		Entry("default cluster domain", dns.DefaultClusterDomain),
 		Entry("custom cluster domain", "custom-domain.internal"),
@@ -250,6 +256,27 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 		rtest.ExpectResourceInList(deleteResources, "calico-apiserver", "calico-system", "apps", "v1", "Deployment")
 		rtest.ExpectResourceInList(deleteResources, "calico-api", "calico-system", "", "v1", "Service")
 		rtest.ExpectResourceInList(deleteResources, "calico-apiserver", "calico-system", "policy", "v1", "PodDisruptionBudget")
+	})
+
+	It("should render a write-only tiered policy passthrough in v3 CRD mode", func() {
+		cfg.RequiresAggregationServer = false
+
+		component, err := render.APIServer(cfg)
+		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
+		Expect(component.ResolveImages(nil)).To(BeNil())
+		resources, _ := apiServerObjects(component)
+
+		cr := rtest.GetResource(resources, "calico-tiered-policy-passthrough", "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
+		Expect(cr.Rules).To(HaveLen(1))
+		Expect(cr.Rules[0].Resources).To(ConsistOf("networkpolicies", "globalnetworkpolicies",
+			"stagednetworkpolicies", "stagedglobalnetworkpolicies"))
+
+		// Writes pass through to the admission webhook, which enforces the tier. Reads have no
+		// such hook, so they stay subject to ordinary RBAC.
+		Expect(cr.Rules[0].Verbs).To(ConsistOf("create", "update", "patch", "delete", "deletecollection"))
+		Expect(cr.Rules[0].Verbs).NotTo(ContainElements("get", "list", "watch"))
+
+		rtest.ExpectResourceInList(resources, "calico-tiered-policy-passthrough", "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding")
 	})
 
 	It("should not register the aggregation APIService when not requiring the aggregation server", func() {


### PR DESCRIPTION
Cherry-pick of https://github.com/tigera/operator/pull/5259 to `release-v1.44`.

The tiered policy passthrough role is only rendered when running the aggregation API server, so on clusters serving the Calico v3 API through CRDs every tier-scoped role is denied on all verbs. This renders it in both modes: all verbs under the aggregation API server as before, writes only in v3 CRD mode, where writes reach the tiered policy admission webhook and reads stay subject to ordinary RBAC. Staged policies also move into the base role, since they are tiered in Calico as well as Enterprise.

The second commit syncs the Calico and Enterprise CRDs. The generated-file check was already failing on this branch before the pick, since the tracked Calico and Enterprise branches have added CRD fields since the last sync.

The third commit moves the FV kind cluster to Kubernetes 1.32. The new IPPool validation rules exceed the CRD cost budget on 1.31, so the synced CRDs cannot be applied there at all.

```release-note
Fixes tier-scoped policy roles being denied all access on clusters serving the Calico v3 API through CRDs.
```

```release-note
Fixes staged network policy writes being denied for tier-scoped roles in Calico.
```
