### PR TITLE
[RBAC] Let the WAF UI personas read the gatewayapi TigeraStatus

### DIFF
--- a/pkg/enterprise/apiserver/extension.go
+++ b/pkg/enterprise/apiserver/extension.go
@@ -1292,6 +1292,14 @@ func (c *apiServer) tigeraUserClusterRole() *rbacv1.ClusterRole {
 			Resources: []string{"gatewayapis"},
 			Verbs:     []string{"get"},
 		},
+		// Allow the user to read the gatewayapi TigeraStatus. Gateway API readiness
+		// lives there, not on the GatewayAPI CR.
+		{
+			APIGroups:     []string{"operator.tigera.io"},
+			Resources:     []string{"tigerastatuses"},
+			ResourceNames: []string{"gatewayapi"},
+			Verbs:         []string{"get"},
+		},
 		// Allow the user to read Gateways and HTTPRoutes to offer as WAF policy attach targets.
 		{
 			APIGroups: []string{"gateway.networking.k8s.io"},
@@ -1542,6 +1550,14 @@ func (c *apiServer) tigeraNetworkAdminClusterRole() *rbacv1.ClusterRole {
 			APIGroups: []string{"operator.tigera.io"},
 			Resources: []string{"gatewayapis"},
 			Verbs:     []string{"get", "create", "update", "patch"},
+		},
+		// Allow the user to read the gatewayapi TigeraStatus. Gateway API readiness
+		// lives there, not on the GatewayAPI CR.
+		{
+			APIGroups:     []string{"operator.tigera.io"},
+			Resources:     []string{"tigerastatuses"},
+			ResourceNames: []string{"gatewayapi"},
+			Verbs:         []string{"get"},
 		},
 		// Allow the user to read Gateways and HTTPRoutes to offer as WAF policy attach targets.
 		{

--- a/pkg/enterprise/apiserver/extension_test.go
+++ b/pkg/enterprise/apiserver/extension_test.go
@@ -372,6 +372,17 @@ var _ = Describe("API server enterprise modifier", func() {
 			Verbs:     []string{"get", "create", "update", "patch"},
 		}))
 
+		// Both roles read the gatewayapi TigeraStatus, which is where Gateway API
+		// readiness lives.
+		for _, role := range []*rbacv1.ClusterRole{uiUser, networkAdmin} {
+			Expect(role.Rules).To(ContainElement(rbacv1.PolicyRule{
+				APIGroups:     []string{"operator.tigera.io"},
+				Resources:     []string{"tigerastatuses"},
+				ResourceNames: []string{"gatewayapi"},
+				Verbs:         []string{"get"},
+			}))
+		}
+
 		// Audit policy configmap.
 		_, ok := extensions.FindObject[*corev1.ConfigMap](objs, "calico-audit-policy")
 		Expect(ok).To(BeTrue())


### PR DESCRIPTION
## Description

`tigeraUserClusterRole` and `tigeraNetworkAdminClusterRole` each get one more rule: `get` on `operator.tigera.io/tigerastatuses`, narrowed with `ResourceNames` to `gatewayapi`.

Gateway API readiness lives on the `gatewayapi` TigeraStatus, not on the GatewayAPI CR, and neither role could read it. https://github.com/tigera/operator/pull/5280 granted the CR write side and nothing on TigeraStatus. The caller is https://github.com/tigera/calico-private/pull/13522, which reports readiness to the WAF management UI.

Enterprise only. No new verbs beyond `get`, and the name restriction keeps it to the one status object.

Test plan: `go test ./pkg/enterprise/apiserver/...` passes. `extension_test.go` asserts the rule on both roles.

## Release Note

```release-note
UI users and network admins can now read the gatewayapi TigeraStatus, so the WAF management UI can report Gateway API readiness.
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
