### PR TITLE
Copy only YAML files when syncing CRDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -711,12 +711,12 @@ endef
 define copy_v1_crds
     $(eval dir := $(1))
 		$(eval product := $(2))
-	@cp $(dir)/libcalico-go/config/crd/* pkg/imports/crds/$(product)/v1.crd.projectcalico.org/ && echo "Copied $(product) CRDs"
+	@cp $(dir)/libcalico-go/config/crd/*.yaml pkg/imports/crds/$(product)/v1.crd.projectcalico.org/ && echo "Copied $(product) CRDs"
 endef
 define copy_v3_crds
     $(eval dir := $(1))
 		$(eval product := $(2))
-	@cp $(dir)/api/config/crd/* pkg/imports/crds/$(product)/v3.projectcalico.org/ && echo "Copied $(product) CRDs"
+	@cp $(dir)/api/config/crd/*.yaml pkg/imports/crds/$(product)/v3.projectcalico.org/ && echo "Copied $(product) CRDs"
 endef
 define copy_k8s_policy_crds
     $(eval product := $(1))
@@ -731,12 +731,12 @@ endef
 define copy_eck_crds
     $(eval dir := $(1))
 		$(eval product := $(2))
-	@cp $(dir)/charts/crd.projectcalico.org.v1/templates/eck/* pkg/imports/crds/$(product)/ && echo "Copied $(product) ECK CRDs"
+	@cp $(dir)/charts/crd.projectcalico.org.v1/templates/eck/*.yaml pkg/imports/crds/$(product)/ && echo "Copied $(product) ECK CRDs"
 endef
 define copy_admission_policies
     $(eval dir := $(1))
 		$(eval product := $(2))
-	@cp $(dir)/api/admission/* pkg/imports/admission/$(product)/ && echo "Copied $(product) admission policies"
+	@cp $(dir)/api/admission/*.yaml pkg/imports/admission/$(product)/ && echo "Copied $(product) admission policies"
 endef
 
 .PHONY: read-libcalico-version read-libcalico-enterprise-version

--- a/pkg/imports/crds/enterprise/applicationlayer.projectcalico.org/applicationlayer.projectcalico.org_wafpolicies.yaml
+++ b/pkg/imports/crds/enterprise/applicationlayer.projectcalico.org/applicationlayer.projectcalico.org_wafpolicies.yaml
@@ -312,9 +312,30 @@ spec:
                           ValidationFailure describes a single validation
                           rule failure
                         properties:
+                          expected:
+                            description: |-
+                              Expected is the value the rule requires, rendered as a string. Set from the
+                              violation's "expected" key.
+                            maxLength: 256
+                            type: string
+                          field:
+                            description: |-
+                              Field is the path of the setting that failed the rule, e.g.
+                              "spec.coreRuleSet.paranoiaLevel". Populated when the rule's Rego emits the
+                              object form of a violation with a "field" key; empty for rules that emit a
+                              bare message. Consumers use it to point a user at the setting to change
+                              rather than making them read the rule.
+                            maxLength: 253
+                            type: string
                           message:
                             description: Message explains why validation failed
                             maxLength: 1024
+                            type: string
+                          observed:
+                            description: |-
+                              Observed is the value the rule actually found, rendered as a string. Set
+                              from the violation's "observed" key.
+                            maxLength: 256
                             type: string
                           policyKind:
                             description: PolicyKind is Global or Namespace-scoped
@@ -328,6 +349,12 @@ spec:
                               PolicyName is the name of the validation policy
                               that failed
                             maxLength: 253
+                            type: string
+                          remedy:
+                            description: |-
+                              Remedy is a short, rule-authored instruction for resolving the failure. Set
+                              from the violation's "remedy" key.
+                            maxLength: 512
                             type: string
                           rule:
                             description:
@@ -360,7 +387,6 @@ spec:
                       enum:
                         - Compliant
                         - Warning
-                        - Degraded
                         - Critical
                       type: string
                     status:

--- a/pkg/imports/crds/enterprise/applicationlayer.projectcalico.org/applicationlayer.projectcalico.org_wafvalidationpolicies.yaml
+++ b/pkg/imports/crds/enterprise/applicationlayer.projectcalico.org/applicationlayer.projectcalico.org_wafvalidationpolicies.yaml
@@ -185,7 +185,6 @@ spec:
                   enum:
                     - Compliant
                     - Warning
-                    - Degraded
                     - Critical
                   type: string
                 validationResults:

--- a/pkg/imports/crds/enterprise/v1.crd.projectcalico.org/applicationlayer.projectcalico.org_wafpolicies.yaml
+++ b/pkg/imports/crds/enterprise/v1.crd.projectcalico.org/applicationlayer.projectcalico.org_wafpolicies.yaml
@@ -312,9 +312,30 @@ spec:
                           ValidationFailure describes a single validation
                           rule failure
                         properties:
+                          expected:
+                            description: |-
+                              Expected is the value the rule requires, rendered as a string. Set from the
+                              violation's "expected" key.
+                            maxLength: 256
+                            type: string
+                          field:
+                            description: |-
+                              Field is the path of the setting that failed the rule, e.g.
+                              "spec.coreRuleSet.paranoiaLevel". Populated when the rule's Rego emits the
+                              object form of a violation with a "field" key; empty for rules that emit a
+                              bare message. Consumers use it to point a user at the setting to change
+                              rather than making them read the rule.
+                            maxLength: 253
+                            type: string
                           message:
                             description: Message explains why validation failed
                             maxLength: 1024
+                            type: string
+                          observed:
+                            description: |-
+                              Observed is the value the rule actually found, rendered as a string. Set
+                              from the violation's "observed" key.
+                            maxLength: 256
                             type: string
                           policyKind:
                             description: PolicyKind is Global or Namespace-scoped
@@ -328,6 +349,12 @@ spec:
                               PolicyName is the name of the validation policy
                               that failed
                             maxLength: 253
+                            type: string
+                          remedy:
+                            description: |-
+                              Remedy is a short, rule-authored instruction for resolving the failure. Set
+                              from the violation's "remedy" key.
+                            maxLength: 512
                             type: string
                           rule:
                             description:
@@ -360,7 +387,6 @@ spec:
                       enum:
                         - Compliant
                         - Warning
-                        - Degraded
                         - Critical
                       type: string
                     status:

--- a/pkg/imports/crds/enterprise/v1.crd.projectcalico.org/applicationlayer.projectcalico.org_wafvalidationpolicies.yaml
+++ b/pkg/imports/crds/enterprise/v1.crd.projectcalico.org/applicationlayer.projectcalico.org_wafvalidationpolicies.yaml
@@ -185,7 +185,6 @@ spec:
                   enum:
                     - Compliant
                     - Warning
-                    - Degraded
                     - Critical
                   type: string
                 validationResults:


### PR DESCRIPTION
## Description

Bug fix. The CRD sync copies every file out of the upstream CRD directories, so it picked up the Go files that sit alongside the generated YAML. The operator parses everything in those directories as CRDs, which made it panic at startup and fail `make test-crds`, the unit tests, and the FVs. This restricts the copy to YAML files.

Verified locally: `make gen-versions` leaves a clean tree, and both `--print-enterprise-crds all` and `--print-calico-crds all` exit 0. Reproduced the panic first on the head of #5298.

Affects the version sync only, not the shipped operator.

## Release Note

```release-note
NONE
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [x] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
