### PR TITLE
feat(manager): grant RBAC for IPAM resources used by ui-apis

### DIFF
--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -1049,6 +1049,20 @@ func managerClusterRole(managedCluster bool, kubernetesProvider operatorv1.Provi
 				Verbs:     []string{"get", "list"},
 			},
 			{
+				// IP Pools page: ui-apis reads pools and IPAM config via the
+				// aggregated API to serve /ipam/pools endpoints and detect IPAM mode.
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{"ippools", "ipamconfigurations"},
+				Verbs:     []string{"get", "list"},
+			},
+			{
+				// IPAMBlocks are only served via the CRD API group, not the
+				// aggregated projectcalico.org API.
+				APIGroups: []string{"crd.projectcalico.org"},
+				Resources: []string{"ipamblocks"},
+				Verbs:     []string{"list"},
+			},
+			{
 				APIGroups: []string{"projectcalico.org"},
 				Resources: []string{
 					"stagednetworkpolicies",

--- a/pkg/render/manager.go
+++ b/pkg/render/manager.go
@@ -1063,6 +1063,12 @@ func managerClusterRole(managedCluster bool, kubernetesProvider operatorv1.Provi
 				Verbs:     []string{"list"},
 			},
 			{
+				// IP Pools page: ui-apis reads the Installation to detect the IPAM mode.
+				APIGroups: []string{"operator.tigera.io"},
+				Resources: []string{"installations"},
+				Verbs:     []string{"get"},
+			},
+			{
 				APIGroups: []string{"projectcalico.org"},
 				Resources: []string{
 					"stagednetworkpolicies",

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -334,6 +334,16 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 			},
 			{
 				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{"ippools", "ipamconfigurations"},
+				Verbs:     []string{"get", "list"},
+			},
+			{
+				APIGroups: []string{"crd.projectcalico.org"},
+				Resources: []string{"ipamblocks"},
+				Verbs:     []string{"list"},
+			},
+			{
+				APIGroups: []string{"projectcalico.org"},
 				Resources: []string{
 					"stagednetworkpolicies",
 					"tier.stagednetworkpolicies",
@@ -676,6 +686,16 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 				APIGroups: []string{"projectcalico.org"},
 				Resources: []string{"clusterinformations"},
 				Verbs:     []string{"get", "list"},
+			},
+			{
+				APIGroups: []string{"projectcalico.org"},
+				Resources: []string{"ippools", "ipamconfigurations"},
+				Verbs:     []string{"get", "list"},
+			},
+			{
+				APIGroups: []string{"crd.projectcalico.org"},
+				Resources: []string{"ipamblocks"},
+				Verbs:     []string{"list"},
 			},
 			{
 				APIGroups: []string{"projectcalico.org"},

--- a/pkg/render/manager_test.go
+++ b/pkg/render/manager_test.go
@@ -343,6 +343,11 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 				Verbs:     []string{"list"},
 			},
 			{
+				APIGroups: []string{"operator.tigera.io"},
+				Resources: []string{"installations"},
+				Verbs:     []string{"get"},
+			},
+			{
 				APIGroups: []string{"projectcalico.org"},
 				Resources: []string{
 					"stagednetworkpolicies",
@@ -696,6 +701,11 @@ var _ = Describe("Tigera Secure Manager rendering tests", func() {
 				APIGroups: []string{"crd.projectcalico.org"},
 				Resources: []string{"ipamblocks"},
 				Verbs:     []string{"list"},
+			},
+			{
+				APIGroups: []string{"operator.tigera.io"},
+				Resources: []string{"installations"},
+				Verbs:     []string{"get"},
 			},
 			{
 				APIGroups: []string{"projectcalico.org"},


### PR DESCRIPTION
## Description

The IP Pools page (EV-7009) in ui-apis needs to read IPAM resources via the calico-manager service account. This PR adds the necessary RBAC rules to the manager ClusterRole:

- `ippools` and `ipamconfigurations` via `projectcalico.org` (aggregated API)
- `ipamblocks` via `crd.projectcalico.org` (CRD API group — blocks are **not** served by the aggregated `projectcalico.org/v3` API)

https://github.com/tigera/calico-private/pull/13614

## Release Note

None

## AI Assistance

This PR was written with AI assistance (Claude Code).

## Docs Changes

docs-not-required