### PR TITLE
Hold bpfKubeProxyHealthzPort=0 until every calico-node accepts it

### DIFF
--- a/pkg/controller/installation/core_controller.go
+++ b/pkg/controller/installation/core_controller.go
@@ -1699,12 +1699,28 @@ func (r *ReconcileInstallation) setDefaultsOnFelixConfiguration(ctx context.Cont
 		}
 	}
 
+	// Whether a calico-node DaemonSet is already running decides both what version is out
+	// there and how bpfEnabled has to be derived, below.
+	ds := &appsv1.DaemonSet{}
+	nodeDSExists := true
+	if err := r.client.Get(ctx, types.NamespacedName{Namespace: common.CalicoNamespace, Name: common.NodeDaemonSetName}, ds); err != nil {
+		if !apierrors.IsNotFound(err) {
+			reqLogger.Error(err, "An error occurred when getting the Daemonset resource")
+			return false, err
+		}
+		nodeDSExists = false
+	}
+
 	// When BPF is enabled but the operator is not managing kube-proxy (e.g. on AKS, where
 	// the platform owns the kube-proxy DaemonSet), the platform's kube-proxy keeps the
 	// default healthz port (10256), and Felix's BPF kube-proxy healthz server would fail
 	// to bind. Default the port to 0 (disabled) so calico-node starts cleanly. Users can
 	// still override by setting BPFKubeProxyHealthzPort explicitly on FelixConfiguration.
-	if install.Spec.BPFEnabled() && !install.Spec.KubeProxyManagementEnabled() && fc.Spec.BPFKubeProxyHealthzPort == nil {
+	//
+	// 0 is only a valid port for Calico >= v3.32.0 and Enterprise >= v3.23.0-2.0, so hold
+	// the write until every node can accept it.
+	if allNodesRunTargetVersion(install, needNsMigration, nodeDSExists, r.ext.ProductVersion(&install.Spec)) &&
+		install.Spec.BPFEnabled() && !install.Spec.KubeProxyManagementEnabled() && fc.Spec.BPFKubeProxyHealthzPort == nil {
 		disableBPFKubeProxyHealthz(fc)
 		updated = true
 	}
@@ -1725,13 +1741,7 @@ func (r *ReconcileInstallation) setDefaultsOnFelixConfiguration(ctx context.Cont
 
 	// If calico-node daemonset exists, we need to check the ENV VAR and set FelixConfiguration accordingly.
 	// Otherwise, this is a fresh install in eBPF mode, set the felix config.
-	ds := &appsv1.DaemonSet{}
-	err = r.client.Get(ctx, types.NamespacedName{Namespace: common.CalicoNamespace, Name: common.NodeDaemonSetName}, ds)
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			reqLogger.Error(err, "An error occurred when getting the Daemonset resource")
-			return false, err
-		}
+	if !nodeDSExists {
 		if !needNsMigration && install.Spec.BPFEnabled() {
 			err = setBPFEnabledOnFelixConfiguration(fc, true)
 			if err != nil {
@@ -1757,6 +1767,22 @@ func (r *ReconcileInstallation) setDefaultsOnFelixConfiguration(ctx context.Cont
 	}
 
 	return updated, nil
+}
+
+// allNodesRunTargetVersion reports whether every calico-node runs targetVersion. Gate
+// FelixConfiguration writes that older nodes' validators reject on it.
+func allNodesRunTargetVersion(install *operatorv1.Installation, needNsMigration, nodeDSExists bool, targetVersion string) bool {
+	if needNsMigration {
+		// Manifest-install pods still serve nodes out of kube-system.
+		return false
+	}
+	if !nodeDSExists {
+		// Fresh install: nothing is running yet.
+		return true
+	}
+	// Written together, and only once the stack was seen available on that version. A status
+	// reporting neither fails this too, which is what we want.
+	return install.Status.Variant == install.Spec.Variant && install.Status.CalicoVersion == targetVersion
 }
 
 // setClusterRoutingOnFelixConfiguration sets programClusterRoutes in the FelixConfiguration resource

--- a/pkg/controller/installation/core_controller_test.go
+++ b/pkg/controller/installation/core_controller_test.go
@@ -78,10 +78,10 @@ var (
 
 var errMismatchedError = fmt.Errorf("installation spec.kubernetesProvider 'DockerEnterprise' does not match auto-detected value 'OpenShift'")
 
-type fakeNamespaceMigration struct{}
+type fakeNamespaceMigration struct{ needsMigration bool }
 
 func (f *fakeNamespaceMigration) NeedsCoreNamespaceMigration(ctx context.Context) (bool, error) {
-	return false, nil
+	return f.needsMigration, nil
 }
 
 func (f *fakeNamespaceMigration) Run(ctx context.Context, log logr.Logger) error {
@@ -1652,6 +1652,64 @@ var _ = Describe("Testing core-controller installation", func() {
 			Expect(*fc.Spec.BPFKubeProxyHealthzPort).To(Equal(12345))
 		})
 
+		It("should not set BPFKubeProxyHealthzPort while calico-node is still on an older version", func() {
+			// A calico-node DaemonSet is already running and the status reports no version
+			// yet, so nodes may predate the value.
+			createNodeDaemonSet()
+
+			network := operator.LinuxDataplaneBPF
+			cr.Spec.CalicoNetwork = &operator.CalicoNetworkSpec{LinuxDataplane: &network}
+			Expect(c.Create(ctx, cr)).NotTo(HaveOccurred())
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			fc := &v3.FelixConfiguration{}
+			err = c.Get(ctx, types.NamespacedName{Name: "default"}, fc)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Expect(fc.Spec.BPFKubeProxyHealthzPort).To(BeNil())
+		})
+
+		It("should set BPFKubeProxyHealthzPort once calico-node reports the target version", func() {
+			createNodeDaemonSet()
+
+			network := operator.LinuxDataplaneBPF
+			cr.Spec.CalicoNetwork = &operator.CalicoNetworkSpec{LinuxDataplane: &network}
+			Expect(c.Create(ctx, cr)).NotTo(HaveOccurred())
+
+			cr.Status.Variant = operator.CalicoEnterprise
+			cr.Status.CalicoVersion = components.EnterpriseRelease
+			Expect(c.Status().Update(ctx, cr)).NotTo(HaveOccurred())
+
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			fc := &v3.FelixConfiguration{}
+			err = c.Get(ctx, types.NamespacedName{Name: "default"}, fc)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Expect(fc.Spec.BPFKubeProxyHealthzPort).NotTo(BeNil())
+			Expect(*fc.Spec.BPFKubeProxyHealthzPort).To(Equal(0))
+		})
+
+		It("should not set BPFKubeProxyHealthzPort while the kube-system migration is pending", func() {
+			// calico-node pods from the manifest install are still serving nodes out of
+			// kube-system, so the operator's own DaemonSet says nothing about them.
+			r.namespaceMigration = &fakeNamespaceMigration{needsMigration: true}
+
+			network := operator.LinuxDataplaneBPF
+			cr.Spec.CalicoNetwork = &operator.CalicoNetworkSpec{LinuxDataplane: &network}
+			Expect(c.Create(ctx, cr)).NotTo(HaveOccurred())
+			_, err := r.Reconcile(ctx, reconcile.Request{})
+			Expect(err).ShouldNot(HaveOccurred())
+
+			fc := &v3.FelixConfiguration{}
+			err = c.Get(ctx, types.NamespacedName{Name: "default"}, fc)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Expect(fc.Spec.BPFKubeProxyHealthzPort).To(BeNil())
+		})
+
 		It("should set BPFEnabled to ture on FelixConfiguration if BPF is enabled on installation", func() {
 			createNodeDaemonSet()
 
@@ -2562,6 +2620,30 @@ func (f *fakeComponentHandler) CreateOrUpdateOrDelete(ctx context.Context, compo
 	f.objectsToDelete = append(f.objectsToDelete, d...)
 	return nil
 }
+
+var _ = Describe("allNodesRunTargetVersion", func() {
+	const targetVersion = "v3.24.0-1.0"
+
+	install := func(statusVariant operator.ProductVariant, statusVersion string) *operator.Installation {
+		return &operator.Installation{
+			Spec:   operator.InstallationSpec{Variant: operator.CalicoEnterprise},
+			Status: operator.InstallationStatus{Variant: statusVariant, CalicoVersion: statusVersion},
+		}
+	}
+
+	DescribeTable("deciding whether older calico-node pods may still be running",
+		func(install *operator.Installation, needNsMigration, nodeDSExists, expected bool) {
+			Expect(allNodesRunTargetVersion(install, needNsMigration, nodeDSExists, targetVersion)).To(Equal(expected))
+		},
+		Entry("fresh install, no DaemonSet yet", install("", ""), false, false, true),
+		Entry("migration pending, no DaemonSet yet", install("", ""), true, false, false),
+		Entry("migration pending alongside a DaemonSet", install(operator.CalicoEnterprise, targetVersion), true, true, false),
+		Entry("DaemonSet running, no version reported yet", install("", ""), false, true, false),
+		Entry("version upgrade in flight", install(operator.CalicoEnterprise, "v3.23.0-1.1"), false, true, false),
+		Entry("variant change in flight", install(operator.Calico, targetVersion), false, true, false),
+		Entry("target version rolled out", install(operator.CalicoEnterprise, targetVersion), false, true, true),
+	)
+})
 
 var _ = Describe("updateMutatingAdmissionPolicies", func() {
 	var (


### PR DESCRIPTION
## Description

Bug fix. Connecting an OSS v3.31.x BPF cluster to Calico Cloud leaves `calico-node` in CrashLoopBackOff and deadlocks the manifest->operator migration:

```
Unable to set global default configuration error=error with field
BPFKubeProxyHealthzPort = '0' (Reason: failed to validate Field:
BPFKubeProxyHealthzPort because of Tag: gte )
```

`0` meaning "disabled" is only accepted from Calico **v3.32.0** and Enterprise **v3.23.0-2.0**. Validation is client-side in libcalico-go and `startup.go` writes the global defaults back on every pod start, so a node predating the value crashloops on a field it does not even use. #4768 (CORE-12755) defaults the port to `0` on BPF clusters where the operator does not manage kube-proxy, gated only on BPF being enabled, kube-proxy being unmanaged and the field being nil — nothing about what version is running. The value therefore lands in the shared FelixConfiguration while old pods are still serving nodes.

Two paths are exposed:

- **manifest -> operator** (the reported one): old pods live in `kube-system`, and the migration recreates them when it edits the nodeSelector, so they re-read FelixConfiguration and die. The migration then waits for them and times out.
- **operator -> operator**: FelixConfiguration is patched early in `Reconcile`, before the DaemonSet is rendered. The rolling update itself mostly survives, since each terminated pod returns on the new image, but an old pod restarting out of turn does not — and neither does a rollback, where the `0` stays in the datastore and every node crashloops with no way forward.

The fix gates the write on `allNodesRunTargetVersion`:

- ns-migration pending -> do not write; pods from the manifest install are still out there.
- no calico-node DaemonSet -> write; a fresh install has nothing older running, so #4768's AKS behaviour is unchanged.
- otherwise -> write only when `Status.Variant` and `Status.CalicoVersion` report the version this operator rolls out. Those are written only on a reconcile that got past `status.IsAvailable()`, so they mean "the whole stack was seen up on that version".

The existing calico-node DaemonSet lookup moves above the healthz block so it and the `bpfEnabled` derivation share one Get.

`isRolloutCompleteWithBPFVolumes` was considered and does not fit: it inspects the calico-system DaemonSet, which during migration is nodeSelector-limited to already-migrated nodes and so reports a complete rollout while unmigrated pods run. It is also count-based, hence trivially true on a DaemonSet the operator has not touched yet this reconcile — safe for the eBPF flip only because the `bpffs` volume marks "new spec applied", and there is no equivalent marker for a version bump.

The helper is written to be reusable: the hazard is generic to any FelixConfiguration value whose validator is newer than the oldest running node. Only this call site is wired up here; whether other operator-written defaults want the same gate is worth a separate look.

**Testing.** A 7-entry table on the helper plus three reconcile specs — upgrade in flight (not written), status reports the target (written), ns-migration pending (not written). `fakeNamespaceMigration` gained a `needsMigration` field. `go test ./pkg/controller/installation/` is green at 303 specs; the 22 `CEL validation` specs need envtest assets and are skipped locally. Every branch of the new helper was mutation-tested: four are caught by a failing test, and a fifth turned out redundant and was removed. Removing the fresh-install branch breaks #4768's original AKS spec, which confirms that path is untouched.

Internal: CORE-13540.

## Release Note

```release-note
Fixed a bug where the operator could set FelixConfiguration bpfKubeProxyHealthzPort to 0 while older calico-node pods were still running. Those pods reject the value and crashloop, which could deadlock a migration to an operator-managed install.
```

## For PR author

- [x] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`
