### PR TITLE
[RBAC] Let tigera-network-admin write the GatewayAPI CR

### DIFF
--- a/pkg/enterprise/apiserver/extension.go
+++ b/pkg/enterprise/apiserver/extension.go
@@ -1537,11 +1537,11 @@ func (c *apiServer) tigeraNetworkAdminClusterRole() *rbacv1.ClusterRole {
 			Resources: []string{"applicationlayers", "packetcaptureapis", "compliances", "intrusiondetections"},
 			Verbs:     []string{"get", "update", "patch", "create", "delete"},
 		},
-		// Allow the user to read the gatewayapis CR to detect if Gateway API is enabled/disabled.
+		// Allow the user to read and write the gatewayapis CR to enable Gateway API.
 		{
 			APIGroups: []string{"operator.tigera.io"},
 			Resources: []string{"gatewayapis"},
-			Verbs:     []string{"get"},
+			Verbs:     []string{"get", "create", "update", "patch"},
 		},
 		// Allow the user to read Gateways and HTTPRoutes to offer as WAF policy attach targets.
 		{

--- a/pkg/enterprise/apiserver/extension_test.go
+++ b/pkg/enterprise/apiserver/extension_test.go
@@ -352,20 +352,25 @@ var _ = Describe("API server enterprise modifier", func() {
 			Verbs: []string{"create", "update", "delete", "patch", "get", "watch", "list"},
 		}))
 
-		// Both roles can read the Gateway API, so the WAF UI can detect it and offer
-		// Gateways and HTTPRoutes as policy attach targets.
+		// Both roles can read Gateways and HTTPRoutes to offer as WAF policy attach targets.
 		for _, role := range []*rbacv1.ClusterRole{uiUser, networkAdmin} {
-			Expect(role.Rules).To(ContainElement(rbacv1.PolicyRule{
-				APIGroups: []string{"operator.tigera.io"},
-				Resources: []string{"gatewayapis"},
-				Verbs:     []string{"get"},
-			}))
 			Expect(role.Rules).To(ContainElement(rbacv1.PolicyRule{
 				APIGroups: []string{"gateway.networking.k8s.io"},
 				Resources: []string{"gateways", "httproutes"},
 				Verbs:     []string{"get", "list", "watch"},
 			}))
 		}
+
+		Expect(uiUser.Rules).To(ContainElement(rbacv1.PolicyRule{
+			APIGroups: []string{"operator.tigera.io"},
+			Resources: []string{"gatewayapis"},
+			Verbs:     []string{"get"},
+		}))
+		Expect(networkAdmin.Rules).To(ContainElement(rbacv1.PolicyRule{
+			APIGroups: []string{"operator.tigera.io"},
+			Resources: []string{"gatewayapis"},
+			Verbs:     []string{"get", "create", "update", "patch"},
+		}))
 
 		// Audit policy configmap.
 		_, ok := extensions.FindObject[*corev1.ConfigMap](objs, "calico-audit-policy")


### PR DESCRIPTION
## Description

`tigera-network-admin` gets `create`, `update` and `patch` on `gatewayapis`, on top of the `get` it already had. `tigera-ui-user` is unchanged.

No `delete`. The GatewayAPI CR has no disable field, so removing it would orphan the Gateway API CRDs.

Overlaps https://github.com/tigera/operator/pull/5001, which widens the same ClusterRole for ConfigMaps. Kept separate because that PR is one of two rival gate designs. Whichever lands second will need a small conflict resolution in this function.

## Testing

`go test ./pkg/enterprise/apiserver/...` passes. One spec asserted a shared rule across both roles, so it is split per role now.

## Release Note

```release-note
The tigera-network-admin cluster role can now create, update and patch the GatewayAPI resource.
```
