### PR TITLE
Recover a GatewayClass wedged in Terminating

### DIFF
--- a/pkg/controller/gatewayapi/gatewayapi_controller.go
+++ b/pkg/controller/gatewayapi/gatewayapi_controller.go
@@ -169,6 +169,23 @@ func Add(mgr manager.Manager, opts options.ControllerOptions) error {
 		return nil
 	}
 
+	// Watch GatewayClass for the same reason, and lazily for the same reason. Without this
+	// we cannot see a class wedged in Terminating: we own it by ownerRef, so deleting the
+	// GatewayAPI CR marks it, and Envoy Gateway's gateway-exists finalizer then blocks the
+	// delete for as long as any Gateway uses the class.
+	gatewayClassesWatched := false
+	r.watchGatewayClasses = func() error {
+		if gatewayClassesWatched {
+			return nil
+		}
+		log.V(1).Info("Adding watch for GatewayClass resources")
+		if err = c.WatchObject(&gapi.GatewayClass{}, &handler.EnqueueRequestForObject{}); err != nil {
+			return fmt.Errorf("gatewayapi-controller failed to watch GatewayClass resource: %w", err)
+		}
+		gatewayClassesWatched = true
+		return nil
+	}
+
 	return nil
 }
 
@@ -189,6 +206,7 @@ type ReconcileGatewayAPI struct {
 	watchEnvoyProxy     func(namespacedName operatorv1.NamespacedName) error
 	watchEnvoyGateway   func(namespacedName operatorv1.NamespacedName) error
 	watchGateways       func() error
+	watchGatewayClasses func() error
 }
 
 // Reconcile reads that state of the cluster for a GatewayAPI object and makes changes based on the state read
@@ -483,6 +501,10 @@ func (r *ReconcileGatewayAPI) Reconcile(ctx context.Context, request reconcile.R
 
 	// Start watching Gateway resources now that the CRDs are in place, so future
 	// Gateway changes trigger reconciliation.
+	if err = r.watchGatewayClasses(); err != nil {
+		r.status.SetDegraded(operatorv1.ResourceReadError, "Error watching GatewayClass resources", err, log)
+		return reconcile.Result{}, err
+	}
 	if err = r.watchGateways(); err != nil {
 		r.status.SetDegraded(operatorv1.ResourceReadError, "Error watching Gateway resources", err, log)
 		return reconcile.Result{}, err
@@ -610,10 +632,85 @@ func (r *ReconcileGatewayAPI) Reconcile(ctx context.Context, request reconcile.R
 		return reconcile.Result{}, err
 	}
 
+	wedged, err := r.unwedgeTerminatingGatewayClasses(ctx, gatewayAPI, gwList.Items, log)
+	if err != nil {
+		r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error recovering a terminating GatewayClass", err, log)
+		return reconcile.Result{}, err
+	}
+	if wedged != "" {
+		// Return before ClearDegraded below, so the repair is visible in tigerastatus rather
+		// than healing silently. The requeued reconcile re-creates the class and clears this.
+		r.status.SetDegraded(operatorv1.ResourceUpdateError, wedged, nil, log)
+		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+
 	// Clear the degraded bit if we've reached this far.
 	r.status.ClearDegraded()
 
 	return reconcile.Result{}, nil
+}
+
+// unwedgeTerminatingGatewayClasses repairs a GatewayClass stuck in Terminating.
+//
+// We set a controller ownerRef on each GatewayClass we render, so deleting the GatewayAPI CR
+// makes the garbage collector mark the class for deletion. Envoy Gateway puts
+// gateway-exists-finalizer.gateway.networking.k8s.io on it, and refuses to release that while
+// any Gateway still uses the class. The delete therefore never completes.
+//
+// A class in that state is not inert. Envoy Gateway keeps managing it but skips its
+// parametersRef entirely, because it only resolves the ref when DeletionTimestamp is nil.
+// Every gateway Deployment it renders then falls back to the upstream Envoy image with no
+// imagePullSecrets, and it still reports the class Accepted=True, so nothing surfaces the
+// fault. Re-creating the GatewayAPI CR restores the EnvoyProxy but cannot clear a
+// DeletionTimestamp, so the cluster never converges on its own.
+//
+// Removing the finalizer lets the pending delete finish. The next reconcile re-creates the
+// class from the render, and Envoy Gateway then resolves parametersRef normally. Gateways
+// briefly lose their managed class while this happens, so the proxy Deployment is torn down
+// and re-provisioned with the correct image.
+//
+// It returns a message describing the first class it repaired, so the caller can surface the
+// repair on TigeraStatus. A wedge that heals silently is how this went unnoticed for hours.
+func (r *ReconcileGatewayAPI) unwedgeTerminatingGatewayClasses(ctx context.Context, gatewayAPI *operatorv1.GatewayAPI, gateways []gapi.Gateway, reqLogger logr.Logger) (string, error) {
+	for i := range gatewayAPI.Spec.GatewayClasses {
+		name := gatewayAPI.Spec.GatewayClasses[i].Name
+
+		gc := &gapi.GatewayClass{}
+		if err := r.client.Get(ctx, types.NamespacedName{Name: name}, gc); err != nil {
+			if errors.IsNotFound(err) || meta.IsNoMatchError(err) {
+				continue
+			}
+			return "", err
+		}
+		if gc.DeletionTimestamp == nil {
+			continue
+		}
+
+		blocking := 0
+		for j := range gateways {
+			if string(gateways[j].Spec.GatewayClassName) == name {
+				blocking++
+			}
+		}
+
+		reqLogger.Info("GatewayClass is stuck terminating; clearing finalizers so it can be re-created",
+			"gatewayClass", name, "deletionTimestamp", gc.DeletionTimestamp,
+			"finalizers", gc.Finalizers, "blockingGateways", blocking)
+
+		patched := gc.DeepCopy()
+		patched.Finalizers = nil
+		if err := r.client.Patch(ctx, patched, client.MergeFrom(gc)); err != nil {
+			if errors.IsNotFound(err) || errors.IsConflict(err) {
+				// Someone else finished the delete, or raced us. The next reconcile re-creates it.
+				continue
+			}
+			return "", err
+		}
+
+		return fmt.Sprintf("GatewayClass %q was stuck terminating with %d Gateway(s) still using it; "+
+			"its finalizers have been cleared so it can be re-created", name, blocking), nil
+	}
+	return "", nil
 }
 
 // GetGatewayAPI finds the correct GatewayAPI resource and returns a message and error in the case of an error.

--- a/pkg/controller/gatewayapi/gatewayapi_controller_test.go
+++ b/pkg/controller/gatewayapi/gatewayapi_controller_test.go
@@ -110,6 +110,7 @@ var _ = Describe("Gateway API controller tests", func() {
 		mockStatus.On("AddCronJobs", mock.Anything)
 		mockStatus.On("OnCRNotFound").Return()
 		mockStatus.On("ClearDegraded")
+		mockStatus.On("SetDegraded", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
 		mockStatus.On("ReadyToMonitor")
 		mockStatus.On("SetMetaData", mock.Anything).Return()
 		mockStatus.On("RemoveDeployments", mock.Anything).Return()
@@ -126,6 +127,7 @@ var _ = Describe("Gateway API controller tests", func() {
 			watchEnvoyProxy:     func(namespacedName operatorv1.NamespacedName) error { return nil },
 			watchEnvoyGateway:   func(namespacedName operatorv1.NamespacedName) error { return nil },
 			watchGateways:       func() error { return nil },
+			watchGatewayClasses: func() error { return nil },
 		}
 	})
 
@@ -875,6 +877,47 @@ var _ = Describe("Gateway API controller tests", func() {
 		}
 		Expect(owners).To(ConsistOf("Gateway/flipped", "Gateway/gw1"))
 	})
+
+	It("clears the finalizers on a GatewayClass wedged in Terminating", func() {
+		Expect(c.Create(ctx, installation)).NotTo(HaveOccurred())
+		Expect(c.Create(ctx, &operatorv1.GatewayAPI{ObjectMeta: metav1.ObjectMeta{Name: "tigera-secure"}})).NotTo(HaveOccurred())
+
+		By("creating a GatewayClass that Envoy Gateway's finalizer is holding open")
+		gc := &gapi.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       gatewayapi.GatewayClassName,
+				Finalizers: []string{"gateway-exists-finalizer.gateway.networking.k8s.io"},
+			},
+		}
+		Expect(c.Create(ctx, gc)).NotTo(HaveOccurred())
+
+		By("deleting it, which only marks it because of the finalizer")
+		Expect(c.Delete(ctx, gc)).NotTo(HaveOccurred())
+		wedged := &gapi.GatewayClass{}
+		Expect(c.Get(ctx, client.ObjectKey{Name: gatewayapi.GatewayClassName}, wedged)).NotTo(HaveOccurred())
+		Expect(wedged.DeletionTimestamp).NotTo(BeNil())
+
+		By("triggering a reconcile")
+		_, err := r.Reconcile(ctx, reconcile.Request{})
+		Expect(err).ShouldNot(HaveOccurred())
+
+		By("checking the wedged class is gone, so the next render can re-create it cleanly")
+		err = c.Get(ctx, client.ObjectKey{Name: gatewayapi.GatewayClassName}, &gapi.GatewayClass{})
+		Expect(apierrors.IsNotFound(err)).To(BeTrue(), "expected the terminating GatewayClass to have been released")
+
+		By("checking the repair was surfaced on TigeraStatus rather than healing silently")
+		var degradedMsgs []string
+		for _, call := range mockStatus.Calls {
+			if call.Method == "SetDegraded" && len(call.Arguments) > 1 {
+				if msg, ok := call.Arguments[1].(string); ok {
+					degradedMsgs = append(degradedMsgs, msg)
+				}
+			}
+		}
+		Expect(degradedMsgs).To(ContainElement(ContainSubstring("stuck terminating")),
+			"expected a Degraded naming the wedged GatewayClass")
+	})
+
 })
 
 var fakeComponentHandlers []*fakeComponentHandler


### PR DESCRIPTION
## Description

Deleting the `GatewayAPI` CR marks the `GatewayClass` for deletion, since we set a controller ownerRef on it. Envoy Gateway's `gateway-exists-finalizer` blocks that delete while any Gateway still uses the class, so it never finishes and nothing repairs it.

Envoy Gateway keeps managing a terminating class but skips its `parametersRef`, because it only resolves the ref when `DeletionTimestamp` is nil (`internal/provider/kubernetes/controller.go:366`, EG v1.8.3). Gateway deployments fall back to the upstream `docker.io/envoyproxy/envoy` image with no `imagePullSecrets`, and the class still reports `Accepted=True`. Re-creating the CR restores the `EnvoyProxy` but can't clear a `DeletionTimestamp`, so the cluster stays wrong until someone clears the finalizer by hand.

The gateway pod carries on serving and tigerastatus stays green, so this shows up later as a pod that won't start after a restart or drain.

This watches `GatewayClass`, clears the finalizers on a terminating one, and reports the repair on tigerastatus. The next reconcile re-creates the class and Envoy Gateway resolves `parametersRef` normally.

Clearing another controller's finalizer is deliberate. The wedge only exists because our ownerRef marked a class that Envoy Gateway won't release, and there's no other way out of it. Gateways lose their managed class for a few seconds while the class is re-created, so the proxy deployment is torn down and re-provisioned.

### Test plan

`go build`, `go vet`, `gofmt` and `go test ./pkg/controller/gatewayapi/...` all pass.

New unit test covers a class with `DeletionTimestamp` set, and asserts both the release and the tigerastatus message. It fails when the repair is short-circuited.

Checked by hand on a GCP kubeadm cluster running Enterprise master. Waiting, restarting envoy-gateway, annotating the Gateway and deleting the deployment all left it wedged. Clearing the finalizer and reconciling fixed it in 6 seconds.

Not covered: no e2e, and the upstream skip in EG is unchanged since v0.5.0 and still on EG main, so this only handles our side of it.

## Release Note

```release-note
Fixed a bug where deleting and re-creating the GatewayAPI resource could leave gateway deployments running an incorrect image without image pull secrets.
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`
