### PR TITLE
Grant calico-node update on the ippools status subresource

### DIFF
--- a/pkg/render/node.go
+++ b/pkg/render/node.go
@@ -503,6 +503,14 @@ func (c *nodeComponent) nodeRole() *rbacv1.ClusterRole {
 				Verbs: []string{"update"},
 			},
 			{
+				// calico/node marks the IP pools it creates allocatable.
+				APIGroups: []string{"projectcalico.org", "crd.projectcalico.org"},
+				Resources: []string{
+					"ippools/status",
+				},
+				Verbs: []string{"update"},
+			},
+			{
 				// For migration code in calico/node startup only. Remove when the migration
 				// code is removed from node.
 				APIGroups: []string{"projectcalico.org", "crd.projectcalico.org"},

--- a/pkg/render/node_test.go
+++ b/pkg/render/node_test.go
@@ -160,6 +160,19 @@ var _ = Describe("Node rendering tests", func() {
 				}))
 			})
 
+			It("should grant calico-node access to the IP pool status subresource", func() {
+				component := render.Node(&cfg)
+				Expect(component.ResolveImages(nil)).To(BeNil())
+				resources, _ := component.Objects()
+
+				role := rtest.GetResource(resources, "calico-node", "", "rbac.authorization.k8s.io", "v1", "ClusterRole").(*rbacv1.ClusterRole)
+				Expect(role.Rules).To(ContainElement(rbacv1.PolicyRule{
+					APIGroups: []string{"projectcalico.org", "crd.projectcalico.org"},
+					Resources: []string{"ippools/status"},
+					Verbs:     []string{"update"},
+				}))
+			})
+
 			It("should render all resources for a default configuration", func() {
 				expectedResources := []struct {
 					name    string


### PR DESCRIPTION
## Description

The IPPool CRD has a status subresource, so writing the Allocatable condition is a write to `ippools/status`. The calico-node ClusterRole grants create and update on `ippools` and nothing on the subresource, so the write is rejected. kube-controllers already carries the rule, added when the pool controller started writing that condition.

calico/node marks the pools it creates allocatable in https://github.com/projectcalico/calico/pull/13564, so this needs to land alongside it.

## Release Note

```release-note
Grant calico-node permission to update the IP pool status subresource.
```
