### PR TITLE
Move the whisker ingress gateway variant check into the Enterprise extension

### DIFF
--- a/pkg/controller/whisker/controller.go
+++ b/pkg/controller/whisker/controller.go
@@ -278,6 +278,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 
+	// Render from a copy, so a variant that does not support a field can unset it
+	// while the CR on the API keeps what the user asked for.
+	renderCR := whiskerCR.DeepCopy()
+	if err := r.ext.ValidateAndDefault(renderCR, r.status); err != nil {
+		r.status.SetDegraded(operatorv1.ResourceValidationError, "Invalid Whisker configuration", err, reqLogger)
+		return reconcile.Result{}, err
+	}
+
 	ri := render.Inputs{
 		Installation:  installationSpec,
 		ClusterDomain: r.clusterDomain,
@@ -291,7 +299,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		TrustedCertBundle:     trustedBundle,
 		WhiskerKeyPair:        whiskerKeyPair,
 		WhiskerBackendKeyPair: backendKeyPair,
-		Whisker:               whiskerCR,
+		Whisker:               renderCR,
 		ClusterDomain:         r.clusterDomain,
 	}
 
@@ -320,14 +328,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	})
 	var gatewayComponents []render.Component
 	var gatewayTLSKeyPair certificatemanagement.KeyPairInterface
-	gatewayEnabled := whiskerCR.Spec.IngressGateway != nil && installationSpec.Variant == operatorv1.Calico
-	if whiskerCR.Spec.IngressGateway != nil && installationSpec.Variant != operatorv1.Calico {
-		r.status.SetWarning("ingressgateway-variant",
-			"spec.ingressGateway on the Whisker resource is ignored on Calico Enterprise; expose the UI through the Manager resource's spec.ingressGateway instead")
-	} else {
-		r.status.ClearWarning("ingressgateway-variant")
-	}
-	if gw := whiskerCR.Spec.IngressGateway; gatewayEnabled {
+	gatewayEnabled := renderCR.Spec.IngressGateway != nil
+	if gw := renderCR.Spec.IngressGateway; gatewayEnabled {
 		var err error
 		gatewayTLSKeyPair, err = certificateManager.GetOrCreateKeyPair(r.cli, whisker.GatewayTLSSecretName, common.OperatorNamespace(), []string{gw.Hostname})
 		if err != nil {
@@ -382,7 +384,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	if gatewayEnabled {
-		if msg := gwHelper.UnhealthyReason(ctx, whiskerCR.Spec.IngressGateway.NamespaceOrDefault()); msg != "" {
+		if msg := gwHelper.UnhealthyReason(ctx, renderCR.Spec.IngressGateway.NamespaceOrDefault()); msg != "" {
 			r.status.SetDegraded(operatorv1.ResourceNotReady, msg, nil, reqLogger)
 			return reconcile.Result{RequeueAfter: utils.StandardRetry}, nil
 		}

--- a/pkg/controller/whisker/controller_test.go
+++ b/pkg/controller/whisker/controller_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/tigera/operator/pkg/controller/certificatemanager"
 	"github.com/tigera/operator/pkg/controller/utils"
 	ctrlrfake "github.com/tigera/operator/pkg/ctrlruntime/client/fake"
+	entwhisker "github.com/tigera/operator/pkg/enterprise/whisker"
 	"github.com/tigera/operator/pkg/extensions"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	rgateway "github.com/tigera/operator/pkg/render/gateway"
@@ -328,9 +329,10 @@ var _ = Describe("whisker controller tests", func() {
 			Expect(degradedErr).To(ContainSubstring("certificateManagement"))
 		})
 
-		It("renders no gateway and tears down leftovers on a non-Calico variant", func() {
+		It("renders no gateway and tears down leftovers when the Enterprise extension is active", func() {
 			// Whisker's own Deployment is deleted on other variants.
 			mockStatus.On("RemoveDeployments", mock.Anything).Return()
+			reconciler.ext = entwhisker.New(operatorv1.CalicoEnterprise)
 			createGatewayAPI()
 			setIngressGateway(nil)
 
@@ -361,6 +363,10 @@ var _ = Describe("whisker controller tests", func() {
 			mockStatus.AssertNotCalled(GinkgoT(), "SetDegraded", operatorv1.ResourceNotReady,
 				mock.Anything, mock.Anything, mock.Anything)
 			mockStatus.AssertCalled(GinkgoT(), "SetWarning", "ingressgateway-variant", mock.Anything)
+
+			w := &operatorv1.Whisker{}
+			Expect(cli.Get(ctx, types.NamespacedName{Name: "default"}, w)).NotTo(HaveOccurred())
+			Expect(w.Spec.IngressGateway).NotTo(BeNil(), "the field the variant ignores must survive on the CR the user wrote")
 		})
 
 		It("tears down labeled gateway resources when spec.ingressGateway is nil", func() {

--- a/pkg/controller/whisker/controller_test.go
+++ b/pkg/controller/whisker/controller_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/tigera/operator/pkg/controller/certificatemanager"
 	"github.com/tigera/operator/pkg/controller/utils"
 	ctrlrfake "github.com/tigera/operator/pkg/ctrlruntime/client/fake"
-	entwhisker "github.com/tigera/operator/pkg/enterprise/whisker"
 	"github.com/tigera/operator/pkg/extensions"
 	rmeta "github.com/tigera/operator/pkg/render/common/meta"
 	rgateway "github.com/tigera/operator/pkg/render/gateway"
@@ -329,16 +328,10 @@ var _ = Describe("whisker controller tests", func() {
 			Expect(degradedErr).To(ContainSubstring("certificateManagement"))
 		})
 
-		It("renders no gateway and tears down leftovers when the Enterprise extension is active", func() {
-			// Whisker's own Deployment is deleted on other variants.
-			mockStatus.On("RemoveDeployments", mock.Anything).Return()
-			reconciler.ext = entwhisker.New(operatorv1.CalicoEnterprise)
+		It("renders no gateway and tears down leftovers when the extension unsets spec.ingressGateway", func() {
+			reconciler.ext = trimIngressGateway{reconciler.ext}
 			createGatewayAPI()
 			setIngressGateway(nil)
-
-			Expect(cli.Get(ctx, types.NamespacedName{Name: installation.Name}, installation)).NotTo(HaveOccurred())
-			installation.Status.Computed.Variant = operatorv1.CalicoEnterprise
-			Expect(cli.Status().Update(ctx, installation)).NotTo(HaveOccurred())
 
 			stray := &gapi.Gateway{ObjectMeta: metav1.ObjectMeta{
 				Name:      gatewayName,
@@ -352,9 +345,9 @@ var _ = Describe("whisker controller tests", func() {
 
 			gw := &gapi.Gateway{}
 			Expect(cli.Get(ctx, types.NamespacedName{Name: gatewayName, Namespace: whisker.WhiskerNamespace}, gw)).To(HaveOccurred(),
-				"Whisker is deleted on other variants, so its gateway must not be rendered")
+				"a variant that does not serve the gateway must not render one")
 			Expect(cli.Get(ctx, types.NamespacedName{Name: gatewayName, Namespace: "ns-b"}, gw)).To(HaveOccurred(),
-				"gateway resources left from a Calico install should be torn down")
+				"gateway resources left from an earlier install should be torn down")
 
 			// The health read-back must be gated the same way as the render. If it
 			// is not, the reconcile degrades over a gateway it just tore down and
@@ -362,7 +355,6 @@ var _ = Describe("whisker controller tests", func() {
 			Expect(result.RequeueAfter).To(BeZero(), "no requeue: there is no gateway to wait for")
 			mockStatus.AssertNotCalled(GinkgoT(), "SetDegraded", operatorv1.ResourceNotReady,
 				mock.Anything, mock.Anything, mock.Anything)
-			mockStatus.AssertCalled(GinkgoT(), "SetWarning", "ingressgateway-variant", mock.Anything)
 
 			w := &operatorv1.Whisker{}
 			Expect(cli.Get(ctx, types.NamespacedName{Name: "default"}, w)).NotTo(HaveOccurred())
@@ -418,3 +410,14 @@ var _ = Describe("whisker controller tests", func() {
 		})
 	})
 })
+
+// trimIngressGateway stands in for a variant that does not serve whisker's own
+// gateway. The Enterprise version of this lives in pkg/enterprise/whisker.
+type trimIngressGateway struct {
+	extensions.WhiskerExtension
+}
+
+func (trimIngressGateway) ValidateAndDefault(cr *operatorv1.Whisker, _ status.StatusManager) error {
+	cr.Spec.IngressGateway = nil
+	return nil
+}

--- a/pkg/enterprise/whisker/extension.go
+++ b/pkg/enterprise/whisker/extension.go
@@ -18,10 +18,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/extensions"
 	"github.com/tigera/operator/pkg/render"
 	rwhisker "github.com/tigera/operator/pkg/render/whisker"
 )
+
+const ingressGatewayWarning = "ingressgateway-variant"
 
 // Extension is the Calico Enterprise behavior for the whisker controller.
 type Extension struct {
@@ -33,6 +36,19 @@ var _ extensions.WhiskerExtension = &Extension{}
 // New returns the whisker extension for the variant the operator resolved.
 func New(variant operatorv1.ProductVariant) *Extension {
 	return &Extension{variant: variant}
+}
+
+// ValidateAndDefault drops spec.ingressGateway, which only Calico's whisker serves.
+func (e *Extension) ValidateAndDefault(cr *operatorv1.Whisker, st status.StatusManager) error {
+	if cr.Spec.IngressGateway == nil {
+		st.ClearWarning(ingressGatewayWarning)
+		return nil
+	}
+
+	st.SetWarning(ingressGatewayWarning,
+		"spec.ingressGateway on the Whisker resource is ignored on Calico Enterprise; expose the UI through the Manager resource's spec.ingressGateway instead")
+	cr.Spec.IngressGateway = nil
+	return nil
 }
 
 // Modify dispatches over the components the whisker controller renders.

--- a/pkg/enterprise/whisker/extension_test.go
+++ b/pkg/enterprise/whisker/extension_test.go
@@ -18,11 +18,13 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/stretchr/testify/mock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/render"
 	rwhisker "github.com/tigera/operator/pkg/render/whisker"
 	"github.com/tigera/operator/pkg/tls/certificatemanagement"
@@ -61,5 +63,54 @@ var _ = Describe("whisker enterprise render extension", func() {
 		create, del := calicoExt.Whisker().Modify(base, renderInputs(operatorv1.Calico)).Objects()
 		Expect(create).To(HaveLen(len(baseCreate)))
 		Expect(del).To(HaveLen(len(baseDelete)))
+	})
+})
+
+var _ = Describe("whisker enterprise CR validation", func() {
+	var (
+		mockStatus *status.MockStatus
+		warningKey string
+		warningMsg string
+	)
+
+	whiskerCR := func() *operatorv1.Whisker {
+		return &operatorv1.Whisker{
+			Spec: operatorv1.WhiskerSpec{
+				IngressGateway: &operatorv1.IngressGatewaySpec{Hostname: "whisker.test.local"},
+			},
+		}
+	}
+
+	BeforeEach(func() {
+		mockStatus = &status.MockStatus{}
+		warningKey, warningMsg = "", ""
+		mockStatus.On("SetWarning", mock.Anything, mock.Anything).
+			Run(func(args mock.Arguments) { warningKey, warningMsg = args.String(0), args.String(1) }).Return().Maybe()
+		mockStatus.On("ClearWarning", mock.Anything).Return().Maybe()
+	})
+
+	It("drops spec.ingressGateway and warns, pointing at the Manager resource", func() {
+		cr := whiskerCR()
+		Expect(ext.Whisker().ValidateAndDefault(cr, mockStatus)).To(Succeed())
+		Expect(cr.Spec.IngressGateway).To(BeNil())
+
+		Expect(warningKey).To(Equal("ingressgateway-variant"))
+		Expect(warningMsg).To(ContainSubstring("Manager resource's spec.ingressGateway"))
+		mockStatus.AssertNotCalled(GinkgoT(), "ClearWarning", mock.Anything)
+	})
+
+	It("keeps spec.ingressGateway when the installation is Calico", func() {
+		cr := whiskerCR()
+		Expect(calicoExt.Whisker().ValidateAndDefault(cr, mockStatus)).To(Succeed())
+		Expect(cr.Spec.IngressGateway).NotTo(BeNil(), "the Enterprise build serves whisker's own gateway on a Calico install")
+
+		Expect(warningKey).To(BeEmpty())
+	})
+
+	It("clears the warning once spec.ingressGateway is unset", func() {
+		Expect(ext.Whisker().ValidateAndDefault(&operatorv1.Whisker{}, mockStatus)).To(Succeed())
+
+		mockStatus.AssertCalled(GinkgoT(), "ClearWarning", "ingressgateway-variant")
+		Expect(warningKey).To(BeEmpty())
 	})
 })

--- a/pkg/enterprise/whisker/extension_test.go
+++ b/pkg/enterprise/whisker/extension_test.go
@@ -102,7 +102,8 @@ var _ = Describe("whisker enterprise CR validation", func() {
 	It("keeps spec.ingressGateway when the installation is Calico", func() {
 		cr := whiskerCR()
 		Expect(calicoExt.Whisker().ValidateAndDefault(cr, mockStatus)).To(Succeed())
-		Expect(cr.Spec.IngressGateway).NotTo(BeNil(), "the Enterprise build serves whisker's own gateway on a Calico install")
+		Expect(cr.Spec.IngressGateway).NotTo(BeNil(),
+			"a Calico install registers no whisker extension, so the Enterprise build still serves whisker's own gateway")
 
 		Expect(warningKey).To(BeEmpty())
 	})

--- a/pkg/extensions/extensions_test.go
+++ b/pkg/extensions/extensions_test.go
@@ -113,6 +113,20 @@ var _ = Describe("the zero value Extensions", func() {
 	})
 })
 
+var _ = Describe("the base Whisker validation", func() {
+	var e extensions.Extensions
+
+	It("keeps spec.ingressGateway, which Calico's whisker serves itself", func() {
+		cr := &operatorv1.Whisker{
+			Spec: operatorv1.WhiskerSpec{
+				IngressGateway: &operatorv1.IngressGatewaySpec{Hostname: "whisker.test.local"},
+			},
+		}
+		Expect(e.Whisker().ValidateAndDefault(cr, nil)).NotTo(HaveOccurred())
+		Expect(cr.Spec.IngressGateway).NotTo(BeNil())
+	})
+})
+
 var _ = Describe("the base ManagementClusterConnection validation", func() {
 	var e extensions.Extensions
 

--- a/pkg/extensions/whisker.go
+++ b/pkg/extensions/whisker.go
@@ -15,18 +15,29 @@
 package extensions
 
 import (
+	operatorv1 "github.com/tigera/operator/api/v1"
+	"github.com/tigera/operator/pkg/controller/status"
 	"github.com/tigera/operator/pkg/render"
 )
 
 // WhiskerExtension is the variant's hook into the components the whisker controller
 // renders.
 type WhiskerExtension interface {
+	// ValidateAndDefault unsets the fields the variant does not render, reporting each
+	// one it drops. Pass the copy the controller renders from, not the CR it writes back.
+	ValidateAndDefault(cr *operatorv1.Whisker, st status.StatusManager) error
+
 	// Modify layers the variant onto a component the controller rendered.
 	Modify(c render.Component, ri render.Inputs) render.Component
 }
 
 // noopWhisker runs the core operator's behavior unchanged.
 type noopWhisker struct{}
+
+// ValidateAndDefault keeps the CR as written, since Calico renders every Whisker field.
+func (noopWhisker) ValidateAndDefault(_ *operatorv1.Whisker, _ status.StatusManager) error {
+	return nil
+}
 
 func (noopWhisker) Modify(c render.Component, _ render.Inputs) render.Component {
 	return c


### PR DESCRIPTION
The whisker controller decided whether to render the ingress gateway by comparing the installed variant, and raised the "ignored on Calico Enterprise" warning itself. Both now sit in the Enterprise extension: it warns and unsets the field, and the controller renders whatever the CR still asks for. The controller validates a copy, so the CR the user wrote keeps the field either way, and neither variant changes behavior.

Follows the whisker split in https://github.com/tigera/operator/pull/5228, and finishes the gateway work https://github.com/tigera/operator/pull/5146 left in core.

Related: [CORE-13397](https://tigera.atlassian.net/browse/CORE-13397)

```release-note
None
```


[CORE-13397]: https://tigera.atlassian.net/browse/CORE-13397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ