### PR TITLE
[release-v1.43] Render a write-only tiered policy passthrough in v3 CRD mode

### DIFF
--- a/pkg/render/apiserver.go
+++ b/pkg/render/apiserver.go
@@ -107,6 +107,16 @@ var (
 		"delete",
 		"deletecollection",
 	}
+
+	// writeVerbs is the subset of allVerbs that the tiered policy admission webhook
+	// intercepts, used for tiered policy passthrough in v3-CRD mode.
+	writeVerbs = []string{
+		"create",
+		"update",
+		"patch",
+		"delete",
+		"deletecollection",
+	}
 )
 
 func APIServer(cfg *APIServerConfiguration) (Component, error) {
@@ -224,6 +234,8 @@ func (c *apiServerComponent) Objects() ([]client.Object, []client.Object) {
 		c.delegateAuthClusterRoleBinding(),
 		c.webhookReaderClusterRole(),
 		c.webhookReaderClusterRoleBinding(),
+		c.calicoPolicyPassthruClusterRole(),
+		c.calicoPolicyPassthruClusterRolebinding(),
 	}
 
 	objsToDelete := []client.Object{}
@@ -257,8 +269,6 @@ func (c *apiServerComponent) Objects() ([]client.Object, []client.Object) {
 	// These are objects that only need to exist when we are running an aggregation API server to
 	// serve projectcalico.org/v3 APIs. If using CRDs for this API group, we can remove these objects.
 	aggregationAPIServerObjects := []client.Object{
-		c.calicoPolicyPassthruClusterRole(),
-		c.calicoPolicyPassthruClusterRolebinding(),
 		c.authClusterRole(),
 		c.authClusterRoleBinding(),
 		c.authReaderRoleBinding(),
@@ -2163,11 +2173,14 @@ func (c *apiServerComponent) tigeraNetworkAdminClusterRole() *rbacv1.ClusterRole
 // calicoPolicyPassthruClusterRole creates a clusterrole that is used to control the RBAC
 // mechanism for Calico tiered policy.
 func (c *apiServerComponent) calicoPolicyPassthruClusterRole() *rbacv1.ClusterRole {
-	resources := []string{"networkpolicies", "globalnetworkpolicies"}
+	resources := []string{"networkpolicies", "globalnetworkpolicies", "stagednetworkpolicies", "stagedglobalnetworkpolicies"}
 
-	// Append additional resources for enterprise Variant.
-	if c.cfg.Installation.Variant.IsEnterprise() {
-		resources = append(resources, "stagednetworkpolicies", "stagedglobalnetworkpolicies")
+	// The aggregation API server authorizes reads against the tier.xxx resource type, so it can
+	// pass every verb through. In v3-CRD mode only writes reach the admission webhook, so reads
+	// stay subject to ordinary RBAC and roles must grant them explicitly.
+	verbs := allVerbs
+	if !c.cfg.RequiresAggregationServer {
+		verbs = writeVerbs
 	}
 
 	return &rbacv1.ClusterRole{
@@ -2182,7 +2195,7 @@ func (c *apiServerComponent) calicoPolicyPassthruClusterRole() *rbacv1.ClusterRo
 			{
 				APIGroups: []string{"projectcalico.org"},
 				Resources: resources,
-				Verbs:     allVerbs,
+				Verbs:     verbs,
 			},
 		},
 	}

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -408,6 +408,8 @@ var _ = Describe("API server rendering tests (Calico Enterprise)", func() {
 			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "tigera-network-admin"}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"}},
 			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "calico-webhook-reader"}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"}},
 			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "calico-apiserver-webhook-reader"}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
+			&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "calico-tiered-policy-passthrough"}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"}},
+			&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: "calico-tiered-policy-passthrough"}, TypeMeta: metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"}},
 		}
 
 		rtest.ExpectResources(resources, expectedResources)

--- a/pkg/render/apiserver_test.go
+++ b/pkg/render/apiserver_test.go
@@ -2062,8 +2062,14 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 		for _, rule := range cr.Rules {
 			tieredPolicyRules = append(tieredPolicyRules, rule.Resources...)
 		}
-		Expect(tieredPolicyRules).To(ContainElements("networkpolicies", "globalnetworkpolicies"))
-		Expect(tieredPolicyRules).ToNot(ContainElements("stagednetworkpolicies", "stagedglobalnetworkpolicies"))
+		// Staged policies are tiered in both variants, so they get the same passthrough.
+		Expect(tieredPolicyRules).To(ContainElements("networkpolicies", "globalnetworkpolicies",
+			"stagednetworkpolicies", "stagedglobalnetworkpolicies"))
+		// StagedKubernetesNetworkPolicy has no tier and is handled by ordinary RBAC.
+		Expect(tieredPolicyRules).ToNot(ContainElement("stagedkubernetesnetworkpolicies"))
+
+		// The aggregation API server authorizes reads itself, so the passthrough covers them too.
+		Expect(cr.Rules[0].Verbs).To(ContainElements("get", "list", "watch"))
 	},
 		Entry("default cluster domain", dns.DefaultClusterDomain),
 		Entry("custom cluster domain", "custom-domain.internal"),
@@ -2092,6 +2098,27 @@ var _ = Describe("API server rendering tests (Calico)", func() {
 		rtest.ExpectResourceInList(deleteResources, "calico-apiserver", "calico-system", "apps", "v1", "Deployment")
 		rtest.ExpectResourceInList(deleteResources, "calico-api", "calico-system", "", "v1", "Service")
 		rtest.ExpectResourceInList(deleteResources, "calico-apiserver", "calico-system", "policy", "v1", "PodDisruptionBudget")
+	})
+
+	It("should render a write-only tiered policy passthrough in v3 CRD mode", func() {
+		cfg.RequiresAggregationServer = false
+
+		component, err := render.APIServer(cfg)
+		Expect(err).To(BeNil(), "Expected APIServer to create successfully %s", err)
+		Expect(component.ResolveImages(nil)).To(BeNil())
+		resources, _ := component.Objects()
+
+		cr := rtest.GetResource(resources, "calico-tiered-policy-passthrough", "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
+		Expect(cr.Rules).To(HaveLen(1))
+		Expect(cr.Rules[0].Resources).To(ConsistOf("networkpolicies", "globalnetworkpolicies",
+			"stagednetworkpolicies", "stagedglobalnetworkpolicies"))
+
+		// Writes pass through to the admission webhook, which enforces the tier. Reads have no
+		// such hook, so they stay subject to ordinary RBAC.
+		Expect(cr.Rules[0].Verbs).To(ConsistOf("create", "update", "patch", "delete", "deletecollection"))
+		Expect(cr.Rules[0].Verbs).NotTo(ContainElements("get", "list", "watch"))
+
+		rtest.ExpectResourceInList(resources, "calico-tiered-policy-passthrough", "", "rbac.authorization.k8s.io", "v1", "ClusterRoleBinding")
 	})
 
 	It("should render an API server with custom configuration", func() {


### PR DESCRIPTION
Cherry-pick of https://github.com/tigera/operator/pull/5259 to `release-v1.43`.

The tiered policy passthrough role is only rendered when running the aggregation API server, so on clusters serving the Calico v3 API through CRDs every tier-scoped role is denied on all verbs. This renders it in both modes: all verbs under the aggregation API server as before, writes only in v3 CRD mode, where writes reach the tiered policy admission webhook and reads stay subject to ordinary RBAC. Staged policies also move into the base role, since they are tiered in Calico as well as Enterprise. This branch predates the split of Enterprise rendering into its own package, so that move folds the Enterprise-only append into the base list.

```release-note
Fixes tier-scoped policy roles being denied all access on clusters serving the Calico v3 API through CRDs.
```

```release-note
Fixes staged network policy writes being denied for tier-scoped roles in Calico.
```
