### PR TITLE
fix(rbac-ui): match ui-apis when reading the RBAC UI gate

### DIFF
--- a/pkg/render/common/rbacmanagement/gate.go
+++ b/pkg/render/common/rbacmanagement/gate.go
@@ -17,8 +17,6 @@
 package rbacmanagement
 
 import (
-	"strconv"
-
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -27,6 +25,8 @@ const (
 	// operator, ui-apis and rbacsync. Keep in sync with ui-apis rbacmanagement/gate.
 	ConfigMapName = "rbac-ui-config"
 	ConfigMapKey  = "rbac-ui-enabled"
+	// ConfigMapEnabledValue is the only value that switches the feature on.
+	ConfigMapEnabledValue = "true"
 
 	// LDAPConfigSecretName is the RBAC-UI LDAP directory-sync config Secret
 	// (calico-system) the rbacsync process reads to perform the sync.
@@ -39,11 +39,15 @@ const (
 )
 
 // Enabled reports whether the RBAC management UI is switched on for this cluster.
-// A missing ConfigMap, missing key or unparsable value reads as disabled.
+// Only the exact value "true" enables it; a missing ConfigMap, a missing key or
+// any other value reads as disabled.
+//
+// The exact match is deliberate. ui-apis serves the feature and decides the same
+// question with a string comparison, so anything more permissive here renders the
+// feature's RBAC on a cluster where ui-apis is still refusing to serve it.
 func Enabled(cm *corev1.ConfigMap) bool {
 	if cm == nil {
 		return false
 	}
-	enabled, err := strconv.ParseBool(cm.Data[ConfigMapKey])
-	return err == nil && enabled
+	return cm.Data[ConfigMapKey] == ConfigMapEnabledValue
 }

--- a/pkg/render/common/rbacmanagement/gate_test.go
+++ b/pkg/render/common/rbacmanagement/gate_test.go
@@ -23,9 +23,10 @@ import (
 	"github.com/tigera/operator/pkg/render/common/rbacmanagement"
 )
 
-// The gate is hand-edited by an admin, so the parser has to be forgiving about
-// spelling and strict about everything else: anything it cannot read as an explicit
-// true leaves the feature — and all of its access — switched off.
+// The gate is hand-edited by an admin, and only the exact value "true" switches
+// the feature on. Anything else leaves the feature, and all of its access, off.
+// The spellings ui-apis rejects are pinned here too, since a value that enables
+// one side and not the other renders RBAC for a feature that will not serve.
 var _ = DescribeTable("Enabled",
 	func(cm *corev1.ConfigMap, expected bool) {
 		Expect(rbacmanagement.Enabled(cm)).To(Equal(expected))
@@ -34,8 +35,8 @@ var _ = DescribeTable("Enabled",
 	Entry("missing key", &corev1.ConfigMap{Data: map[string]string{}}, false),
 	Entry("explicitly disabled", &corev1.ConfigMap{Data: map[string]string{rbacmanagement.ConfigMapKey: "false"}}, false),
 	Entry("enabled", &corev1.ConfigMap{Data: map[string]string{rbacmanagement.ConfigMapKey: "true"}}, true),
-	Entry("enabled, capitalised", &corev1.ConfigMap{Data: map[string]string{rbacmanagement.ConfigMapKey: "True"}}, true),
-	Entry("enabled as 1", &corev1.ConfigMap{Data: map[string]string{rbacmanagement.ConfigMapKey: "1"}}, true),
+	Entry("capitalised stays off, as in ui-apis", &corev1.ConfigMap{Data: map[string]string{rbacmanagement.ConfigMapKey: "True"}}, false),
+	Entry("1 stays off, as in ui-apis", &corev1.ConfigMap{Data: map[string]string{rbacmanagement.ConfigMapKey: "1"}}, false),
 	Entry("unparsable value stays off", &corev1.ConfigMap{Data: map[string]string{rbacmanagement.ConfigMapKey: "yes please"}}, false),
 	Entry("empty value stays off", &corev1.ConfigMap{Data: map[string]string{rbacmanagement.ConfigMapKey: ""}}, false),
 )


### PR DESCRIPTION
## Description

Bug fix. Independent of #5001, found while reviewing it.

The operator and ui-apis disagree on what value in the `rbac-ui-config` ConfigMap switches the RBAC management UI on.

`rbacmanagement.Enabled` parses `rbac-ui-enabled` with `strconv.ParseBool`, so `"1"`, `"True"` and `"t"` all read as on. ui-apis compares the value to `"true"` exactly, and ui-apis is what actually serves the feature. The constant's own comment says the two are kept in sync. They are not.

So `kubectl create configmap rbac-ui-config -n calico-system --from-literal=rbac-ui-enabled=1` leaves the cluster in a state where ui-apis answers 404 on `/team/*` while the operator renders the feature's RBAC:

- the `compliances` read added to `calico-manager-role`
- the `clusterroles` / `rolebindings` write rules on `tigera-network-admin`
- the whole `calico-system` Role covering the LDAP config Secret and `tigera-idp-groups`

Grants for a feature that is not running. It fails in the safe direction as far as the feature goes, but the standing RBAC is worth closing.

This tightens the operator rather than loosening ui-apis, because ui-apis serves the feature and because rbacsync resolves the same question the same way, so exact match is the majority behaviour.

No cluster loses a working feature. Anywhere the value is `"1"` or `"True"` today, ui-apis was already refusing to serve; the only change is that the accompanying grants stop being rendered.

Affected component: operator (manager render, apiserver render, via `utils.RBACManagementEnabled`).

Testing: `go test ./pkg/render/common/rbacmanagement/` passes. The table now pins the spellings ui-apis rejects, so the two cannot drift apart again without a test failing. No other fixture in the repo sets the key to anything but `"true"` or `"false"`, so nothing depended on the loose parse.

## Release Note

```release-note
None
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.