### PR TITLE
[release-v1.43] Bump the FV kind cluster to Kubernetes 1.32

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -355,7 +355,7 @@ run-fvs: $(ENVOY_GATEWAY_CHART) $(ISTIO_CHART_FILES)
 ## Create a local kind dual stack cluster.
 KIND_CLUSTER_NAME?=tigera-operator-kind
 KIND_KUBECONFIG?=./kubeconfig.yaml
-KINDEST_NODE_VERSION?=v1.31.12
+KINDEST_NODE_VERSION?=v1.32.11
 cluster-create: $(BINDIR)/kubectl $(BINDIR)/kind
 	# First make sure any previous cluster is deleted
 	make cluster-destroy


### PR DESCRIPTION
The FV kind cluster moves from Kubernetes 1.31 to 1.32.

New CEL validation rules on the IPPool CRD exceed the per-schema cost budget that kube-apiserver 1.31 enforces, so `make fv` dies applying CRDs before a single test runs. Those rules are already in Calico v3.33 and will reach this branch the next time its CRDs are synced. https://github.com/tigera/operator/pull/5266 made the same bump on `release-v1.44`, where it was needed to get FV green.

```release-note
None
```
