### PR TITLE
Copy only YAML files when syncing CRDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -716,12 +716,12 @@ endef
 define copy_v1_crds
     $(eval dir := $(1))
 		$(eval product := $(2))
-	@cp $(dir)/libcalico-go/config/crd/* pkg/imports/crds/$(product)/v1.crd.projectcalico.org/ && echo "Copied $(product) CRDs"
+	@cp $(dir)/libcalico-go/config/crd/*.yaml pkg/imports/crds/$(product)/v1.crd.projectcalico.org/ && echo "Copied $(product) CRDs"
 endef
 define copy_v3_crds
     $(eval dir := $(1))
 		$(eval product := $(2))
-	@cp $(dir)/api/config/crd/* pkg/imports/crds/$(product)/v3.projectcalico.org/ && echo "Copied $(product) CRDs"
+	@cp $(dir)/api/config/crd/*.yaml pkg/imports/crds/$(product)/v3.projectcalico.org/ && echo "Copied $(product) CRDs"
 endef
 define copy_k8s_policy_crds
     $(eval product := $(1))
@@ -736,12 +736,12 @@ endef
 define copy_eck_crds
     $(eval dir := $(1))
 		$(eval product := $(2))
-	@cp $(dir)/charts/crd.projectcalico.org.v1/templates/eck/* pkg/imports/crds/$(product)/ && echo "Copied $(product) ECK CRDs"
+	@cp $(dir)/charts/crd.projectcalico.org.v1/templates/eck/*.yaml pkg/imports/crds/$(product)/ && echo "Copied $(product) ECK CRDs"
 endef
 define copy_admission_policies
     $(eval dir := $(1))
 		$(eval product := $(2))
-	@cp $(dir)/api/admission/* pkg/imports/admission/$(product)/ && echo "Copied $(product) admission policies"
+	@cp $(dir)/api/admission/*.yaml pkg/imports/admission/$(product)/ && echo "Copied $(product) admission policies"
 endef
 
 .PHONY: read-libcalico-version read-libcalico-enterprise-version


### PR DESCRIPTION
## Description

Bug fix. The CRD sync copies every file out of the upstream CRD directories, so it picked up the Go files that sit alongside the generated YAML. The operator parses everything in those directories as CRDs, which made it panic at startup. This restricts the copy to YAML files.

Cherry-pick of #5307. This branch pins both products to tags that predate the Go files, so the sync output is unchanged here.

Affects the version sync only, not the shipped operator.

## Release Note

```release-note
NONE
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
