### PR TITLE
build: bump Go to 1.27.0 and align the go-build image with k8s 1.37.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,9 +102,9 @@ REPO?=tigera/operator
 PACKAGE_NAME?=github.com/tigera/operator
 LOCAL_USER_ID?=$(shell id -u $$USER)
 # The project Go version.
-GO_VERSION?=1.26.5
+GO_VERSION?=1.27.0
 # Version of Kubernetes to use for dependencies, tests, and kubectl.
-K8S_VERSION?=v1.37.0-beta.0
+K8S_VERSION?=v1.37.0
 # The version of LLVM to use for the go-build image.
 LLVM_VERSION?=21.1.8
 # Calico toolchain versions and the calico/go-build image to use.

--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1472,12 +1472,12 @@ func (r *ReconcileInstallation) Reconcile(ctx context.Context, request reconcile
 	if needsNamespaceMigration {
 		if err := r.namespaceMigration.Run(ctx, reqLogger); err != nil {
 			r.status.SetDegraded(operatorv1.ResourceMigrationError, "error migrating resources to calico-system", err, reqLogger)
-			// We should always requeue a migration problem. Don't return error
-			// to make sure we never start backing off retrying.
-			return reconcile.Result{Requeue: true}, nil
+			// Always requeue a migration problem. Returning nil rather than the
+			// error keeps the retry interval flat instead of escalating.
+			return reconcile.Result{RequeueAfter: utils.StandardRetry}, nil
 		}
 		// Requeue so we can update our resources (without the migration changes)
-		return reconcile.Result{Requeue: true}, nil
+		return reconcile.Result{RequeueAfter: utils.StandardRetry}, nil
 	} else if r.namespaceMigration.NeedCleanup() {
 		if err := r.namespaceMigration.CleanupMigration(ctx, reqLogger); err != nil {
 			r.status.SetDegraded(operatorv1.ResourceMigrationError, "error migrating resources to calico-system", err, reqLogger)

--- a/pkg/enterprise/controller/logstorage/initializer/conditions_controller.go
+++ b/pkg/enterprise/controller/logstorage/initializer/conditions_controller.go
@@ -97,6 +97,7 @@ func (r *LogStorageConditions) Reconcile(ctx context.Context, request reconcile.
 			// The LogStorage was modified after we read it - our cached copy is stale. Requeue and
 			// recompute the conditions from the updated object instead of reporting an error.
 			reqLogger.V(3).Info("Conflict updating LogStorage status conditions, retrying")
+			//nolint:staticcheck // SA1019: a conflict wants a prompt retry, not a flat delay
 			return reconcile.Result{Requeue: true}, nil
 		}
 		log.WithValues("reason", err).Info("Failed to update LogStorage status conditions")

--- a/pkg/enterprise/controller/monitor/monitor_controller_test.go
+++ b/pkg/enterprise/controller/monitor/monitor_controller_test.go
@@ -337,6 +337,7 @@ var _ = Describe("Monitor controller tests", func() {
 								},
 							},
 							HTTPConfigWithoutTLS: monitoringv1.HTTPConfigWithoutTLS{
+								//nolint:staticcheck // SA1019: mirrors the deprecated field monitor.go still renders
 								BearerTokenSecret: &corev1.SecretKeySelector{
 									LocalObjectReference: corev1.LocalObjectReference{
 										Name: monitor.TigeraExternalPrometheus,

--- a/pkg/enterprise/controller/packetcapture/packetcapture_controller.go
+++ b/pkg/enterprise/controller/packetcapture/packetcapture_controller.go
@@ -279,9 +279,7 @@ func (r *ReconcilePacketCapture) Reconcile(ctx context.Context, request reconcil
 		}),
 	}
 
-	if pcPolicy := render.PacketCaptureAPIPolicy(packetCaptureApiCfg); pcPolicy != nil {
-		components = append(components, pcPolicy)
-	}
+	components = append(components, render.PacketCaptureAPIPolicy(packetCaptureApiCfg))
 
 	if err = imageset.ApplyImageSet(ctx, r.client, r.opts.Variant, components...); err != nil {
 		r.status.SetDegraded(operatorv1.ResourceUpdateError, "Error with images from ImageSet", err, reqLogger)

--- a/pkg/enterprise/render/logcollector/fluentbit_test.go
+++ b/pkg/enterprise/render/logcollector/fluentbit_test.go
@@ -425,6 +425,7 @@ var _ = Describe("Tigera Secure Fluent Bit rendering tests", func() {
 		// fluentdDaemonSet field, using the fluentd-era container names.
 		cfg.LogCollector = &operatorv1.LogCollector{
 			Spec: operatorv1.LogCollectorSpec{
+				//nolint:staticcheck // SA1019: the deprecated alias is what this covers
 				FluentdDaemonSet: &operatorv1.FluentBitDaemonSet{
 					Spec: &operatorv1.FluentBitDaemonSetSpec{
 						Template: &operatorv1.FluentBitDaemonSetPodTemplateSpec{

--- a/pkg/enterprise/render/monitor/monitor.go
+++ b/pkg/enterprise/render/monitor/monitor.go
@@ -1769,6 +1769,7 @@ func (mc *monitorComponent) externalServiceMonitor() (client.Object, bool) {
 						},
 					},
 					HTTPConfigWithoutTLS: monitoringv1.HTTPConfigWithoutTLS{
+						//nolint:staticcheck // SA1019: migrating to authorization changes the rendered ServiceMonitor
 						BearerTokenSecret: &ep.BearerTokenSecret,
 					},
 				},

--- a/pkg/render/gateway/component.go
+++ b/pkg/render/gateway/component.go
@@ -194,33 +194,33 @@ func (c *gatewayComponent) backendAccess() (*rbacv1.Role, *rbacv1.RoleBinding) {
 // own ServiceAccount, the identity that renders the gateway resources.
 func (c *gatewayComponent) access(name, namespace string, rules []rbacv1.PolicyRule) (*rbacv1.Role, *rbacv1.RoleBinding) {
 	return &rbacv1.Role{
-			TypeMeta: metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: namespace,
-				Labels:    map[string]string{GatewayLabel: c.cfg.ResourcePrefix},
+		TypeMeta: metav1.TypeMeta{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{GatewayLabel: c.cfg.ResourcePrefix},
+		},
+		Rules: rules,
+	}, &rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{GatewayLabel: c.cfg.ResourcePrefix},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     name,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      common.OperatorServiceAccount(),
+				Namespace: common.OperatorNamespace(),
 			},
-			Rules: rules,
-		}, &rbacv1.RoleBinding{
-			TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: namespace,
-				Labels:    map[string]string{GatewayLabel: c.cfg.ResourcePrefix},
-			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: "rbac.authorization.k8s.io",
-				Kind:     "Role",
-				Name:     name,
-			},
-			Subjects: []rbacv1.Subject{
-				{
-					Kind:      "ServiceAccount",
-					Name:      common.OperatorServiceAccount(),
-					Namespace: common.OperatorNamespace(),
-				},
-			},
-		}
+		},
+	}
 }
 
 func (c *gatewayComponent) tlsSecret() *corev1.Secret {


### PR DESCRIPTION
## Description

Moves the operator to `GO_VERSION=1.27.0` and `K8S_VERSION=v1.37.0`, where calico-private and calico OSS already are.

This unblocks the Envoy Gateway v1.9.1 bump, which stacks on top of this PR. EG v1.9.1 declares `go 1.26.7`. There is no `calico/go-build` image for 1.26.6 or 1.26.7, and the container runs `GOTOOLCHAIN=local`, so it will not fetch one. 1.27.0 is the only tag paired with a k8s1.37 image, so `K8S_VERSION` moves with it. `K8S_VERSION` only feeds `GO_BUILD_VER`; `ENVTEST_K8S_VERSION` stays at `1.34.x`.

The 1.27.0 image carries golangci-lint 2.13.1 instead of 2.12.2, which reports seven pre-existing staticcheck issues. They are not from this diff: linting clean `master` with the same image gives the identical seven at the same lines.

Three are fixed. The two namespace-migration requeues in `core_controller.go` move from rate-limited backoff to a flat 30s `RequeueAfter`, matching the other controllers; the old path already exceeded 30s per attempt after about 13 requeues. `PacketCaptureAPIPolicy` returns `NewPassthrough`, which is never nil, so its dead nil check is gone.

Four keep their behaviour and take a targeted `nolint` with a reason, matching ones already in the tree. Three are deprecated fields we still want: the prometheus-operator `BearerTokenSecret` pair, where moving to `authorization` would change the rendered ServiceMonitor, and the `FluentdDaemonSet` alias, which that test exists to cover. The fourth is the LogStorage status conflict retry, which wants to be prompt; a flat 30s would leave the conditions stale after a conflicting write.

`pkg/render/gateway/component.go` is gofmt-only. The 1.27.0 gofmt reindents multi-value returns of composite literals.

## Test plan

- `make static-checks`: **0 issues**. Reports 7 without this change.
- `make ut`: 109 suites, all passed, 10m28s.
- `go build ./...` and `go vet ./...` clean.

Not covered: nothing here runs against a live cluster. The migration requeue path needs an upgrade that actually triggers namespace migration, which CI does not do.

## Release Note

```release-note
NONE
```
