### PR TITLE
feat(manager): show the WAF management UI when the WAF extension is on

### DIFF
--- a/pkg/controller/manager/manager_controller.go
+++ b/pkg/controller/manager/manager_controller.go
@@ -737,6 +737,12 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 		return reconcile.Result{}, err
 	}
 
+	wafUIEnabled, err := wafManagementEnabled(ctx, r.client, installationSpec.Variant, tenant.MultiTenant())
+	if err != nil {
+		r.status.SetDegraded(operatorv1.ResourceReadError, "Error reading the GatewayAPI WAF extension", err, logc)
+		return reconcile.Result{}, err
+	}
+
 	managerCfg := &render.ManagerConfiguration{
 		VoltronRouteConfig:         routeConfig,
 		KeyValidatorConfig:         keyValidatorConfig,
@@ -764,6 +770,7 @@ func (r *ReconcileManager) Reconcile(ctx context.Context, request reconcile.Requ
 		Authentication:             authenticationCR,
 		KibanaEnabled:              kibanaEnabled,
 		RBACManagementEnabled:      rbacManagementEnabled,
+		WAFManagementEnabled:       wafUIEnabled,
 		CACertCommonName:           certificateManager.CACertCommonName(),
 		Cloud:                      r.opts.Cloud,
 		CloudResources:             mcr,
@@ -1037,6 +1044,32 @@ func (r *ReconcileManager) managerGatewayNamespaces(ctx context.Context) ([]stri
 	}
 	slices.Sort(namespaces)
 	return namespaces, true, nil
+}
+
+// wafManagementEnabled reports whether to render the WAF management UI surface, which
+// follows GatewayAPI.spec.extensions.waf: turning WAF on gives you the UI for it, and
+// there is no second switch to forget.
+//
+// Enterprise-only, and off on multi-tenant management clusters, matching
+// utils.RBACManagementEnabled. The read mirrors isGatewayWAFEnabled in the
+// applicationlayer controller: a missing GatewayAPI CR means no gateways, so no WAF and
+// no UI, and that is not an error. Any other read error is returned so the caller
+// requeues rather than reporting the feature off.
+//
+// The manager controller already watches GatewayAPI (see Add), so flipping the extension
+// re-reconciles and rolls ui-apis with the new value.
+func wafManagementEnabled(ctx context.Context, c client.Client, variant operatorv1.ProductVariant, multiTenant bool) (bool, error) {
+	if !variant.IsEnterprise() || multiTenant {
+		return false, nil
+	}
+	gatewayAPI, msg, err := gatewayapi.GetGatewayAPI(ctx, c)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("%s: %w", msg, err)
+	}
+	return gatewayAPI.Spec.IsWAFGatewayExtensionEnabled(), nil
 }
 
 // resolveGateway validates the Manager spec.ingressGateway configuration, resolves the

--- a/pkg/controller/manager/manager_controller_test.go
+++ b/pkg/controller/manager/manager_controller_test.go
@@ -1581,3 +1581,71 @@ func assertSANs(secret *corev1.Secret, expectedSAN string) {
 
 	Expect(cert.DNSNames).To(Equal([]string{expectedSAN}))
 }
+
+// The WAF management UI follows GatewayAPI.spec.extensions.waf, so there is no second
+// switch to set. These cover the read the manager controller does to resolve it.
+var _ = Describe("wafManagementEnabled", func() {
+	var c client.Client
+	var ctx context.Context
+
+	BeforeEach(func() {
+		scheme := runtime.NewScheme()
+		Expect(apis.AddToScheme(scheme, false)).NotTo(HaveOccurred())
+		c = ctrlrfake.DefaultFakeClientBuilder(scheme).Build()
+		ctx = context.Background()
+	})
+
+	gatewayAPI := func(name string, state *operatorv1.WAFExtensionState) *operatorv1.GatewayAPI {
+		gw := &operatorv1.GatewayAPI{ObjectMeta: metav1.ObjectMeta{Name: name}}
+		if state != nil {
+			gw.Spec.Extensions = &operatorv1.GatewayAPIExtensions{
+				WAF: &operatorv1.WAFExtensionSpec{State: state},
+			}
+		}
+		return gw
+	}
+	enabled := operatorv1.WAFExtensionStateEnabled
+	disabled := operatorv1.WAFExtensionStateDisabled
+
+	// A cluster with no gateways has no WAF, so no UI. That is the normal state of a
+	// cluster that never enabled Gateway API, not a failure to read.
+	It("is disabled and does not error when no GatewayAPI CR exists", func() {
+		got, err := wafManagementEnabled(ctx, c, operatorv1.CalicoEnterprise, false)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got).To(BeFalse())
+	})
+
+	DescribeTable("follows the WAF extension state",
+		func(state *operatorv1.WAFExtensionState, expected bool) {
+			Expect(c.Create(ctx, gatewayAPI("default", state))).NotTo(HaveOccurred())
+			got, err := wafManagementEnabled(ctx, c, operatorv1.CalicoEnterprise, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got).To(Equal(expected))
+		},
+		Entry("extensions unset", nil, false),
+		Entry("state Disabled", &disabled, false),
+		Entry("state Enabled", &enabled, true),
+	)
+
+	// GetGatewayAPI falls back to the legacy enterprise name, so an older cluster that
+	// never got a "default" CR still resolves.
+	It("reads the legacy tigera-secure CR", func() {
+		Expect(c.Create(ctx, gatewayAPI("tigera-secure", &enabled))).NotTo(HaveOccurred())
+		got, err := wafManagementEnabled(ctx, c, operatorv1.CalicoEnterprise, false)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got).To(BeTrue())
+	})
+
+	// The variant and tenancy guards win over the extension, matching
+	// utils.RBACManagementEnabled.
+	DescribeTable("stays off where the feature is not offered",
+		func(variant operatorv1.ProductVariant, multiTenant bool) {
+			Expect(c.Create(ctx, gatewayAPI("default", &enabled))).NotTo(HaveOccurred())
+			got, err := wafManagementEnabled(ctx, c, variant, multiTenant)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got).To(BeFalse())
+		},
+		Entry("Calico variant", operatorv1.Calico, false),
+		Entry("multi-tenant management cluster", operatorv1.CalicoEnterprise, true),
+	)
+})

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -218,6 +218,11 @@ type ManagerConfiguration struct {
 	// The controller has already applied the variant, the admin's gate and tenancy.
 	RBACManagementEnabled bool
 
+	// WAFManagementEnabled reports whether to serve the WAF management UI surface.
+	// It follows GatewayAPI.spec.extensions.waf; the controller has already applied
+	// the variant and tenancy.
+	WAFManagementEnabled bool
+
 	// CACertCommonName is the CommonName from the CA certificate used for operator-managed certificates.
 	// Passed to Voltron so it can identify the correct CA issuer public key.
 	CACertCommonName string
@@ -770,6 +775,7 @@ func (c *managerComponent) managerUIAPIsContainer() corev1.Container {
 		{Name: "LINSEED_CLIENT_KEY", Value: keyPath},
 		{Name: "ELASTIC_KIBANA_DISABLED", Value: strconv.FormatBool(c.cfg.Tenant.MultiTenant())},
 		{Name: "VOLTRON_URL", Value: ManagerService(c.cfg.Tenant)},
+		{Name: "WAF_UI_ENABLED", Value: strconv.FormatBool(c.cfg.WAFManagementEnabled)},
 	}
 
 	// Determine the Linseed location. Use code default unless in multi-tenant mode,

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -158,6 +158,7 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			{Name: "LINSEED_CLIENT_KEY", Value: "/internal-manager-tls/tls.key"},
 			{Name: "ELASTIC_KIBANA_DISABLED", Value: "false"},
 			{Name: "VOLTRON_URL", Value: render.ManagerService(nil)},
+			{Name: "WAF_UI_ENABLED", Value: "false"},
 		}
 		Expect(uiAPIs.Env).To(Equal(uiAPIsExpectedEnvVars))
 
@@ -1846,6 +1847,35 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			})
 		})
 	})
+	Context("WAF management UI", func() {
+		var installation *operatorv1.InstallationSpec
+		BeforeEach(func() {
+			replicas := int32(1)
+			installation = &operatorv1.InstallationSpec{
+				ControlPlaneReplicas: &replicas,
+				Variant:              operatorv1.CalicoEnterprise,
+				Registry:             "testregistry.com/",
+			}
+		})
+
+		// ui-apis reads WAF_UI_ENABLED at startup rather than watching anything, so the
+		// GatewayAPI WAF extension's state has to reach it through the pod spec.
+		DescribeTable("projects the WAF extension state onto WAF_UI_ENABLED",
+			func(enabled bool, expected string) {
+				resources, _ := renderObjects(renderConfig{
+					installation:         installation,
+					ns:                   render.ManagerNamespace,
+					wafManagementEnabled: enabled,
+				})
+				deployment := rtest.GetResource(resources, render.ManagerDeploymentName, render.ManagerNamespace, "apps", "v1", "Deployment").(*appsv1.Deployment)
+				uiAPIs := rtest.GetContainer(deployment.Spec.Template.Spec.Containers, render.UIAPIsName)
+				Expect(uiAPIs).NotTo(BeNil())
+				Expect(uiAPIs.Env).To(ContainElement(corev1.EnvVar{Name: "WAF_UI_ENABLED", Value: expected}))
+			},
+			Entry("extension off", false, "false"),
+			Entry("extension on", true, "true"),
+		)
+	})
 })
 
 type renderConfig struct {
@@ -1866,6 +1896,8 @@ type renderConfig struct {
 	ldapHost       string
 	// rbacManagementEnabled mirrors the admin's rbac-ui-config value.
 	rbacManagementEnabled bool
+	// wafManagementEnabled mirrors GatewayAPI.spec.extensions.waf.state.
+	wafManagementEnabled  bool
 	cloud                 bool
 	voltronMetricsEnabled bool
 	cloudResources        render.ManagerCloudResources
@@ -1940,6 +1972,7 @@ func renderObjects(roc renderConfig) ([]client.Object, []client.Object) {
 		ExternalElastic:       roc.externalElastic,
 		CACertCommonName:      certificateManager.CACertCommonName(),
 		RBACManagementEnabled: roc.rbacManagementEnabled,
+		WAFManagementEnabled:  roc.wafManagementEnabled,
 		Cloud:                 roc.cloud,
 		CloudResources:        roc.cloudResources,
 	}


### PR DESCRIPTION
Jira: https://tigera.atlassian.net/browse/EV-6793

Turning on `GatewayAPI.spec.extensions.waf` now gives you the WAF management UI. There is no second switch to find.

The manager controller reads the WAF extension state and sets `WAF_UI_ENABLED` on the ui-apis container. That is the variable ui-apis already reads at startup, so this is the whole change. No new API field and no ConfigMap.

Nothing new gets watched. The manager controller has watched `GatewayAPI` since it started resolving the ingress gateway class (`manager_controller.go:172`), so flipping the extension already re-reconciles the manager.

The read mirrors `isGatewayWAFEnabled` in the applicationlayer controller. A missing `GatewayAPI` CR means no gateways, so no WAF and no UI, and that is not an error. Any other read error degrades so the controller requeues instead of reporting the feature off. Enterprise only, and off on multi-tenant, matching `utils.RBACManagementEnabled`.

Flipping `waf.state` rolls the manager Deployment. That happens on enable or disable, not during normal use.

Affected component: operator (manager controller, manager render).

## Testing

`go test ./pkg/controller/manager/ ./pkg/render/` pass. New controller specs cover no CR, extensions unset, `Disabled`, `Enabled`, the legacy `tigera-secure` CR, the Calico variant, and multi-tenant. New render spec asserts `WAF_UI_ENABLED` tracks the flag both ways.

Also run on a cluster, swapping only the operator image. One master hashrelease cluster, one `GatewayAPI` CR, nothing else changed:

| operator | `waf.state` | `WAF_UI_ENABLED` |
|---|---|---|
| stock | no CR | absent |
| this PR | no CR | `false` |
| this PR | `Enabled` | `true` |
| stock | `Enabled` | **absent** |
| this PR | `Enabled` | `true` |

Row 4 is the bug: stock reconciles, bumps the Deployment generation, and strips the variable back out while WAF is on.

## Release Note

```release-note
The WAF management UI now appears when the GatewayAPI WAF extension is enabled.
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
