### PR TITLE
Stop syncing versions into master

### DIFF
--- a/.github/workflows/sync-versions.yml
+++ b/.github/workflows/sync-versions.yml
@@ -20,12 +20,12 @@ jobs:
       - name: Discover branches
         id: branches
         run: |
-          # Get master + the two most recent release branches (by semver).
+          # Get the two most recent release branches (by semver). master is not
+          # released from, so it is skipped.
           branches=$(gh api repos/${{ github.repository }}/branches --paginate --jq '
             [.[] | select(.name | test("^release-v[0-9]+\\.[0-9]+$")) | .name]
             | sort_by(ltrimstr("release-v") | split(".") | map(tonumber))
             | .[-2:]
-            | ["master"] + .
           ')
           echo "branches=${branches}" >> "$GITHUB_OUTPUT"
         env:


### PR DESCRIPTION
## Description

CI change. The hourly version sync opens a PR against master as well as the two most recent release branches. Releases come from the release branches, so this drops master from the matrix.

The workflow runs from the default branch on a schedule, so this has to land on master to take effect.

Once this merges, #5304 can be closed.

## Release Note

```release-note
NONE
```

## For PR author

- [ ] Tests for change.
- [ ] If changing pkg/apis/, run `make gen-files`
- [ ] If changing versions, run `make gen-versions`

## For PR reviewers

A note for code reviewers - all pull requests must have the following:

- [ ] Milestone set according to targeted release.
- [ ] Appropriate labels:
  - `kind/bug` if this is a bugfix.
  - `kind/enhancement` if this is a a new feature.
  - `enterprise` if this PR applies to Calico Enterprise only.
